### PR TITLE
chore: prohibit public modifiers

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,10 @@ export default tseslint.config(
         "error",
         { argsIgnorePattern: "^_" },
       ],
+      "@typescript-eslint/explicit-member-accessibility": [
+        "error",
+        { accessibility: "no-public" },
+      ],
     },
   },
   // Intentionally last to override any conflicting rules.


### PR DESCRIPTION
https://typescript-eslint.io/rules/explicit-member-accessibility

Consistent with Google-internal style guide - [go/tsjs-style#visibility](http://go/tsjs-style#visibility): _TypeScript symbols are public by default. Never use the public modifier except when declaring non-readonly public parameter properties (in constructors)_.