### PR TITLE
feat: contribute the authentication provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,14 @@
     "onNotebook:jupyter-notebook",
     "onNotebook:interactive"
   ],
+  "contributes": {
+    "authentication": [
+      {
+        "label": "Google",
+        "id": "google"
+      }
+    ]
+  },
   "main": "./out/extension.js",
   "scripts": {
     "clean": "rm -rf out/*",


### PR DESCRIPTION
The `GoogleAuthProvider` is registered but not marked as contributed.
Adding this sets up an activation event for the provider and displays it
in the extensions features.

https://code.visualstudio.com/api/references/contribution-points#contributes.authentication

I noticed we were missing this when running the integration tests
locally (warning log).