### PR TITLE
feat: auto-increment the server placeholder

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const serverProvider = new ColabJupyterServerProvider(
     vscode,
     assignmentManager,
-    new ServerPicker(vscode),
+    new ServerPicker(vscode, assignmentManager),
     jupyter,
   );
 


### PR DESCRIPTION
Follows standard file explorer semantics for duplicating files.

- If no server exists, placeholder is `Colab CPU`.
- If `Colab CPU` exists, placeholder is `Colab CPU (1)`.
- If `Colab CPU` and `Colab CPU (1)` exist, placeholder is `Colab CPU (2)`.
- If `Colab CPU` and `Colab CPU (2)` exist (because `1` was removed),
  placeholder is `Colab CPU (1)`.

The above should be easily understood looking at the tests.

Determining the number to use requires the `AssignmentManager`, so the functions
were moved to members of the `ServerPicker` class.

I also re-organized the file a bit so exported members are at the top.