### PR TITLE
chore: cache npm

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
@@ -42,6 +43,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
       - run: npm ci
       - run: npm run test:unit
 


### PR DESCRIPTION
Had set it for `vsCodeTests` but missed in `lint` and `unitTests`.

Configured as per
https://github.com/actions/setup-node?tab=readme-ov-file#caching-global-packages-data.