### PR TITLE
feat: require IDs to be UUIDs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,8 @@ export default tseslint.config(
           ignoreStrings: true,
           ignoreTemplateLiterals: true,
           ignoreUrls: true,
-          ignorePattern: "<.*>",
+          // Generics and regex literals are often long and can be hard to split.
+          ignorePattern: "(<.*>)|(\/.+\/)",
         },
       ],
       "@typescript-eslint/no-unused-vars": [

--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -1,6 +1,8 @@
+import { UUID } from "crypto";
 import * as https from "https";
 import fetch, { Request } from "node-fetch";
 import { AuthenticationSession } from "vscode";
+import { uuidToWebSafeBase64 } from "../utils/uuid";
 import {
   Assignment,
   CCUInfo,
@@ -63,7 +65,7 @@ export class ColabClient {
    * @returns The assignment which is assigned to the user.
    */
   async assign(
-    notebookHash: string,
+    notebookHash: UUID,
     variant: Variant,
     accelerator?: Accelerator,
   ): Promise<Assignment> {
@@ -91,7 +93,7 @@ export class ColabClient {
   }
 
   private async getAssignment(
-    notebookHash: string,
+    notebookHash: UUID,
     variant: Variant,
     accelerator?: Accelerator,
   ): Promise<AssignmentToken | AssignedAssignment> {
@@ -107,7 +109,7 @@ export class ColabClient {
   }
 
   private async postAssignment(
-    notebookHash: string,
+    notebookHash: UUID,
     xsrfToken: string,
     variant: Variant,
     accelerator?: Accelerator,
@@ -119,12 +121,12 @@ export class ColabClient {
   }
 
   private buildAssignUrl(
-    notebookHash: string,
+    notebookHash: UUID,
     variant: Variant,
     accelerator?: Accelerator,
   ): URL {
     const url = new URL(ASSIGN_ENDPOINT, this.domain);
-    url.searchParams.append("nbh", notebookHash);
+    url.searchParams.append("nbh", uuidToWebSafeBase64(notebookHash));
     if (variant !== Variant.DEFAULT) {
       url.searchParams.append("variant", variant.toString());
     }

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { expect } from "chai";
 import { Response } from "node-fetch";
 import * as nodeFetch from "node-fetch";
@@ -18,7 +19,7 @@ import { ColabClient } from "./client";
 
 const DOMAIN = "https://colab.example.com";
 const BEARER_TOKEN = "access-token";
-const NOTEBOOK_HASH = "notebook-hash";
+const NOTEBOOK_HASH = randomUUID();
 
 describe("ColabClient", () => {
   let fetchStub: SinonStub<
@@ -91,7 +92,7 @@ describe("ColabClient", () => {
         endpoint: "mock-endpoint",
         sub: SubscriptionState.UNSUBSCRIBED,
         subTier: SubscriptionTier.UNKNOWN_TIER,
-        variant: Variant.DEFAULT,
+        variant: Variant.GPU,
         machineShape: Shape.STANDARD,
         runtimeProxyInfo: {
           token: "mock-token",
@@ -133,7 +134,7 @@ describe("ColabClient", () => {
         endpoint: "mock-endpoint",
         sub: SubscriptionState.UNSUBSCRIBED,
         subTier: SubscriptionTier.UNKNOWN_TIER,
-        variant: Variant.DEFAULT,
+        variant: Variant.GPU,
         machineShape: Shape.STANDARD,
         runtimeProxyInfo: {
           token: "mock-token",

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import {
   Jupyter,
   JupyterServer,
@@ -8,12 +9,15 @@ import fetch, { Headers } from "node-fetch";
 import vscode, { CancellationToken, ProviderResult } from "vscode";
 import { CCUInfo, Variant } from "../colab/api";
 import { ColabClient } from "../colab/client";
-import { SERVERS } from "./servers";
+import { COLAB_SERVERS } from "./servers";
 
 /**
  * A header key for the Colab runtime proxy token.
  */
 const COLAB_RUNTIME_PROXY_TOKEN_HEADER = "X-Colab-Runtime-Proxy-Token";
+
+// TODO: Derive NBH.
+const staticNbh = randomUUID();
 
 /**
  * A header key for the Colab client agent.
@@ -62,7 +66,7 @@ export class ColabJupyterServerProvider
       const eligibleGpus = new Set(ccuInfo.eligibleGpus);
       const ineligibleGpus = new Set(ccuInfo.ineligibleGpus);
       // TODO: TPUs are currently not supported by the CCU Info API.
-      return Array.from(SERVERS.values()).filter((server) => {
+      return Array.from(COLAB_SERVERS).filter((server) => {
         if (server.variant !== Variant.GPU) {
           return true;
         }
@@ -87,16 +91,15 @@ export class ColabJupyterServerProvider
     server: JupyterServer,
     _token: CancellationToken,
   ): ProviderResult<JupyterServer> {
-    // TODO: Derive NBH.
-    const nbh = "booooooooooooooooooooooooooooooooooooooooooo"; // cspell:disable-line
-
-    const colabServer = SERVERS.get(server.id);
+    const colabServer = Array.from(COLAB_SERVERS).find(
+      (s) => s.id === server.id,
+    );
     if (!colabServer) {
       return Promise.reject(new Error(`Unknown server: ${server.id}`));
     }
 
     return this.client
-      .assign(nbh, colabServer.variant, colabServer.accelerator)
+      .assign(staticNbh, colabServer.variant, colabServer.accelerator)
       .then((assignment): JupyterServer => {
         const { url, token } = assignment.runtimeProxyInfo ?? {};
 
@@ -108,6 +111,7 @@ export class ColabJupyterServerProvider
 
         return {
           ...server,
+          id: staticNbh,
           connectionInformation: {
             baseUrl: this.vs.Uri.parse(url),
             headers: { COLAB_RUNTIME_PROXY_TOKEN_HEADER: token },

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -19,8 +19,11 @@ import {
 } from "../colab/api";
 import { ColabClient } from "../colab/client";
 import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
+import { isUUID } from "../utils/uuid";
 import { ColabJupyterServerProvider } from "./provider";
-import { ColabJupyterServer, SERVERS } from "./servers";
+import { ColabJupyterServer, COLAB_SERVERS } from "./servers";
+
+const SERVERS = Array.from(COLAB_SERVERS);
 
 describe("ColabJupyterServerProvider", () => {
   let vsCodeStub: VsCodeStub;
@@ -103,7 +106,7 @@ describe("ColabJupyterServerProvider", () => {
       const providedServers =
         await serverProvider.provideJupyterServers(cancellationToken);
 
-      expect(providedServers).to.deep.equal(Array.from(SERVERS.values()));
+      expect(providedServers).to.deep.equal(SERVERS);
       sinon.assert.calledOnce(colabClientStub.ccuInfo);
     });
 
@@ -123,7 +126,7 @@ describe("ColabJupyterServerProvider", () => {
       const providedServers =
         await serverProvider.provideJupyterServers(cancellationToken);
 
-      const expectedServers = Array.from(SERVERS.values()).filter(
+      const expectedServers = SERVERS.filter(
         (server) => server.accelerator !== Accelerator.L4,
       );
       expect(providedServers).to.deep.equal(expectedServers);
@@ -146,7 +149,7 @@ describe("ColabJupyterServerProvider", () => {
       const providedServers =
         await serverProvider.provideJupyterServers(cancellationToken);
 
-      const expectedServers = Array.from(SERVERS.values()).filter(
+      const expectedServers = SERVERS.filter(
         (server) => server.accelerator !== Accelerator.L4,
       );
       expect(providedServers).to.deep.equal(expectedServers);
@@ -167,19 +170,20 @@ describe("ColabJupyterServerProvider", () => {
     });
 
     it("rejects for server assignments without connection information", async () => {
-      const server = SERVERS.get("gpu-a100");
+      const server = SERVERS.find((s) => s.id === "gpu-a100");
       assert.isDefined(server);
-      const nbh = "booooooooooooooooooooooooooooooooooooooooooo"; // cspell:disable-line
       const assignment: Assignment = {
         accelerator: Accelerator.A100,
         endpoint: "mock-endpoint",
         sub: SubscriptionState.UNSUBSCRIBED,
         subTier: SubscriptionTier.UNKNOWN_TIER,
-        variant: Variant.DEFAULT,
+        variant: Variant.GPU,
         machineShape: Shape.STANDARD,
         runtimeProxyInfo: undefined,
       };
-      colabClientStub.assign.withArgs(nbh, server.variant).resolves(assignment);
+      colabClientStub.assign
+        .withArgs(sinon.match(isUUID), server.variant)
+        .resolves(assignment);
 
       await expect(
         serverProvider.resolveJupyterServer(server, cancellationToken),
@@ -187,16 +191,15 @@ describe("ColabJupyterServerProvider", () => {
     });
 
     it("successfully", async () => {
-      const server = SERVERS.get("gpu-a100");
+      const server = SERVERS.find((s) => s.id === "gpu-a100");
       assert.isDefined(server);
       const fetchStub = sinon.stub(fetch);
-      const nbh = "booooooooooooooooooooooooooooooooooooooooooo"; // cspell:disable-line
       const assignment: Assignment = {
         accelerator: Accelerator.A100,
         endpoint: "mock-endpoint",
         sub: SubscriptionState.UNSUBSCRIBED,
         subTier: SubscriptionTier.UNKNOWN_TIER,
-        variant: Variant.DEFAULT,
+        variant: Variant.GPU,
         machineShape: Shape.STANDARD,
         runtimeProxyInfo: {
           token: "mock-token",
@@ -204,10 +207,19 @@ describe("ColabJupyterServerProvider", () => {
           url: "https://mock-url.com",
         },
       };
-      colabClientStub.assign.withArgs(nbh, server.variant).resolves(assignment);
+      colabClientStub.assign
+        .withArgs(sinon.match(isUUID), server.variant)
+        .resolves(assignment);
       assert.isDefined(assignment.runtimeProxyInfo);
+
+      const resolvedServer = await serverProvider.resolveJupyterServer(
+        server,
+        cancellationToken,
+      );
+
+      sinon.assert.calledOnce(colabClientStub.assign);
       const expectedResolvedServer: ColabJupyterServer = {
-        id: server.id,
+        id: colabClientStub.assign.firstCall.args[0],
         label: server.label,
         connectionInformation: {
           baseUrl: vsCodeStub.Uri.parse(assignment.runtimeProxyInfo.url),
@@ -219,12 +231,6 @@ describe("ColabJupyterServerProvider", () => {
         variant: server.variant,
         accelerator: server.accelerator,
       };
-
-      const resolvedServer = await serverProvider.resolveJupyterServer(
-        server,
-        cancellationToken,
-      );
-
       assert.isDefined(resolvedServer?.connectionInformation?.fetch);
       sinon.replace(resolvedServer.connectionInformation, "fetch", fetchStub);
       expect(resolvedServer).to.deep.equal(expectedResolvedServer);
@@ -233,9 +239,8 @@ describe("ColabJupyterServerProvider", () => {
 
   it("specifies the Colab headers on fetch requests", async () => {
     const fetchStub = sinon.stub(fetch, "default");
-    const server = SERVERS.get("m");
+    const server = SERVERS.find((s) => s.id === "m");
     assert.isDefined(server);
-    const nbh = "booooooooooooooooooooooooooooooooooooooooooo"; // cspell:disable-line
     const assignment: Assignment = {
       accelerator: Accelerator.NONE,
       endpoint: "mock-endpoint",
@@ -249,7 +254,9 @@ describe("ColabJupyterServerProvider", () => {
         url: "https://mock-url.com",
       },
     };
-    colabClientStub.assign.withArgs(nbh, server.variant).resolves(assignment);
+    colabClientStub.assign
+      .withArgs(sinon.match(isUUID), server.variant)
+      .resolves(assignment);
     assert.isDefined(assignment.runtimeProxyInfo);
 
     const resolvedServer = await serverProvider.resolveJupyterServer(

--- a/src/jupyter/servers.ts
+++ b/src/jupyter/servers.ts
@@ -1,71 +1,82 @@
-import { JupyterServer } from "@vscode/jupyter-extension";
+import { UUID } from "crypto";
+import {
+  JupyterServer,
+  JupyterServerConnectionInformation,
+} from "@vscode/jupyter-extension";
 import { Accelerator, Variant } from "../colab/api";
 
 /**
  * Colab's Jupyter server descriptor which includes machine-specific
  * designations.
  */
-export interface ColabJupyterServer extends JupyterServer {
-  variant: Variant;
-  accelerator?: Accelerator;
+export interface ColabServerDescriptor {
+  // Note: id will be removed as part of the Jupyter server provider rework.
+  readonly id: string;
+  readonly label: string;
+  readonly variant: Variant;
+  readonly accelerator?: Accelerator;
 }
+
+/**
+ * A Jupyter server which includes the Colab descriptor and enforces that IDs
+ * are UUIDs.
+ */
+export interface ColabJupyterServer
+  extends ColabServerDescriptor,
+    JupyterServer {
+  readonly id: UUID;
+}
+
+/**
+ * A Colab Jupyter server which has been assigned, thus including the required
+ * connection information.
+ */
+export type ColabAssignedServer = ColabJupyterServer & {
+  readonly connectionInformation: JupyterServerConnectionInformation & {
+    readonly token: string;
+  };
+};
 
 /**
  * The mapping of all potentially available ID to Colab Jupyter servers.
  */
-export const SERVERS = new Map<string, ColabJupyterServer>([
+export const COLAB_SERVERS = new Set<ColabServerDescriptor>([
   // CPUs
-  [
-    "m",
-    {
-      id: "m",
-      label: "Colab CPU",
-      variant: Variant.DEFAULT,
-    },
-  ],
+  {
+    id: "m",
+    label: "Colab CPU",
+    variant: Variant.DEFAULT,
+  },
   // GPUs
-  [
-    "gpu-t4",
-    {
-      id: "gpu-t4",
-      label: "Colab GPU T4",
-      variant: Variant.GPU,
-      accelerator: Accelerator.T4,
-    },
-  ],
-  [
-    "gpu-l4",
-    {
-      id: "gpu-l4",
-      label: "Colab GPU L4",
-      variant: Variant.GPU,
-      accelerator: Accelerator.L4,
-    },
-  ],
-  [
-    "gpu-a100",
-    {
-      id: "gpu-a100",
-      label: "Colab GPU A100",
-      variant: Variant.GPU,
-      accelerator: Accelerator.A100,
-    },
-  ],
+  {
+    id: "gpu-t4",
+    label: "Colab GPU T4",
+    variant: Variant.GPU,
+    accelerator: Accelerator.T4,
+  },
+  {
+    id: "gpu-l4",
+    label: "Colab GPU L4",
+    variant: Variant.GPU,
+    accelerator: Accelerator.L4,
+  },
+  {
+    id: "gpu-a100",
+    label: "Colab GPU A100",
+    variant: Variant.GPU,
+    accelerator: Accelerator.A100,
+  },
   // TPUs
-  [
-    "tpu-v28",
-    {
-      id: "tpu-v28",
-      label: "Colab TPU v2-8",
-      variant: Variant.TPU,
-    },
-  ],
-  [
-    "tpu-v5e1",
-    {
-      id: "tpu-v5e1",
-      label: "Colab TPU v5e-1",
-      variant: Variant.TPU,
-    },
-  ],
+  {
+    id: "tpu-v2-8",
+    label: "Colab TPU v2-8",
+    variant: Variant.TPU,
+    accelerator: Accelerator.V28,
+  },
+  {
+    id: "tpu-v5e1",
+    label: "Colab TPU v5e-1",
+    variant: Variant.TPU,
+    accelerator: Accelerator.V5E1,
+  },
 ]);

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,27 @@
+import { UUID } from "crypto";
+
+/**
+ * Type guard to check if a value is a valid UUID. Ensures the string follows
+ * the UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ *
+ * @param value - The value to check.
+ * @returns True if the value is a valid UUID, otherwise false.
+ */
+export function isUUID(value: string): value is UUID {
+  const uuidRegex =
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+  return uuidRegex.test(value);
+}
+
+/**
+ * Converts a UUID string into a Colab-valid notebook (file ID) hash.
+ *
+ * The result conforms to Colab's NBH-Regex: `^[a-zA-Z0-9\\-_.]{44}$`.
+ *
+ * @param uuid - The UUID to convert.
+ * @returns A 44-character padded string of the UUID.
+ */
+export function uuidToWebSafeBase64(uuid: UUID): string {
+  // Ensure 44-character length by adding the necessary padding.
+  return uuid.replace(/-/g, "_") + ".".repeat(44 - uuid.length);
+}


### PR DESCRIPTION
This modifies the code to require IDs to be UUIDs. It includes changes to the max-len ignore pattern to include regular expressions. The code also adds type guards and conversion functions for UUIDs.

Fun bit... `zod` continues to amaze me... `z.string().refine(isUUID, "String must be a valid UUID.")` 😍.

This is a prefactor for the Jupyter server provider refactor which extends beyond a single static server. For now, I'm simply assigning that server to a static UUID. That'll all go away with the refactor (upcoming PR).

I know the structure of `COLAB_SERVERS` could be more efficient, but for now it's easiest to have it be a `Set` and incur the insignificant, temporary, pentalty of iterating it in the provider. The rework is _just a few PRs away_.