### PR TITLE
feat: list Colab assignments

### DIFF
--- a/src/colab/api.ts
+++ b/src/colab/api.ts
@@ -68,7 +68,7 @@ function uppercaseEnum<T extends z.EnumLike>(
   }, z.nativeEnum(enumObj));
 }
 
-export const FreeCCUQuotaInfoSchema = z.object({
+export const FreeCcuQuotaInfoSchema = z.object({
   /**
    * Number of tokens remaining in the "USAGE-mCCUs" quota group (remaining
    * free usage allowance in milli-CCUs).
@@ -79,12 +79,12 @@ export const FreeCCUQuotaInfoSchema = z.object({
    */
   nextRefillTimestampSec: z.number(),
 });
-export type FreeCCUQuotaInfo = z.infer<typeof FreeCCUQuotaInfoSchema>;
+export type FreeCcuQuotaInfo = z.infer<typeof FreeCcuQuotaInfoSchema>;
 
 /**
  * Cloud compute unit (CCU) information.
  */
-export const CCUInfoSchema = z.object({
+export const CcuInfoSchema = z.object({
   /**
    * The current balance of the paid CCUs.
    *
@@ -113,9 +113,9 @@ export const CCUInfoSchema = z.object({
   /**
    * Free CCU quota information if applicable.
    */
-  freeCcuQuotaInfo: FreeCCUQuotaInfoSchema.optional(),
+  freeCcuQuotaInfo: FreeCcuQuotaInfoSchema.optional(),
 });
-export type CCUInfo = z.infer<typeof CCUInfoSchema>;
+export type CcuInfo = z.infer<typeof CcuInfoSchema>;
 
 export const GetAssignmentResponseSchema = z.object({
   /** The pool's {@link Accelerator}. */
@@ -177,3 +177,5 @@ export const AssignmentSchema = z.object({
   runtimeProxyInfo: RuntimeProxyInfoSchema.optional(),
 });
 export type Assignment = z.infer<typeof AssignmentSchema>;
+
+export const AssignmentsSchema = z.array(AssignmentSchema);


### PR DESCRIPTION
Adds a new method to the Colab API client to list assignments.

A few minor additional changes:

- Properly cases "CCU" as "Ccu" (camel).
- Removes `?authuser=0` from all endpoints and applies it globally.
- De-dups test data.
- Fixed _getCCUInfo_ describe to _ccuInfo_ (the SUT).
- Matched on a subset of the error instead of the full response (less brittle)
  for applicable tests.
- Modified `SinonMatcher` for the fetch matching to more robustly match query params.