### PR TITLE
chore: cleanup Colab API schemas

### DIFF
--- a/src/colab/api.ts
+++ b/src/colab/api.ts
@@ -1,8 +1,20 @@
 /**
  * API types for interacting with Colab's backend.
  *
- * As mentioned throughout several of the relevant fields, a lot of the name
- * choices are due to historical reasons and are not ideal.
+ * This file not only defines the entire Colab API surface area, but also tries
+ * to compartmentalize a lot of the funky intricacies:
+ *
+ * - Several name choices are due to historical reasons and are not ideal.
+ * - Inconsistent naming conventions.
+ * - Different representations for the same thing.
+ * - Overlapping API functionality.
+ * - Non-standard REST APIs.
+ *
+ * This complexity is largely due to the fact that Colab is an older product
+ * that's gone through a ton of change! The APIs were enriched greatly over
+ * time, with only a single frontend (Colab web) in mind. The team is now
+ * working on cleaning up these APIs and it's expected that over time this file
+ * will get smaller and more sensible.
  */
 
 import { z } from "zod";
@@ -58,6 +70,12 @@ export enum Accelerator {
   V6E1 = "V6E1",
 }
 
+/**
+ * Preprocess a native enum to get the enum value from a lower case string.
+ *
+ * @param enumObj - the native enum object schema to preprocess to.
+ * @returns the zod effect to get the native enum from a lower case string.
+ */
 function uppercaseEnum<T extends z.EnumLike>(
   enumObj: T,
 ): z.ZodEffects<z.ZodNativeEnum<T>, T[keyof T], unknown> {
@@ -69,22 +87,7 @@ function uppercaseEnum<T extends z.EnumLike>(
   }, z.nativeEnum(enumObj));
 }
 
-export const FreeCcuQuotaInfoSchema = z.object({
-  /**
-   * Number of tokens remaining in the "USAGE-mCCUs" quota group (remaining
-   * free usage allowance in milli-CCUs).
-   */
-  remainingTokens: z.number(),
-  /**
-   * Next free quota refill timestamp (epoch) in seconds.
-   */
-  nextRefillTimestampSec: z.number(),
-});
-export type FreeCcuQuotaInfo = z.infer<typeof FreeCcuQuotaInfoSchema>;
-
-/**
- * Cloud compute unit (CCU) information.
- */
+/** The schema of Colab Compute Units (CCU) information. */
 export const CcuInfoSchema = z.object({
   /**
    * The current balance of the paid CCUs.
@@ -103,13 +106,9 @@ export const CcuInfoSchema = z.object({
    * is positive.
    */
   assignmentsCount: z.number(),
-  /**
-   * The list of eligible GPU accelerators.
-   */
+  /** The list of eligible GPU accelerators. */
   eligibleGpus: z.array(uppercaseEnum(Accelerator)),
-  /**
-   * The list of ineligible GPU accelerators.
-   */
+  /** The list of ineligible GPU accelerators. */
   ineligibleGpus: z.array(uppercaseEnum(Accelerator)).optional(),
   /**
    * The list of eligible TPU accelerators.
@@ -119,78 +118,121 @@ export const CcuInfoSchema = z.object({
    * The list of ineligible TPU accelerators.
    */
   ineligibleTpus: z.array(uppercaseEnum(Accelerator)).optional(),
-  /**
-   * Free CCU quota information if applicable.
-   */
-  freeCcuQuotaInfo: FreeCcuQuotaInfoSchema.optional(),
+  /** Free CCU quota information if applicable. */
+  freeCcuQuotaInfo: z
+    .object({
+      /**
+       * Number of tokens remaining in the "USAGE-mCCUs" quota group (remaining
+       * free usage allowance in milli-CCUs).
+       */
+      remainingTokens: z.number(),
+      /** Next free quota refill timestamp (epoch) in seconds. */
+      nextRefillTimestampSec: z.number(),
+    })
+    .optional(),
 });
+/** Colab Compute Units (CCU) information. */
 export type CcuInfo = z.infer<typeof CcuInfoSchema>;
 
