### PR TITLE
feat: reconcile assignments on activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,7 @@ export async function activate(context: vscode.ExtensionContext) {
     colabClient,
     serverStorage,
   );
+  await assignmentManager.reconcileAssignedServers();
   const serverPicker = new ServerPicker(vscode);
   const serverProvider = new ColabJupyterServerProvider(
     vscode,


### PR DESCRIPTION
The extension maintains a list of assignments that originate from itself. Upon activation, that list needs to be reconciled with those that Colab maintains as it's possible they were pruned (either due to inactivity, exceeding life-cycle or manually in Colab-web).