### PR TITLE
test: extend integration test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "format:check": "prettier . --check",
     "pretest": "npm run compile && npm run lint",
     "test:unittests": "npm run compile && mocha --enable-source-maps --require ./out/test/unit-test-setup.js './out/**/*.unit.test.js'",
-    "test:xvfb": "xvfb-run -s '-screen 0 1024x768x24' node ./out/test/runTest.js",
-    "test": "node ./out/test/runTest.js",
+    "test:xvfb": "xvfb-run -s '-screen 0 1024x768x24' node ./out/test/integration-test-runner.js",
+    "test": "node ./out/test/integration-test-runner.js",
     "vscode:prepublish": "npm run compile",
     "watch:prod": "tsc -watch -p ./tsconfig.prod.json",
     "watch": "tsc -watch -p ./"

--- a/src/test/integration-test-runner.ts
+++ b/src/test/integration-test-runner.ts
@@ -54,7 +54,8 @@ async function main() {
       extensionTestsPath,
       launchArgs: ["--extensions-dir", extensionsDir]
         .concat(["--skip-welcome"])
-        .concat(["--skip-release-notes"]),
+        .concat(["--skip-release-notes"])
+        .concat(["--timeout", "5000"]),
       version: "insiders",
     });
   } catch (err) {


### PR DESCRIPTION
Twice now, most recently on https://github.com/googlecolab/colab-vscode/pull/19, I noticed integration test flake.

```
  Extension
    ✔ should be present
    1) should activate
  1 passing (2s)
  1 failing
  1) Extension
       should activate:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/runner/work/colab-vscode/colab-vscode/out/test/extension.vscode.test.js)
  	at listOnTimeout (node:internal/timers:581:17)
  	at process.processTimers (node:internal/timers:519:7)
```

Looking at some successful runs, we're frequently upwards of 1s so I believe we're a bit too tight on the default timeout. Given that these integration tests use _real_ VS Code, that seems understandable.

Extending to 5 seconds, but if we still see these flakes there may be something wrong with the test harness. But cruising through [this SO post](https://stackoverflow.com/a/52641542) I don't think there's anything fundamentally wrong.

---

Also took the opportunity to rename `runTest.ts` to better conform with our other files/naming structure.