### PR TITLE
fix: correct assignment reconciliation logic

### DIFF
--- a/src/colab/api.ts
+++ b/src/colab/api.ts
@@ -164,9 +164,9 @@ export const AssignmentSchema = z.object({
   /** Whether the backend is trusted. */
   allowedCredentials: z.boolean().optional(),
   /** The subscription state. */
-  sub: z.nativeEnum(SubscriptionState),
+  sub: z.nativeEnum(SubscriptionState).optional(),
   /** The subscription tier. */
-  subTier: z.nativeEnum(SubscriptionTier),
+  subTier: z.nativeEnum(SubscriptionTier).optional(),
   /** The outcome of the assignment. */
   outcome: z.nativeEnum(Outcome).optional(),
   /** The variant of the assignment. */
@@ -178,4 +178,6 @@ export const AssignmentSchema = z.object({
 });
 export type Assignment = z.infer<typeof AssignmentSchema>;
 
-export const AssignmentsSchema = z.array(AssignmentSchema);
+export const AssignmentsSchema = z.object({
+  assignments: z.array(AssignmentSchema),
+});

--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -105,11 +105,12 @@ export class ColabClient {
    * @returns The list of assignments.
    */
   async listAssignments(): Promise<Assignment[]> {
-    return this.issueRequest(
+    const assignments = await this.issueRequest(
       new URL(ASSIGNMENTS_ENDPOINT, this.domain),
       "GET",
       AssignmentsSchema,
     );
+    return assignments.assignments;
   }
 
   private async getAssignment(

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -166,9 +166,12 @@ describe("ColabClient", () => {
       fetchStub
         .withArgs(matchAuthorizedRequest("tun/m/assignments", "GET"))
         .resolves(
-          new Response(withXSSI(JSON.stringify([DEFAULT_ASSIGNMENT])), {
-            status: 200,
-          }),
+          new Response(
+            withXSSI(JSON.stringify({ assignments: [DEFAULT_ASSIGNMENT] })),
+            {
+              status: 200,
+            },
+          ),
         );
 
       await expect(client.listAssignments()).to.eventually.deep.equal([

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -30,7 +30,7 @@ const defaultAssignmentDescriptor: ColabServerDescriptor = {
 
 const defaultAssignment: Assignment & { runtimeProxyInfo: RuntimeProxyInfo } = {
   accelerator: Accelerator.A100,
-  endpoint: "mock-endpoint",
+  endpoint: "m-s-foo",
   sub: SubscriptionState.UNSUBSCRIBED,
   subTier: SubscriptionTier.UNKNOWN_TIER,
   variant: Variant.GPU,
@@ -56,6 +56,7 @@ describe("AssignmentManager", () => {
     defaultServer = {
       ...defaultAssignmentDescriptor,
       id: randomUUID(),
+      endpoint: defaultAssignment.endpoint,
       connectionInformation: {
         baseUrl: vsCodeStub.Uri.parse(defaultAssignment.runtimeProxyInfo.url),
         token: defaultAssignment.runtimeProxyInfo.token,
@@ -185,6 +186,7 @@ describe("AssignmentManager", () => {
           {
             ...defaultServer,
             id: randomUUID(),
+            endpoint: "m-s-bar",
             connectionInformation: {
               ...defaultServer.connectionInformation,
               baseUrl: vsCodeStub.Uri.parse("https://example2.com"),
@@ -195,6 +197,7 @@ describe("AssignmentManager", () => {
           defaultAssignment,
           {
             ...defaultAssignment,
+            endpoint: "m-s-bar",
             runtimeProxyInfo: {
               ...defaultAssignment.runtimeProxyInfo,
               url: servers[1].connectionInformation.baseUrl.toString(),
@@ -229,6 +232,7 @@ describe("AssignmentManager", () => {
         const thirdServer: ColabAssignedServer = {
           ...defaultServer,
           id: randomUUID(),
+          endpoint: "m-s-baz",
           connectionInformation: {
             ...defaultServer.connectionInformation,
             baseUrl: vsCodeStub.Uri.parse("https://example3.com"),
@@ -250,6 +254,7 @@ describe("AssignmentManager", () => {
         storageStub.list.resolves(servers);
         const colabAssignment: Assignment = {
           ...defaultAssignment,
+          endpoint: "m-s-baz",
           runtimeProxyInfo: {
             ...defaultAssignment.runtimeProxyInfo,
             url: "https://not-from-vs-code.com",

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -75,6 +75,7 @@ describe("ColabJupyterServerProvider", () => {
       label: "Colab GPU A100",
       variant: Variant.GPU,
       accelerator: Accelerator.A100,
+      endpoint: "m-s-foo",
       connectionInformation: {
         baseUrl: vsCodeStub.Uri.parse("https://example.com"),
         token: "123",

--- a/src/jupyter/servers.ts
+++ b/src/jupyter/servers.ts
@@ -30,6 +30,7 @@ export interface ColabJupyterServer
  * connection information.
  */
 export type ColabAssignedServer = ColabJupyterServer & {
+  readonly endpoint: string;
   readonly connectionInformation: JupyterServerConnectionInformation & {
     readonly token: string;
   };

--- a/src/jupyter/storage.ts
+++ b/src/jupyter/storage.ts
@@ -13,6 +13,7 @@ const AssignedServers = z.array(
     label: z.string().nonempty(),
     variant: z.nativeEnum(Variant),
     accelerator: z.nativeEnum(Accelerator).optional(),
+    endpoint: z.string().nonempty(),
     connectionInformation: z.object({
       baseUrl: z.string().nonempty(),
       token: z.string().nonempty(),
@@ -53,6 +54,7 @@ export class ServerStorage {
       label: server.label,
       variant: server.variant,
       accelerator: server.accelerator,
+      endpoint: server.endpoint,
       connectionInformation: {
         baseUrl: this.vs.Uri.parse(server.connectionInformation.baseUrl),
         token: server.connectionInformation.token,
@@ -80,6 +82,7 @@ export class ServerStorage {
         label: server.label,
         variant: server.variant,
         accelerator: server.accelerator,
+        endpoint: server.endpoint,
         connectionInformation: {
           baseUrl: server.connectionInformation.baseUrl.toString(),
           token: server.connectionInformation.token,

--- a/src/jupyter/storage.unit.test.ts
+++ b/src/jupyter/storage.unit.test.ts
@@ -27,6 +27,7 @@ describe("ServerStorage", () => {
       label: "foo",
       variant: Variant.DEFAULT,
       accelerator: undefined,
+      endpoint: "m-s-foo",
       connectionInformation: {
         baseUrl: vsCodeStub.Uri.parse("https://example.com"),
         token: "123",


### PR DESCRIPTION
I guess I didn't try reloading the extension upon assigning for the
first time. I misinterepretted our convoluted API which is super
inconsistent. This change fixes that mistake. Manually tested locally to
verify. These mistakes will be avoided once we have automated e2e
testing.