### PR TITLE
fix: ergonomic improvments for assignments

### DIFF
--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -54,11 +54,11 @@ export class AssignmentManager implements vscode.Disposable {
   }
 
   /**
-   * Retrieves a list of available servers that can be assigned.
+   * Retrieves a list of available server descriptors that can be assigned.
    *
-   * @returns A list of available servers.
+   * @returns A list of available server descriptors.
    */
-  async availableServers(): Promise<ColabServerDescriptor[]> {
+  async getAvailableServerDescriptors(): Promise<ColabServerDescriptor[]> {
     const ccuInfo = await this.client.ccuInfo();
     const eligibleGpus = new Set(ccuInfo.eligibleGpus);
     const ineligibleGpus = new Set(ccuInfo.ineligibleGpus);
@@ -84,8 +84,8 @@ export class AssignmentManager implements vscode.Disposable {
    * @returns A list of assigned servers. Connection information is included
    * and can be refreshed by calling {@link refreshConnection}.
    */
-  async assignedServers(): Promise<ColabAssignedServer[]> {
-    return (await this.storage.get()).map((server) => ({
+  async getAssignedServers(): Promise<ColabAssignedServer[]> {
+    return (await this.storage.list()).map((server) => ({
       ...server,
       connectionInformation: {
         ...server.connectionInformation,
@@ -151,7 +151,7 @@ export class AssignmentManager implements vscode.Disposable {
       },
       assignment.runtimeProxyInfo,
     );
-    await this.storage.store(server);
+    await this.storage.store([server]);
     this.assignmentsChange.fire();
     return server;
   }

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -61,7 +61,7 @@ export class ColabJupyterServerProvider
   provideJupyterServers(
     _token: CancellationToken,
   ): ProviderResult<JupyterServer[]> {
-    return this.assignmentManager.assignedServers();
+    return this.assignmentManager.getAssignedServers();
   }
 
   /**
@@ -146,7 +146,7 @@ export class ColabJupyterServerProvider
   }
 
   private async getServer(id: UUID): Promise<JupyterServer> {
-    const assignedServers = await this.assignmentManager.assignedServers();
+    const assignedServers = await this.assignmentManager.getAssignedServers();
     const assignedServer = assignedServers.find((s) => s.id === id);
     if (!assignedServer) {
       throw new Error("Server not found");
@@ -156,7 +156,7 @@ export class ColabJupyterServerProvider
 
   private async assignServer(): Promise<JupyterServer> {
     const serverType = await this.serverPicker.prompt(
-      await this.assignmentManager.availableServers(),
+      await this.assignmentManager.getAvailableServerDescriptors(),
     );
     if (!serverType) {
       throw new this.vs.CancellationError();

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -116,7 +116,7 @@ describe("ColabJupyterServerProvider", () => {
 
   describe("provideJupyterServers", () => {
     it("returns no servers when none are assigned", async () => {
-      assignmentStub.assignedServers.resolves([]);
+      assignmentStub.getAssignedServers.resolves([]);
 
       const servers =
         await serverProvider.provideJupyterServers(cancellationToken);
@@ -125,7 +125,7 @@ describe("ColabJupyterServerProvider", () => {
     });
 
     it("returns a single server when one is assigned", async () => {
-      assignmentStub.assignedServers.resolves([defaultServer]);
+      assignmentStub.getAssignedServers.resolves([defaultServer]);
 
       const servers =
         await serverProvider.provideJupyterServers(cancellationToken);
@@ -138,7 +138,7 @@ describe("ColabJupyterServerProvider", () => {
         defaultServer,
         { ...defaultServer, id: randomUUID() },
       ];
-      assignmentStub.assignedServers.resolves(assignedServers);
+      assignmentStub.getAssignedServers.resolves(assignedServers);
 
       const servers =
         await serverProvider.provideJupyterServers(cancellationToken);
@@ -172,7 +172,7 @@ describe("ColabJupyterServerProvider", () => {
           token: "456",
         },
       };
-      assignmentStub.assignedServers.resolves([defaultServer]);
+      assignmentStub.getAssignedServers.resolves([defaultServer]);
       assignmentStub.refreshConnection
         .withArgs(defaultServer)
         .resolves(refreshedServer);
@@ -257,7 +257,9 @@ describe("ColabJupyterServerProvider", () => {
 
         it("completes assigning a server", async () => {
           const availableServers = Array.from(COLAB_SERVERS);
-          assignmentStub.availableServers.resolves(availableServers);
+          assignmentStub.getAvailableServerDescriptors.resolves(
+            availableServers,
+          );
           const selectedServer: ColabServerDescriptor = {
             label: "My new server",
             variant: defaultServer.variant,

--- a/src/jupyter/storage.ts
+++ b/src/jupyter/storage.ts
@@ -37,10 +37,10 @@ export class ServerStorage {
   ) {}
 
   /**
-   * Get the assigned servers that have been stored.
+   * List the assigned servers that have been stored.
    * @returns The assigned servers that have been stored.
    */
-  async get(): Promise<ColabAssignedServer[]> {
+  async list(): Promise<ColabAssignedServer[]> {
     if (this.cache !== undefined) {
       return this.cache;
     }
@@ -64,24 +64,29 @@ export class ServerStorage {
   }
 
   /**
-   * Store an assigned server.
+   * Stores the provided assigned servers.
    *
-   * @param server The server to store.
+   * Servers are unique by their ID. If a server with the same ID is already
+   * stored, it will be replaced.
+   *
+   * @param servers The servers to store.
    */
-  async store(server: ColabAssignedServer): Promise<void> {
+  async store(servers: ColabAssignedServer[]): Promise<void> {
     const existingServersJson = await this.secrets.get(ASSIGNED_SERVERS_KEY);
     const serversById = mapServersById(existingServersJson);
-    serversById.set(server.id, {
-      id: server.id,
-      label: server.label,
-      variant: server.variant,
-      accelerator: server.accelerator,
-      connectionInformation: {
-        baseUrl: server.connectionInformation.baseUrl.toString(),
-        token: server.connectionInformation.token,
-        headers: server.connectionInformation.headers,
-      },
-    });
+    for (const server of servers) {
+      serversById.set(server.id, {
+        id: server.id,
+        label: server.label,
+        variant: server.variant,
+        accelerator: server.accelerator,
+        connectionInformation: {
+          baseUrl: server.connectionInformation.baseUrl.toString(),
+          token: server.connectionInformation.token,
+          headers: server.connectionInformation.headers,
+        },
+      });
+    }
     return this.storeServers(
       Array.from(serversById.values()),
       existingServersJson,


### PR DESCRIPTION
Only none-cosmetic change is modifying `store` to accept a list. This is a
prefactor for being able to reconcile stored servers with those returned from `/assignments`.