### PR TITLE
fix: amend varsIgnorePattern for the no-unused-vars lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,7 +46,7 @@ export default tseslint.config(
       ],
       "@typescript-eslint/no-unused-vars": [
         "error",
-        { varsIgnorePattern: "^_$", argsIgnorePattern: "^_" },
+        { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
       ],
       "@typescript-eslint/explicit-member-accessibility": [
         "error",


### PR DESCRIPTION
Regex was incorrect since there are characters following the `_`.