### PR TITLE
[Config]: Correct config settings Resources misspelling

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
       "type": "object",
       "title": "Colab",
       "properties": {
-        "colab.resoruceProxyBaseUrl": {
+        "colab.resourceProxyBaseUrl": {
           "type": "string",
           "default": "",
           "description": "A temporary setting to hardcode a resource proxy base URL."
         },
-        "colab.resoruceProxyToken": {
+        "colab.resourceProxyToken": {
           "type": "string",
           "default": "",
           "description": "A temporary setting to hardcode a resource proxy token."

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,10 +11,16 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(servers);
 }
 
+/** Configuration settings enum */
+export enum Config {
+  ProxyBaseUrl = "resourceProxyBaseUrl",
+  ProxyToken = "resourceProxyToken",
+}
+
 function getRpConfig(): RpConfig {
   const config = workspace.getConfiguration("colab");
-  const baseUrl = config.get<string>("resoruceProxyBaseUrl");
-  const token = config.get<string>("resoruceProxyToken");
+  const baseUrl = config.get<string>(Config.ProxyBaseUrl);
+  const token = config.get<string>(Config.ProxyToken);
 
   if (!baseUrl || !token) {
     throw new Error(

--- a/src/test/extension.vscode.test.ts
+++ b/src/test/extension.vscode.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
+import { Config } from "../extension";
 
 describe("Extension", () => {
   it("should be present", () => {
@@ -7,8 +8,8 @@ describe("Extension", () => {
   });
 
   it("should activate", async () => {
-    await setConfig("resoruceProxyBaseUrl", "foo");
-    await setConfig("resoruceProxyToken", "bar");
+    await setConfig(Config.ProxyBaseUrl, "foo");
+    await setConfig(Config.ProxyToken, "bar");
     const extension = vscode.extensions.getExtension("google.colab");
 
     await extension?.activate();


### PR DESCRIPTION
Corrects misspelling of "Resoruces" to "Resources" in the settings config.
This misspelling is distracting and is relied on when grabbing the
config properties in the extension code, we can prevent strange
reliance on misspelled words by fixing this early.

Additionally moved config related strings to an enum instead of hard
coding them in place.