-export const GetAssignmentResponseSchema = z.object({
-  /** The pool's {@link Accelerator}. */
-  acc: uppercaseEnum(Accelerator),
-  /** The notebook ID hash. */
-  nbh: z.string(),
-  /** Whether or not Recaptcha should prompt. */
-  p: z.boolean(),
-  /** XSRF token for assignment posting. */
-  token: z.string(),
-  /** The variant of the assignment. */
-  // On GET, this is a string so we must preprocess it to the enum.
-  variant: z.preprocess((val) => {
-    if (typeof val === "string") {
-      switch (val) {
-        case "DEFAULT":
-          return Variant.DEFAULT;
-        case "GPU":
-          return Variant.GPU;
-        case "TPU":
-          return Variant.TPU;
+/** The response when getting an assignment. */
+export const GetAssignmentResponseSchema = z
+  .object({
+    /** The pool's accelerator. */
+    acc: uppercaseEnum(Accelerator),
+    /** The notebook ID hash. */
+    nbh: z.string(),
+    /** Whether or not Recaptcha should prompt. */
+    p: z.boolean(),
+    /** XSRF token for assignment posting. */
+    token: z.string(),
+    /** The variant of the assignment. */
+    // On GET, this is a string so we must preprocess it to the enum.
+    variant: z.preprocess((val) => {
+      if (typeof val === "string") {
+        switch (val) {
+          case "DEFAULT":
+            return Variant.DEFAULT;
+          case "GPU":
+            return Variant.GPU;
+          case "TPU":
+            return Variant.TPU;
+        }
       }
-    }
-    return val;
-  }, z.nativeEnum(Variant)),
-});
+      return val;
+    }, z.nativeEnum(Variant)),
+  })
+  .transform(({ acc, nbh, p, token, ...rest }) => ({
+    ...rest,
+    /** The pool's accelerator. */
+    accelerator: acc,
+    /** The notebook ID hash. */
+    notebookIdHash: nbh,
+    /** Whether or not Recaptcha should prompt. */
+    shouldPromptRecaptcha: p,
+    /** XSRF token for assignment posting. */
+    xsrfToken: token,
+  }));
+/** The response when getting an assignment. */
 export type GetAssignmentResponse = z.infer<typeof GetAssignmentResponseSchema>;
 
-export const RuntimeProxyInfoSchema = z.object({
-  /** Token for the runtime proxy. */
-  token: z.string(),
-  /** Token expiration time in seconds. */
-  tokenExpiresInSeconds: z.number(),
-  /** URL of the runtime proxy. */
-  url: z.string(),
-});
+export const RuntimeProxyInfoSchema = z
+  .object({
+    /** Token for the runtime proxy. */
+    token: z.string(),
+    /** Token expiration time in seconds. */
+    tokenExpiresInSeconds: z.number(),
+    /** URL of the runtime proxy. */
+    url: z.string(),
+  })
+  .transform(({ tokenExpiresInSeconds, ...rest }) => ({
+    ...rest,
+    /** Token expiration time in seconds. */
+    expirySec: tokenExpiresInSeconds,
+  }));
 export type RuntimeProxyInfo = z.infer<typeof RuntimeProxyInfoSchema>;
 
-export const AssignmentSchema = z.object({
-  /** The assigned accelerator. */
-  accelerator: uppercaseEnum(Accelerator),
-  /** The endpoint URL. */
-  endpoint: z.string(),
-  /** Frontend idle timeout in seconds. */
-  fit: z.number().optional(),
-  /** Whether the backend is trusted. */
-  allowedCredentials: z.boolean().optional(),
-  /** The subscription state. */
-  sub: z.nativeEnum(SubscriptionState).optional(),
-  /** The subscription tier. */
-  subTier: z.nativeEnum(SubscriptionTier).optional(),
-  /** The outcome of the assignment. */
-  outcome: z.nativeEnum(Outcome).optional(),
-  /** The variant of the assignment. */
-  variant: z.nativeEnum(Variant),
-  /** The machine shape. */
-  machineShape: z.nativeEnum(Shape),
-  /** Information about the runtime proxy. */
-  runtimeProxyInfo: RuntimeProxyInfoSchema.optional(),
-});
+/** A machine assignment in Colab. */
+export const AssignmentSchema = z
+  .object({
+    /** The assigned accelerator. */
+    accelerator: uppercaseEnum(Accelerator),
+    /** The endpoint URL. */
+    endpoint: z.string(),
+    /** Frontend idle timeout in seconds. */
+    fit: z.number().optional(),
+    /** Whether the backend is trusted. */
+    allowedCredentials: z.boolean().optional(),
+    /** The subscription state. */
+    sub: z.nativeEnum(SubscriptionState).optional(),
+    /** The subscription tier. */
+    subTier: z.nativeEnum(SubscriptionTier).optional(),
+    /** The outcome of the assignment. */
+    outcome: z.nativeEnum(Outcome).optional(),
+    /** The variant of the assignment. */
+    variant: z.nativeEnum(Variant),
+    /** The machine shape. */
+    machineShape: z.nativeEnum(Shape),
+    /** Information about the runtime proxy. */
+    runtimeProxyInfo: RuntimeProxyInfoSchema.optional(),
+  })
+  .transform(({ fit, sub, subTier, ...rest }) => ({
+    ...rest,
+    /** The idle timeout in seconds. */
+    idleTimeoutSec: fit,
+    /** The subscription state. */
+    subscriptionState: sub,
+    /** The subscription tier. */
+    subscriptionTier: subTier,
+  }));
+/** A machine assignment in Colab. */
 export type Assignment = z.infer<typeof AssignmentSchema>;
 
+/** The schema of the Colab API's list assignments endpoint. */
 export const AssignmentsSchema = z.object({
   assignments: z.array(AssignmentSchema),
 });
 
+/** A Colab Jupyter kernel returned from the Colab API. */
 // This can be obtained by querying the Jupyter REST API's /api/spec.yaml
 // endpoint.
 export const KernelSchema = z
@@ -206,14 +248,12 @@ export const KernelSchema = z
     /** The number of active connections to the kernel. */
     connections: z.number(),
   })
