### PR TITLE
feat: naive Jupyter provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,23 +8,28 @@
       "name": "colab",
       "version": "0.0.1",
       "dependencies": {
+        "@vscode/jupyter-extension": "^1.1.1",
         "glob": "^11.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
+        "@types/chai": "^4.3.20",
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
-        "@types/vscode": "^1.54.0",
+        "@types/sinon": "^17.0.3",
+        "@types/vscode": "^1.93.1",
         "@vscode/test-cli": "^0.0.10",
         "@vscode/test-electron": "^2.4.1",
+        "chai": "^4.5.0",
         "eslint": "^9.15.0",
         "eslint-plugin-import": "^2.31.0",
         "mocha": "^10.8.2",
+        "sinon": "^19.0.2",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.15.0"
       },
       "engines": {
-        "vscode": "^1.54.0"
+        "vscode": "^1.93.1"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -383,6 +388,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/commons/node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+      "dev": true,
+      "license": "(Unlicense OR Apache-2.0)"
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -427,6 +488,23 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.95.0",
@@ -632,6 +710,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@vscode/jupyter-extension": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@vscode/jupyter-extension/-/jupyter-extension-1.1.1.tgz",
+      "integrity": "sha512-wQ7bEbrHSe9gfdT3PCNE/ayC+w8aFFXpJBlUjMN3WMZpO4fWXZv2O8gCf3w80a465uEhMDiSmuRYl0OR6RR25Q==",
+      "license": "MIT"
     },
     "node_modules/@vscode/test-cli": {
       "version": "0.0.10",
@@ -966,6 +1050,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1172,6 +1266,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1200,6 +1313,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -1470,6 +1596,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2263,6 +2402,16 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3224,6 +3373,13 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3274,6 +3430,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3296,6 +3459,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lru-cache": {
@@ -3595,6 +3768,20 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+      "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.1",
+        "@sinonjs/text-encoding": "^0.7.3",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.1.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3944,6 +4131,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/picomatch": {
@@ -4361,6 +4568,48 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sinon": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+      "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.2",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "nise": "^6.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stdin-discarder": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
@@ -4705,6 +4954,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Connect to Colab runtimes.",
   "version": "0.0.1",
   "engines": {
-    "vscode": "^1.54.0"
+    "vscode": "^1.93.1"
   },
   "categories": [
     "Notebooks"
@@ -26,7 +26,7 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "pretest": "npm run compile && npm run lint",
-    "test:unittests": "npm run compile && mocha --enable-source-maps ./out/**/*.unit.test.js",
+    "test:unittests": "npm run compile && mocha --enable-source-maps './out/**/*.unit.test.js'",
     "test:xvfb": "xvfb-run -s '-screen 0 1024x768x24' node ./out/test/runTest.js",
     "test": "node ./out/test/runTest.js",
     "vscode:prepublish": "npm run compile",
@@ -34,18 +34,23 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
+    "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",
     "@types/node": "20.x",
-    "@types/vscode": "^1.54.0",
+    "@types/sinon": "^17.0.3",
+    "@types/vscode": "^1.93.1",
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.4.1",
+    "chai": "^4.5.0",
     "eslint": "^9.15.0",
     "eslint-plugin-import": "^2.31.0",
     "mocha": "^10.8.2",
+    "sinon": "^19.0.2",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.15.0"
   },
   "dependencies": {
+    "@vscode/jupyter-extension": "^1.1.1",
     "glob": "^11.0.0"
   }
 }

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -1,0 +1,97 @@
+import {
+  Jupyter,
+  JupyterServer,
+  JupyterServerCollection,
+  JupyterServerConnectionInformation,
+  JupyterServerProvider,
+} from "@vscode/jupyter-extension";
+import { CancellationToken, Uri, ProviderResult } from "vscode";
+
+/**
+ * Registers the Colab Jupyter Server provider with the Jupyter Kernels API.
+ *
+ * @param jupyter Kernels API.
+ * @param config for connecting to the Resource Proxy.
+ */
+export function register(
+  jupyter: Jupyter,
+  config: RpConfig
+): JupyterServerCollection {
+  return jupyter.createJupyterServerCollection(
+    "colab",
+    "Colab",
+    new ColabJupyterServerProvider(config)
+  );
+}
+
+/**
+ * Configuration for the Resource Proxy connection.
+ */
+export interface RpConfig {
+  /**
+   * Base {@link Uri Uri} of the Jupyter Server behind the resource proxy.
+   */
+  readonly baseUri: Uri;
+
+  /**
+   * The resource proxy token attached as a header to Jupyter Server requests.
+   */
+  readonly token: string;
+}
+
+/**
+ * Colab Jupyter server provider.
+ *
+ * Provides a static list of Colab Jupyter servers and resolves the connection information using the provided config.
+ */
+export class ColabJupyterServerProvider implements JupyterServerProvider {
+  // TODO: Fetch available servers from the backend. Hardcoded for now.
+  private readonly idToServer = new Map<string, ColabJupyterServer>([
+    ["m", new ColabJupyterServer("m", "Colab CPU")],
+    ["gpu-t4", new ColabJupyterServer("gpu-t4", "Colab T4")],
+    ["gpu-l4", new ColabJupyterServer("gpu-l4", "Colab L4")],
+    ["gpu-a100", new ColabJupyterServer("gpu-a100", "Colab A100")],
+    ["tpu-v28", new ColabJupyterServer("tpu-v28", "Colab TPU v2-8")],
+    ["tpu-v5e1", new ColabJupyterServer("tpu-v5e1", "Colab TPU v5e-1")],
+  ]);
+
+  constructor(private readonly config: RpConfig) {}
+
+  /**
+   * Provides the list of {@link JupyterServer Jupyter Servers}.
+   */
+  provideJupyterServers(
+    _token: CancellationToken
+  ): ProviderResult<JupyterServer[]> {
+    return Array.from(this.idToServer.values());
+  }
+
+  /**
+   * Resolves the connection for the provided {@link JupyterServer Jupyter Server}.
+   */
+  resolveJupyterServer(
+    server: JupyterServer,
+    _token: CancellationToken
+  ): ProviderResult<JupyterServer> {
+    const colabServer = this.idToServer.get(server.id);
+    if (!colabServer) {
+      return;
+    }
+    colabServer.resolve(this.config);
+    return colabServer;
+  }
+}
+
+class ColabJupyterServer implements JupyterServer {
+  connectionInformation?: JupyterServerConnectionInformation;
+
+  constructor(readonly id: string, readonly label: string) {}
+
+  resolve(config: RpConfig): void {
+    // TODO: Assign the appropriate machine for the server instead of the single hardcoded configuration.
+    this.connectionInformation = {
+      baseUrl: config.baseUri,
+      headers: { "X-Colab-Runtime-Proxy-Token": config.token },
+    };
+  }
+}

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -1,0 +1,106 @@
+import { Jupyter, JupyterServer } from "@vscode/jupyter-extension";
+import {
+  JupyterServerProvider,
+  JupyterServerCollection,
+} from "@vscode/jupyter-extension";
+import { assert, expect } from "chai";
+import sinon from "sinon";
+import { CancellationToken, Uri } from "vscode";
+import { ColabJupyterServerProvider, register, RpConfig } from "./provider";
+
+describe("register", () => {
+  it("creates a Jupyter server collection", () => {
+    const id = "colab";
+    const label = "Colab";
+    const createJupyterServerCollectionStub = sinon
+      .stub<
+        [id: string, label: string, serverProvider: JupyterServerProvider],
+        JupyterServerCollection
+      >()
+      .returns({ id, label } as JupyterServerCollection);
+    const jupyterMock = {
+      createJupyterServerCollection: createJupyterServerCollectionStub,
+    } as unknown as Jupyter;
+    const config: RpConfig = {
+      baseUri: {} as Uri,
+      token: "foo",
+    };
+
+    const servers = register(jupyterMock, config);
+
+    sinon.assert.calledOnce(createJupyterServerCollectionStub);
+    const call = createJupyterServerCollectionStub.getCall(0);
+    assert.equal(call.args[0], id);
+    assert.equal(servers.id, id);
+    assert.equal(call.args[1], label);
+    assert.equal(servers.label, label);
+  });
+});
+
+describe("ColabJupyterServerProvider", () => {
+  const config: RpConfig = { baseUri: {} as Uri, token: "foo" };
+  const expectedServers: JupyterServer[] = [
+    {
+      connectionInformation: undefined,
+      id: "m",
+      label: "Colab CPU",
+    },
+    {
+      connectionInformation: undefined,
+      id: "gpu-t4",
+      label: "Colab T4",
+    },
+    {
+      connectionInformation: undefined,
+      id: "gpu-l4",
+      label: "Colab L4",
+    },
+    {
+      connectionInformation: undefined,
+      id: "gpu-a100",
+      label: "Colab A100",
+    },
+    {
+      connectionInformation: undefined,
+      id: "tpu-v28",
+      label: "Colab TPU v2-8",
+    },
+    {
+      connectionInformation: undefined,
+      id: "tpu-v5e1",
+      label: "Colab TPU v5e-1",
+    },
+  ];
+  let serverProvider: ColabJupyterServerProvider;
+
+  beforeEach(() => {
+    serverProvider = new ColabJupyterServerProvider(config);
+  });
+
+  it("provides Jupyter servers", async () => {
+    const providedServers = await serverProvider.provideJupyterServers(
+      {} as CancellationToken
+    );
+
+    expect(providedServers).to.deep.equal(expectedServers);
+  });
+
+  expectedServers.forEach((server) => {
+    it(`resolves the '${server.id}' Jupyter server`, async () => {
+      const expectedResolvedServer: JupyterServer = {
+        ...server,
+        connectionInformation: {
+          baseUrl: config.baseUri,
+          headers: { "X-Colab-Runtime-Proxy-Token": config.token },
+        },
+      };
+
+      const resolvedServer = await serverProvider.resolveJupyterServer(
+        server,
+        {} as CancellationToken
+      );
+
+      expect(resolvedServer).to.deep.equal(expectedResolvedServer);
+    });
+  });
+});

