### PR TITLE
chore: remove legacy configuration options

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,24 +19,6 @@
     "onNotebook:interactive"
   ],
   "main": "./out/extension.js",
-  "contributes": {
-    "configuration": {
-      "type": "object",
-      "title": "Colab",
-      "properties": {
-        "colab.resourceProxyBaseUrl": {
-          "type": "string",
-          "default": "",
-          "description": "A temporary setting to hardcode a resource proxy base URL."
-        },
-        "colab.resourceProxyToken": {
-          "type": "string",
-          "default": "",
-          "description": "A temporary setting to hardcode a resource proxy token."
-        }
-      }
-    }
-  },
   "scripts": {
     "clean": "rm -rf out/*",
     "compile": "tsc -p ./",


### PR DESCRIPTION
The need for these options was removed in
https://github.com/googlecolab/colab-vscode/pull/15.