### PR TITLE
feat: register Jupyter provider on activation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,12 +5,8 @@
       "name": "Run Extension",
       "type": "extensionHost",
       "request": "launch",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
-      ],
-      "outFiles": [
-        "${workspaceFolder}/out/**/*.js"
-      ],
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
       "preLaunchTask": "${defaultBuildTask}"
     },
     {
@@ -21,9 +17,6 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
-      ],
-      "outFiles": [
-        "${workspaceFolder}/out/test/**/*.js"
       ],
       "preLaunchTask": "npm: compile"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,13 +82,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
-      "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
+      "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.4",
+        "@eslint/object-schema": "^2.1.5",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -121,11 +121,14 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
-      "integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
+      "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -189,9 +192,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
-      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
+      "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -199,9 +202,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
-      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
+      "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1224,23 +1227,36 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.0.tgz",
+      "integrity": "sha512-CCKAP2tkPau7D3GE8+V8R6sQubA9R5foIzGp+85EXCVSCivuxBNAWqcpn72PKYiIcqoViv/kcUDpaEIMBVi1lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1568,9 +1584,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1677,6 +1693,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.0.tgz",
+      "integrity": "sha512-9+Sj30DIu+4KvHqMfLUGLFYL2PkURSYMVXJyXe92nFRvlYq5hBjLEhblKB+vkd/WVlUYMWigiY07T91Fkk0+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -1765,14 +1796,11 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -2415,17 +2443,20 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.5.tgz",
+      "integrity": "sha512-Y4+pKa7XeRUPWFNvOOYHkRYrfzW07oraURSvjDmRVOJ748OrVmeXtpE4+GCEHncjCjkTxPNRt8kEbxDhsn6VTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "dunder-proto": "^1.0.0",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2534,14 +2565,11 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.1.0.tgz",
-      "integrity": "sha512-FQoVQnqcdk4hVM4JN1eromaun4iuS34oStkdlLENLdpULsuQcTyXj8w7ayhuUfPwEYZ1ZOooOTT6fdA9Vmx/RA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -2597,13 +2625,13 @@
       }
     },
     "node_modules/has-proto": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.1.0.tgz",
-      "integrity": "sha512-QLdzI9IIO1Jg7f9GT1gXpPpXArAn6cS31R1eEZqz08Gc+uQ8/XiqHWt17Fiw+2p6oTTIq5GXEpQkAlA88YRl/Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "dunder-proto": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4264,19 +4292,20 @@
       }
     },
     "node_modules/reflect.getprototypeof": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.7.tgz",
-      "integrity": "sha512-bMvFGIUKlc/eSfXNX+aZ+EL95/EgZzuwA0OBPTbZZDEJw/0AkentjMuM1oiRfwHrshqk4RzdgiTg5CcDalXN5g==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.8.tgz",
+      "integrity": "sha512-B5dj6usc5dkk8uFliwjwDHM8To5/QwdKz9JcBZ8Ic4G1f0YmeeJTtE/ZTdgRFPAfxZFiUaPhZ1Jcs4qeagItGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
+        "dunder-proto": "^1.0.0",
         "es-abstract": "^1.23.5",
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "which-builtin-type": "^1.1.4"
+        "gopd": "^1.2.0",
+        "which-builtin-type": "^1.2.0"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -4,21 +4,38 @@
   "displayName": "Colab",
   "description": "Connect to Colab runtimes.",
   "version": "0.0.1",
+  "type": "commonjs",
   "engines": {
     "vscode": "^1.93.1"
   },