--- a/src/tmp.unit.test.ts
+++ b/src/tmp.unit.test.ts
@@ -1,8 +1,0 @@
-import { equal } from "assert";
-import { describe, it } from "mocha";
-
-describe("Temporary unit tests", () => {
-    it("should be able to execute", () => {
-        equal(true, true);
-    });
-});


### PR DESCRIPTION
For now, the provider naively provides and resolves a static list of Colab servers. Additionally, the RP connection information is provided as a hardcoded configuration until we have assignment logic implemented. Both of these items are flagged with TODOs.

Other minor changes:

- Deleted the temporary `tmp.unit.test.ts` since we now have a _real_ unit test. As per https://github.com/googlecolab/colab-vscode/pull/4.
- Updated the `test:unittests` script to quote the glob pattern that's used. This was a bit of a fun one to figure out. In short, when left as a naked glob, the shell will expand it. on Linux `sh` will not enable globstar by default. This was causing the test files to not both be resolved (prior to deleting the `tmp` one). This is most effectively solved by quoting the glob which in turn relies on the glob tool used by the tool (`mocha`) to consistently expand the star. [This blog post](https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784) covers this in detail.
- Bumped the VS Code version.
- Added a dependency on `chai` for assertions and `sinon` for spies, stubs and mocks. Across the extension ecosystem and TS/JS in general, these are the (current) most popular choices.