### PR TITLE
fix: properly await async assertions

### DIFF
--- a/src/auth/redirect.unit.test.ts
+++ b/src/auth/redirect.unit.test.ts
@@ -27,14 +27,14 @@ describe("RedirectUriCodeProvider", () => {
     sinon.restore();
   });
 
-  it("throws when waiting for the same nonce", () => {
+  it("throws when waiting for the same nonce", async () => {
     const nonce = "1";
 
     void provider.waitForCode(nonce, cancellationTokenSource.token);
 
-    expect(
+    await expect(
       provider.waitForCode(nonce, cancellationTokenSource.token),
-    ).to.eventually.throw(/waiting/);
+    ).to.be.rejectedWith(/waiting/);
   });
   it("throws when the URI does not include a code", async () => {
     const nonce = "1";

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -218,12 +218,14 @@ describe("ColabClient", () => {
     sinon.assert.calledOnce(fetchStub);
   });
 
-  it("rejects invalid JSON responses", () => {
+  it("rejects invalid JSON responses", async () => {
     fetchStub
       .withArgs(matchAuthorizedRequest("tun/m/ccu-info", "GET"))
       .resolves(new Response(withXSSI("not JSON eh?"), { status: 200 }));
 
-    expect(client.ccuInfo()).to.eventually.be.rejectedWith(/not valid.+eh\?/);
+    await expect(client.ccuInfo()).to.eventually.be.rejectedWith(
+      /not JSON.+eh\?/,
+    );
   });
 
   it("rejects response schema mismatches", async () => {

--- a/src/colab/server-picker.unit.test.ts
+++ b/src/colab/server-picker.unit.test.ts
@@ -44,8 +44,8 @@ describe("ServerPicker", () => {
       return stub;
     }
 
-    it("returns undefined when there are no available servers", () => {
-      expect(serverPicker.prompt([])).to.eventually.equal(undefined);
+    it("returns undefined when there are no available servers", async () => {
+      await expect(serverPicker.prompt([])).to.eventually.equal(undefined);
     });
 
     it("returns undefined when selecting a variant is cancelled", async () => {
@@ -56,7 +56,7 @@ describe("ServerPicker", () => {
       await variantPickerShown;
       variantQuickPickStub.onDidHide.yield();
 
-      expect(prompt).to.eventually.equal(undefined);
+      await expect(prompt).to.eventually.equal(undefined);
     });
 
     it("returns undefined when selecting an accelerator is cancelled", async () => {
@@ -195,7 +195,7 @@ describe("ServerPicker", () => {
       const aliasInputBoxStub = stubInputBoxForCall(0);
       const variantPickerShown = variantQuickPickStub.nextShow();
 
-      const pick = serverPicker.prompt(ALL_SERVERS);
+      void serverPicker.prompt(ALL_SERVERS);
 
       await variantPickerShown;
       const aliasInputShown = aliasInputBoxStub.nextShow();
@@ -209,10 +209,6 @@ describe("ServerPicker", () => {
         vsCodeStub.QuickInputButtons.Back,
       );
       await secondVariantPickerShown;
-      secondVariantQuickPickStub.onDidTriggerButton.yield(
-        vsCodeStub.QuickInputButtons.Back,
-      );
-      expect(pick).to.eventually.equal(undefined);
     });
 
     it("sets the previously specified value when navigating back", async () => {
@@ -221,7 +217,7 @@ describe("ServerPicker", () => {
       const aliasInputBoxStub = stubInputBoxForCall(0);
       const variantPickerShown = variantQuickPickStub.nextShow();
 
-      const pick = serverPicker.prompt(ALL_SERVERS);
+      void serverPicker.prompt(ALL_SERVERS);
 
       await variantPickerShown;
       const acceleratorPickerShown = acceleratorQuickPickStub.nextShow();
@@ -254,10 +250,6 @@ describe("ServerPicker", () => {
       expect(secondVariantQuickPickStub.activeItems).to.be.deep.equal([
         { value: Variant.GPU, label: "GPU" },
       ]);
-      secondVariantQuickPickStub.onDidTriggerButton.yield(
-        vsCodeStub.QuickInputButtons.Back,
-      );
-      expect(pick).to.eventually.equal(undefined);
     });
 
     it("sets the right step", async () => {

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -157,15 +157,16 @@ describe("ColabJupyterServerProvider", () => {
       ).to.throw(/expected UUID/);
     });
 
-    it("rejects if the server is not found", () => {
+    it("rejects if the server is not found", async () => {
+      assignmentStub.getAssignedServers.resolves([defaultServer]);
       const server: JupyterServer = { id: randomUUID(), label: "foo" };
 
-      expect(
+      await expect(
         serverProvider.resolveJupyterServer(server, cancellationToken),
       ).to.eventually.be.rejectedWith(/not found/);
     });
 
-    it("returns the assigned server with refreshed connection info", () => {
+    it("returns the assigned server with refreshed connection info", async () => {
       const refreshedServer: ColabAssignedServer = {
         ...defaultServer,
         connectionInformation: {
@@ -178,7 +179,7 @@ describe("ColabJupyterServerProvider", () => {
         .withArgs(defaultServer)
         .resolves(refreshedServer);
 
-      expect(
+      await expect(
         serverProvider.resolveJupyterServer(defaultServer, cancellationToken),
       ).to.eventually.deep.equal(refreshedServer);
     });

--- a/src/jupyter/storage.unit.test.ts
+++ b/src/jupyter/storage.unit.test.ts
@@ -70,12 +70,14 @@ describe("ServerStorage", () => {
 
       // TODO: Update tests now that we're accepting an array.
 
-      it("stores the server", () => {
+      it("stores the server", async () => {
         sinon.assert.calledOnceWithMatch(
           secretsStub.store,
           ASSIGNED_SERVERS_KEY,
         );
-        expect(serverStorage.list()).to.eventually.deep.equal([defaultServer]);
+        await expect(serverStorage.list()).to.eventually.deep.equal([
+          defaultServer,
+        ]);
       });
 
       it("clears the cache", async () => {
@@ -149,9 +151,10 @@ describe("ServerStorage", () => {
 
     describe("store", () => {
       it("stores a new server", async () => {
-        const newServer = {
+        const newServer: ColabAssignedServer = {
           ...defaultServer,
           id: randomUUID(),
+          label: "bar",
         };
 
         await expect(serverStorage.store([newServer])).to.eventually.be
@@ -161,9 +164,10 @@ describe("ServerStorage", () => {
           secretsStub.store,
           ASSIGNED_SERVERS_KEY,
         );
-        expect(serverStorage.list()).to.eventually.deep.equal([
-          defaultServer,
-          newServer,
+        const serverLabels = (await serverStorage.list()).map((s) => s.label);
+        expect(serverLabels).to.have.same.deep.members([
+          defaultServer.label,
+          newServer.label,
         ]);
       });
 
@@ -180,7 +184,9 @@ describe("ServerStorage", () => {
           secretsStub.store,
           ASSIGNED_SERVERS_KEY,
         );
-        expect(serverStorage.list()).to.eventually.deep.equal([updatedServer]);
+        await expect(serverStorage.list()).to.eventually.deep.equal([
+          updatedServer,
+        ]);
       });
 
       describe("when storing is a no-op", () => {
@@ -189,7 +195,7 @@ describe("ServerStorage", () => {
             .fulfilled;
 
           sinon.assert.notCalled(secretsStub.store);
-          expect(serverStorage.list()).to.eventually.deep.equal([
+          await expect(serverStorage.list()).to.eventually.deep.equal([
             defaultServer,
           ]);
         });
@@ -235,9 +241,9 @@ describe("ServerStorage", () => {
           secretsStub.get.resetHistory();
         });
 
-        it("deletes it", () => {
+        it("deletes it", async () => {
           sinon.assert.calledOnce(secretsStub.store);
-          expect(serverStorage.list()).to.eventually.deep.equal([]);
+          await expect(serverStorage.list()).to.eventually.deep.equal([]);
         });
 
         it("clears the cache", async () => {
@@ -342,10 +348,9 @@ describe("ServerStorage", () => {
           secretsStub.store,
           ASSIGNED_SERVERS_KEY,
         );
-        expect(serverStorage.list()).to.eventually.have.same.deep.members([
-          ...servers,
-          newServer,
-        ]);
+        await expect(serverStorage.list()).to.eventually.have.same.deep.members(
+          [...servers, newServer],
+        );
       });
 
       it("stores an updated server", async () => {
@@ -361,10 +366,9 @@ describe("ServerStorage", () => {
           secretsStub.store,
           ASSIGNED_SERVERS_KEY,
         );
-        expect(serverStorage.list()).to.eventually.have.same.deep.members([
-          updatedServer,
-          servers[1],
-        ]);
+        await expect(serverStorage.list()).to.eventually.have.same.deep.members(
+          [updatedServer, servers[1]],
+        );
       });
 
       describe("when storing is a no-op", () => {
@@ -373,9 +377,9 @@ describe("ServerStorage", () => {
             .fulfilled;
 
           sinon.assert.notCalled(secretsStub.store);
-          expect(serverStorage.list()).to.eventually.have.same.deep.members(
-            servers,
-          );
+          await expect(
+            serverStorage.list(),
+          ).to.eventually.have.same.deep.members(servers);
         });
 
         it("does not clear cache", async () => {
@@ -419,9 +423,11 @@ describe("ServerStorage", () => {
           secretsStub.get.resetHistory();
         });
 
-        it("deletes it", () => {
+        it("deletes it", async () => {
           sinon.assert.calledOnce(secretsStub.store);
-          expect(serverStorage.list()).to.eventually.deep.equal([servers[1]]);
+          await expect(serverStorage.list()).to.eventually.deep.equal([
+            servers[1],
+          ]);
         });
 
         it("clears the cache", async () => {


### PR DESCRIPTION
With [chai-as-promised](https://www.npmjs.com/package/chai-as-promised)
I missed that we must `await` _eventually_ assertions
([docs](https://github.com/chaijs/chai-as-promised?tab=readme-ov-file#working-with-asyncawait-and-promise-friendly-test-runners)).

Adding these `await`-s brought to light a few test-bugs.