### PR TITLE
fix: remove erroneous double URL encoding

### DIFF
--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -181,12 +181,11 @@ export class GoogleAuthProvider
         const promisedCode = this.codeProvider.waitForCode(nonce, cancel);
 
         const callbackUri = await this.getCallbackUri(nonce);
-        const encodedCallbackUri = callbackUri.toString();
         const pkce = await this.oAuth2Client.generateCodeVerifierAsync();
         const authorizeUrl = this.oAuth2Client.generateAuthUrl({
           response_type: "code",
           scope: scopes,
-          state: encodedCallbackUri,
+          state: callbackUri.toString(),
           prompt: "login",
           code_challenge_method: CodeChallengeMethod.S256,
           code_challenge: pkce.codeChallenge,


### PR DESCRIPTION
`vscode.Uri.parse` and `vscode.env.asExternalUri` does the correct single escaping we need. No need to doubly encode the `nonce` query param and then the entire `callbackUri` again.

Tested E2E manually with the _runlocal_ stack.