### PR TITLE
chore: allow unbound methods in test

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,6 +49,12 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    files: ["**/*.unit.test.ts"],
+    rules: {
+      "@typescript-eslint/unbound-method": "off",
+    },
+  },
   // Intentionally last to override any conflicting rules.
   eslintConfigPrettier,
 );

--- a/src/auth/provider.unit.test.ts
+++ b/src/auth/provider.unit.test.ts
@@ -101,7 +101,6 @@ describe("GoogleAuthProvider", () => {
     it('disposes the "Google" authentication provider', () => {
       authProvider.dispose();
 
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       sinon.assert.calledOnce(registrationDisposable.dispose);
     });
   });


### PR DESCRIPTION
Useful for easily asserting sinon stubbed methods.

Used estensively in PRs to follow.