+  "extensionDependencies": [
+    "ms-toolsai.jupyter"
+  ],
   "categories": [
     "Notebooks"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onNotebook:jupyter-notebook",
+    "onNotebook:interactive"
+  ],
   "main": "./out/extension.js",
   "contributes": {
-    "commands": [
-      {
-        "command": "colab.helloWorld",
-        "title": "Hello World"
+    "configuration": {
+      "type": "object",
+      "title": "Colab",
+      "properties": {
+        "colab.resoruceProxyBaseUrl": {
+          "type": "string",
+          "default": "",
+          "description": "A temporary setting to hardcode a resource proxy base URL."
+        },
+        "colab.resoruceProxyToken": {
+          "type": "string",
+          "default": "",
+          "description": "A temporary setting to hardcode a resource proxy token."
+        }
       }
-    ]
+    }
   },
   "scripts": {
     "clean": "rm -rf out/*",

--- a/src/jupyter/jupyter_extension.ts
+++ b/src/jupyter/jupyter_extension.ts
@@ -1,0 +1,16 @@
+import { Jupyter } from "@vscode/jupyter-extension";
+import { extensions } from "vscode";
+
+/**
+ * Get the exported API from the Jupyter extension.
+ */
+export async function getJupyterApi(): Promise<Jupyter> {
+  const ext = extensions.getExtension<Jupyter>("ms-toolsai.jupyter");
+  if (!ext) {
+    throw new Error("Jupyter Extension not installed");
+  }
+  if (!ext.isActive) {
+    await ext.activate();
+  }
+  return ext.exports;
+}

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -8,23 +8,6 @@ import {
 import { CancellationToken, Uri, ProviderResult } from "vscode";
 
 /**
- * Registers the Colab Jupyter Server provider with the Jupyter Kernels API.
- *
- * @param jupyter Kernels API.
- * @param config for connecting to the Resource Proxy.
- */
-export function register(
-  jupyter: Jupyter,
-  config: RpConfig
-): JupyterServerCollection {
-  return jupyter.createJupyterServerCollection(
-    "colab",
-    "Colab",
-    new ColabJupyterServerProvider(config)
-  );
-}
-
-/**
  * Configuration for the Resource Proxy connection.
  */
 export interface RpConfig {
@@ -45,6 +28,20 @@ export interface RpConfig {
  * Provides a static list of Colab Jupyter servers and resolves the connection information using the provided config.
  */
 export class ColabJupyterServerProvider implements JupyterServerProvider {
+  /**
+   * Registers the Colab Jupyter Server provider with the Jupyter Kernels API.
+   *
+   * @param jupyter Kernels API.
+   * @param config for connecting to the Resource Proxy.
+   */
+  static register(jupyter: Jupyter, config: RpConfig): JupyterServerCollection {
+    return jupyter.createJupyterServerCollection(
+      "colab",
+      "Colab",
+      new ColabJupyterServerProvider(config)
+    );
+  }
+
   // TODO: Fetch available servers from the backend. Hardcoded for now.
   private readonly idToServer = new Map<string, ColabJupyterServer>([
     ["m", new ColabJupyterServer("m", "Colab CPU")],

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -4,9 +4,9 @@ import {
   JupyterServerCollection,
 } from "@vscode/jupyter-extension";
 import { assert, expect } from "chai";
-import sinon from "sinon";
+import * as sinon from "sinon";
 import { CancellationToken, Uri } from "vscode";
-import { ColabJupyterServerProvider, register, RpConfig } from "./provider";
+import { ColabJupyterServerProvider, RpConfig } from "./provider";
 
 describe("register", () => {
   it("creates a Jupyter server collection", () => {
@@ -26,7 +26,7 @@ describe("register", () => {
       token: "foo",
     };
 
-    const servers = register(jupyterMock, config);
+    const servers = ColabJupyterServerProvider.register(jupyterMock, config);
 
     sinon.assert.calledOnce(createJupyterServerCollectionStub);
     const call = createJupyterServerCollectionStub.getCall(0);

--- a/src/test/extension.vscode.test.ts
+++ b/src/test/extension.vscode.test.ts
@@ -1,25 +1,24 @@
-import * as assert from 'assert';
-import * as vscode from 'vscode';
+import * as assert from "assert";
+import * as vscode from "vscode";
 
-suite('Extension', () => {
-	test('should be present', () => {
-		assert.ok(vscode.extensions.getExtension('google.colab'));
-	});
+describe("Extension", () => {
+  it("should be present", () => {
+    assert.ok(vscode.extensions.getExtension("google.colab"));
+  });
 
-	test('should activate', async () => {
-		const extension = vscode.extensions.getExtension('google.colab');
+  it("should activate", async () => {
+    await setConfig("resoruceProxyBaseUrl", "foo");
+    await setConfig("resoruceProxyToken", "bar");
+    const extension = vscode.extensions.getExtension("google.colab");
 
-		await extension?.activate();
+    await extension?.activate();
 
-		assert.strictEqual(extension?.isActive, true);
-	});
-
-	test('should register the helloWorld command', async () => {
-		const extension = vscode.extensions.getExtension('google.colab');
-		await extension?.activate();
-
-		const commands = await vscode.commands.getCommands(true);
-
-		assert.ok(commands.includes('colab.helloWorld'));
-	});
+    assert.strictEqual(extension?.isActive, true);
+  });
 });
+
+async function setConfig(section: string, value: string): Promise<void> {
+  await vscode.workspace
+    .getConfiguration("colab")
+    .update(section, value, vscode.ConfigurationTarget.Global);
+}

--- a/src/test/jupyter_extension.vscode.test.ts
+++ b/src/test/jupyter_extension.vscode.test.ts
@@ -1,0 +1,58 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { getJupyterApi } from "../jupyter/jupyter_extension";
+
+describe("getJupyterApi", () => {
+  let getExtensionStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    getExtensionStub = sinon.stub(vscode.extensions, "getExtension");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should throw an error if the Jupyter extension is not installed", async () => {
+    getExtensionStub.returns(undefined);
+
+    try {
+      await getJupyterApi();
+      throw new Error("Expected getJupyterApi to throw an error");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "Jupyter Extension not installed"
+      );
+    }
+  });
+
+  it("should activate the extension if it is not active", async () => {
+    const activateStub = sinon.stub().resolves();
+    const ext = {
+      isActive: false,
+      activate: activateStub,
+      exports: {},
+    };
+    getExtensionStub.returns(ext);
+
+    const result = await getJupyterApi();
+
+    sinon.assert.calledOnce(activateStub);
+    expect(result).to.equal(ext.exports);
+  });
+
+  it("should return the exports if the extension is already active", async () => {
+    const ext = {
+      isActive: true,
+      activate: sinon.stub(),
+      exports: {},
+    };
+    getExtensionStub.returns(ext);
+
+    const result = await getJupyterApi();
+
+    sinon.assert.calledOnce(getExtensionStub);
+    expect(result).to.equal(ext.exports);
+  });
+});

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,23 +1,69 @@
-import * as path from 'path';
+import { spawnSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  downloadAndUnzipVSCode,
+  resolveCliPathFromVSCodeExecutablePath,
+  runTests,
+} from "@vscode/test-electron";
 
-import { runTests } from '@vscode/test-electron';
+function getExtensionsDir(vscodeExecutablePath: string): string {
+  const extDirPath = path.resolve(vscodeExecutablePath, "../", "extensions");
+  if (!fs.existsSync(extDirPath)) {
+    fs.mkdirSync(extDirPath);
+  }
+  return extDirPath;
+}
+
+function installExtension(
+  cliPath: string,
+  extensionsDir: string,
+  extension: string
+) {
+  console.info("Installing Jupyter Extension");
+  spawnSync(
+    cliPath,
+    [
+      "--install-extension",
+      extension,
+      "--extensions-dir",
+      extensionsDir,
+      "--disable-telemetry",
+    ],
+    {
+      encoding: "utf-8",
+      stdio: "inherit",
+    }
+  );
+}
 
 async function main() {
-    try {
-        const extensionDevelopmentPath = path.resolve(__dirname, '../../');
-        const extensionTestsPath = path.resolve(__dirname, './suite/index');
-        await runTests({
-            extensionDevelopmentPath,
-            extensionTestsPath,
-            launchArgs: ['--disable-extensions'],
-        });
-    } catch {
-        console.error('Failed to run tests');
-        process.exit(1);
-    }
+  try {
+    const extensionDevelopmentPath = path.resolve(__dirname, "../../");
+
+    const extensionTestsPath = path.resolve(__dirname, "./suite/index");
+    const vscodeExecutablePath = await downloadAndUnzipVSCode("insiders");
+    const cliPath =
+      resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
+    const extensionsDir = getExtensionsDir(vscodeExecutablePath);
+
+    installExtension(cliPath, extensionsDir, "ms-toolsai.jupyter");
+
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: ["--extensions-dir", extensionsDir]
+        .concat(["--skip-welcome"])
+        .concat(["--skip-release-notes"]),
+      version: "insiders",
+    });
+  } catch (err) {
+    console.error("Failed to run tests", err);
+    process.exit(1);
+  }
 }
 
 main().catch((error: unknown) => {
-    console.error('Unhandled error in main function', error);
-    process.exit(1);
+  console.error("Unhandled error in main function", error);
+  process.exit(1);
 });

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,32 +1,32 @@
-import * as path from 'path';
-import { Glob } from 'glob';
-import Mocha from 'mocha';
+import * as path from "path";
+import { Glob } from "glob";
+import * as Mocha from "mocha";
 
 export function run(): Promise<void> {
-    const mocha = new Mocha({
-        ui: 'tdd'
-    });
+  const mocha = new Mocha({
+    ui: "bdd",
+  });
 
-    const testsRoot = path.resolve(__dirname, '..');
+  const testsRoot = path.resolve(__dirname, "..");
 
-    return new Promise((c, e) => {
-        const files = new Glob('**/**.test.js', { cwd: testsRoot });
+  return new Promise((c, e) => {
+    const files = new Glob("**/**.test.js", { cwd: testsRoot });
 
-        for (const file of files) {
-            mocha.addFile(path.resolve(testsRoot, file));
+    for (const file of files) {
+      mocha.addFile(path.resolve(testsRoot, file));
+    }
+
+    try {
+      mocha.run((failures) => {
+        if (failures > 0) {
+          e(new Error(`${failures.toString()} tests failed.`));
+        } else {
+          c();
         }
-
-        try {
-            mocha.run(failures => {
-                if (failures > 0) {
-                    e(new Error(`${failures.toString()} tests failed.`));
-                } else {
-                    c();
-                }
-            });
-        } catch (err) {
-            console.error(err);
-            e(err instanceof Error ? err : new Error(String(err)));
-        }
-    });
+      });
+    } catch (err) {
+      console.error(err);
+      e(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,31 +1,26 @@
 {
-	"include": [
-		"src/**/*",
-		"eslint.config.mjs"
-	],
-	"compilerOptions": {
-		"module": "Node16",
-		"target": "ES2022",
-		"rootDir": "src",
-		"outDir": "out",
-		"lib": [
-			"ES2022"
-		],
-		"forceConsistentCasingInFileNames": true,
-		"noFallthroughCasesInSwitch": true,
-		"noImplicitAny": true,
-		"noImplicitOverride": true,
-		"noImplicitReturns": true,
-		"noImplicitThis": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"resolveJsonModule": true,
-		"sourceMap": true,
-		"strict": true,
-		"strictBindCallApply": true,
-		"strictFunctionTypes": true,
-		"strictNullChecks": true,
-		"strictPropertyInitialization": false,
-		"useUnknownInCatchVariables": false
-	}
+  "include": ["src/**/*", "eslint.config.mjs"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "rootDir": "src",
+    "outDir": "out",
+    "lib": ["ES2022"],
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "strict": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": false,
+    "useUnknownInCatchVariables": false
+  }
 }


### PR DESCRIPTION
[RP hardcoded demo.webm](https://github.com/user-attachments/assets/abf3ab44-2320-4969-b154-57e844d4eea8)

For now, the URL and token are hardcoded as settings until we have auth and the assignment flow implemented. This is temporary.

Added `ms-toolsai.jupyter` to the extension dependencies. Added the necessary install step in the test runner.

Run tests with the `"insiders"` build of VS Code so it can be run alongside VS Code while developing ([VS Code tip](https://code.visualstudio.com/api/working-with-extensions/testing-extension#using-insiders-version-for-extension-development)). This is consistent with what I see other extensions doing ([example](https://github.com/microsoft/vscode-jupyter-hub/blob/main/src/test/runTest.ts#L18)).

Unfortunately there's a few more formatting changes than I'd like. Reminds me I need to setup Prettier and enforce that with automation sooner than later. I'll try to get to that shortly.

Other minor changes:

- Moved `register` to be a static function on `ColabJupyterServerProvider`.
- Removes the specification of `outFiles` for the _Extension Integration Tests_ launch configuration so VS Code can map breakpoints to the non-test `src/` files.
- Specifies `commonjs` in `package.json` module compatibility. Seems to be what most extensions set.
- Switched from Mocha's TDD -> BDD since that's what the team's more familiar with internally (with Jasmine).