-  .transform((k) => {
-    const { last_activity, execution_state, ...rest } = k;
-    return {
-      ...rest,
-      /** The ISO 8601 timestamp for the last-seen activity on the kernel. */
-      lastActivity: last_activity,
-      /** The current execution state of the kernel. */
-      executionState: execution_state,
-    };
-  });
+  .transform(({ last_activity, execution_state, ...rest }) => ({
+    ...rest,
+    /** The ISO 8601 timestamp for the last-seen activity on the kernel. */
+    lastActivity: last_activity,
+    /** The current execution state of the kernel. */
+    executionState: execution_state,
+  }));
+/** A Colab Jupyter kernel. */
 export type Kernel = z.infer<typeof KernelSchema>;

--- a/src/colab/ccu-info.ts
+++ b/src/colab/ccu-info.ts
@@ -45,7 +45,7 @@ export class CcuInformationManager implements Disposable {
    * Updates with new CCU info and emits an event when there is a change.
    */
   private async updateCcuInfo(signal: AbortSignal): Promise<void> {
-    const ccuInfo = await this.client.ccuInfo(signal);
+    const ccuInfo = await this.client.getCcuInfo(signal);
     if (JSON.stringify(ccuInfo) === JSON.stringify(this.ccuInfo)) {
       return;
     }
@@ -62,7 +62,7 @@ export class CcuInformationManager implements Disposable {
     vs: typeof vscode,
     client: ColabClient,
   ): Promise<CcuInformationManager> {
-    const info = await client.ccuInfo();
+    const info = await client.getCcuInfo();
     return new CcuInformationManager(vs, client, info);
   }
 }

--- a/src/colab/ccu-info.unit.test.ts
+++ b/src/colab/ccu-info.unit.test.ts
@@ -48,7 +48,7 @@ describe("CcuInformation", () => {
     let ccuInfo: CcuInformationManager;
 
     beforeEach(async () => {
-      clientStub.ccuInfo.resolves(DEFAULT_CCU_INFO);
+      clientStub.getCcuInfo.resolves(DEFAULT_CCU_INFO);
       ccuInfo = await CcuInformationManager.initialize(
         vsCodeStub.asVsCode(),
         clientStub,
@@ -60,24 +60,24 @@ describe("CcuInformation", () => {
     });
 
     it("fetches CCU info on initialization", async () => {
-      sinon.assert.calledOnce(clientStub.ccuInfo);
-      await expect(clientStub.ccuInfo()).to.eventually.deep.equal(
+      sinon.assert.calledOnce(clientStub.getCcuInfo);
+      await expect(clientStub.getCcuInfo()).to.eventually.deep.equal(
         DEFAULT_CCU_INFO,
       );
     });
 
     it("disposes the runner", async () => {
-      clientStub.ccuInfo.resetHistory();
+      clientStub.getCcuInfo.resetHistory();
 
       ccuInfo.dispose();
 
       await fakeClock.tickAsync(POLL_INTERVAL_MS);
-      sinon.assert.notCalled(clientStub.ccuInfo);
+      sinon.assert.notCalled(clientStub.getCcuInfo);
     });
 
     it("aborts slow calls to get CCU info", async () => {
-      clientStub.ccuInfo.resetHistory();
-      clientStub.ccuInfo.onFirstCall().callsFake(
+      clientStub.getCcuInfo.resetHistory();
+      clientStub.getCcuInfo.onFirstCall().callsFake(
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         async () => new Promise(() => {}),
       );
@@ -85,8 +85,8 @@ describe("CcuInformation", () => {
       await fakeClock.tickAsync(POLL_INTERVAL_MS);
       await fakeClock.tickAsync(TASK_TIMEOUT_MS + 1);
 
-      sinon.assert.calledOnce(clientStub.ccuInfo);
-      expect(clientStub.ccuInfo.firstCall.args[0]?.aborted).to.be.true;
+      sinon.assert.calledOnce(clientStub.getCcuInfo);
+      expect(clientStub.getCcuInfo.firstCall.args[0]?.aborted).to.be.true;
     });
   });
 
@@ -95,20 +95,20 @@ describe("CcuInformation", () => {
     let onDidChangeCcuInfo: sinon.SinonStub<[]>;
 
     beforeEach(async () => {
-      clientStub.ccuInfo.resolves(DEFAULT_CCU_INFO);
+      clientStub.getCcuInfo.resolves(DEFAULT_CCU_INFO);
       ccuInfo = await CcuInformationManager.initialize(
         vsCodeStub.asVsCode(),
         clientStub,
       );
       onDidChangeCcuInfo = sinon.stub();
       ccuInfo.onDidChangeCcuInfo(onDidChangeCcuInfo);
-      clientStub.ccuInfo.resetHistory();
+      clientStub.getCcuInfo.resetHistory();
     });
 
     it("does not emit an event", async () => {
       await fakeClock.tickAsync(POLL_INTERVAL_MS);
 
-      sinon.assert.calledOnce(clientStub.ccuInfo);
+      sinon.assert.calledOnce(clientStub.getCcuInfo);
       sinon.assert.notCalled(onDidChangeCcuInfo);
     });
 
@@ -131,22 +131,22 @@ describe("CcuInformation", () => {
     let onDidChangeCcuInfo: sinon.SinonStub<[]>;
 
     beforeEach(async () => {
-      clientStub.ccuInfo.onFirstCall().resolves(DEFAULT_CCU_INFO);
+      clientStub.getCcuInfo.onFirstCall().resolves(DEFAULT_CCU_INFO);
       ccuInfo = await CcuInformationManager.initialize(
         vsCodeStub.asVsCode(),
         clientStub,
       );
       onDidChangeCcuInfo = sinon.stub();
       ccuInfo.onDidChangeCcuInfo(onDidChangeCcuInfo);
-      clientStub.ccuInfo.resetHistory();
-      clientStub.ccuInfo.onFirstCall().resolves(newCcuInfo);
+      clientStub.getCcuInfo.resetHistory();
+      clientStub.getCcuInfo.onFirstCall().resolves(newCcuInfo);
     });
 
     it("emits an event", async () => {
       await fakeClock.tickAsync(POLL_INTERVAL_MS);
 
       sinon.assert.calledOnce(onDidChangeCcuInfo);
-      sinon.assert.calledOnce(clientStub.ccuInfo);
+      sinon.assert.calledOnce(clientStub.getCcuInfo);
     });
 
     it("gets the CCU info", async () => {

--- a/src/colab/keep-alive.ts
+++ b/src/colab/keep-alive.ts
@@ -89,7 +89,7 @@ export class ServerKeepAliveController implements Disposable {
       signal,
     );
     if (await this.shouldKeepAlive(assignment, kernels)) {
-      await this.colabClient.keepAlive(assignment.endpoint, signal);
+      await this.colabClient.sendKeepAlive(assignment.endpoint, signal);
     }
   }
 

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -59,7 +59,7 @@ export class AssignmentManager implements vscode.Disposable {
    * @returns A list of available server descriptors.
    */
   async getAvailableServerDescriptors(): Promise<ColabServerDescriptor[]> {
-    const ccuInfo = await this.client.ccuInfo();
+    const ccuInfo = await this.client.getCcuInfo();
     const eligibleGpus = new Set(ccuInfo.eligibleGpus);
     const ineligibleGpus = new Set(ccuInfo.ineligibleGpus);
     const eligibleTpus = new Set(ccuInfo.eligibleTpus);

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -31,13 +31,14 @@ const defaultAssignmentDescriptor: ColabServerDescriptor = {
 const defaultAssignment: Assignment & { runtimeProxyInfo: RuntimeProxyInfo } = {
   accelerator: Accelerator.A100,
   endpoint: "m-s-foo",
-  sub: SubscriptionState.UNSUBSCRIBED,
-  subTier: SubscriptionTier.UNKNOWN_TIER,
+  idleTimeoutSec: 30,
+  subscriptionState: SubscriptionState.UNSUBSCRIBED,
+  subscriptionTier: SubscriptionTier.UNKNOWN_TIER,
   variant: Variant.GPU,
   machineShape: Shape.STANDARD,
   runtimeProxyInfo: {
     token: "mock-token",
-    tokenExpiresInSeconds: 42,
+    expirySec: 42,
     url: "https://example.com",
   },
 };
@@ -80,7 +81,7 @@ describe("AssignmentManager", () => {
 
   describe("getAvailableServerDescriptors", () => {
     it("returns all colab servers when all are eligible", async () => {
-      colabClientStub.ccuInfo.resolves({
+      colabClientStub.getCcuInfo.resolves({
         currentBalance: 1,
         consumptionRateHourly: 2,
         assignmentsCount: 0,
@@ -97,11 +98,11 @@ describe("AssignmentManager", () => {
       const servers = await assignmentManager.getAvailableServerDescriptors();
 
       expect(servers).to.deep.equal(Array.from(COLAB_SERVERS));
-      sinon.assert.calledOnce(colabClientStub.ccuInfo);
+      sinon.assert.calledOnce(colabClientStub.getCcuInfo);
     });
 
     it("filters to only eligible servers", async () => {
-      colabClientStub.ccuInfo.resolves({
+      colabClientStub.getCcuInfo.resolves({
         currentBalance: 1,
         consumptionRateHourly: 2,
         assignmentsCount: 0,
@@ -123,11 +124,11 @@ describe("AssignmentManager", () => {
           server.accelerator !== Accelerator.V5E1,
       );
       expect(servers).to.deep.equal(expectedServers);
-      sinon.assert.calledOnce(colabClientStub.ccuInfo);
+      sinon.assert.calledOnce(colabClientStub.getCcuInfo);
     });
 
     it("filters out ineligible servers", async () => {
-      colabClientStub.ccuInfo.resolves({
+      colabClientStub.getCcuInfo.resolves({
         currentBalance: 1,
         consumptionRateHourly: 2,
         assignmentsCount: 0,
@@ -149,7 +150,7 @@ describe("AssignmentManager", () => {
           server.accelerator !== Accelerator.V5E1,
       );
       expect(servers).to.deep.equal(expectedServers);
-      sinon.assert.calledOnce(colabClientStub.ccuInfo);
+      sinon.assert.calledOnce(colabClientStub.getCcuInfo);
     });
   });
 


### PR DESCRIPTION
- Rename some `ColabClient` methods to conform to standard TS naming conventions.
- Transform some field names for a more consistent API surface.
- Inline the definition of `FreeCcuQuotaInfo` since it's just used once and
  never referenced directly.
- Document some non-exported functions for clarity.
- Amend some top-level comments for correctness and clarity.
- Optional TS-doc comment formatting.