### PR TITLE
feat: add a user-info accessor to the Colab Google API

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -1,5 +1,6 @@
 authuser
 colab
+gapi
 Googlers
 highmem
 milli

--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -11,7 +11,13 @@ import { PackageInfo } from "../config/package-info";
 import { CodeProvider } from "./redirect";
 import { AuthStorage, RefreshableAuthenticationSession } from "./storage";
 
-export const REQUIRED_SCOPES = ["profile", "email"] as const;
+export const REQUIRED_SCOPES = [
+  "profile",
+  "email",
+  // This scope is temporary. It's temporarily needed to integrate with the
+  // Colab GAPI used to query for user-info.
+  "https://www.googleapis.com/auth/drive.readonly",
+] as const;
 const PROVIDER_ID = "google";
 const PROVIDER_LABEL = "Google";
 const REFRESH_MARGIN_MS = 5 * 60 * 1000; // 5 minutes

--- a/src/auth/provider.unit.test.ts
+++ b/src/auth/provider.unit.test.ts
@@ -431,7 +431,7 @@ describe("GoogleAuthProvider", () => {
         expect(Array.from(query.entries())).to.deep.include.members([
           ["access_type", "offline"],
           ["response_type", "code"],
-          ["scope", "email profile"],
+          ["scope", SCOPES.join(" ")],
           ["prompt", "consent"],
           ["code_challenge_method", CodeChallengeMethod.S256],
           ["client_id", CLIENT_ID],

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -17,6 +17,7 @@ import {
 import { ColabClient } from "./client";
 
 const COLAB_DOMAIN = "https://colab.example.com";
+const GOOGLE_APIS_DOMAIN = "https://colab.example.googleapis.com";
 const BEARER_TOKEN = "access-token";
 const NOTEBOOK_HASH = randomUUID();
 const DEFAULT_ASSIGNMENT_RESPONSE = {
@@ -24,7 +25,7 @@ const DEFAULT_ASSIGNMENT_RESPONSE = {
   endpoint: "mock-endpoint",
   fit: 30,
   sub: SubscriptionState.UNSUBSCRIBED,
-  subTier: SubscriptionTier.UNKNOWN_TIER,
+  subTier: SubscriptionTier.NONE,
   variant: Variant.GPU,
   machineShape: Shape.STANDARD,
   runtimeProxyInfo: {
@@ -58,7 +59,11 @@ describe("ColabClient", () => {
   beforeEach(() => {
     fetchStub = sinon.stub(nodeFetch, "default");
     sessionStub = sinon.stub<[], Promise<string>>().resolves(BEARER_TOKEN);
-    client = new ColabClient(new URL(COLAB_DOMAIN), sessionStub);
+    client = new ColabClient(
+      new URL(COLAB_DOMAIN),
+      new URL(GOOGLE_APIS_DOMAIN),
+      sessionStub,
+    );
   });
 
   afterEach(() => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,10 +39,15 @@ export async function activate(context: vscode.ExtensionContext) {
     redirectUriHandler,
   );
   await authProvider.initialize();
-  const colabClient = new ColabClient(new URL("https://localhost:8888"), () =>
-    GoogleAuthProvider.getOrCreateSession(vscode).then(
-      (session) => session.accessToken,
-    ),
+  // TODO: Align these URLs with the environment. Mismatch is no big deal during
+  // development.
+  const colabClient = new ColabClient(
+    new URL("https://localhost:8888"),
+    new URL("https://staging-colab.sandbox.googleapis.com"),
+    () =>
+      GoogleAuthProvider.getOrCreateSession(vscode).then(
+        (session) => session.accessToken,
+      ),
   );
   const serverStorage = new ServerStorage(vscode, context.secrets);
   const assignmentManager = new AssignmentManager(

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -33,7 +33,7 @@ const defaultAssignment: Assignment & { runtimeProxyInfo: RuntimeProxyInfo } = {
   endpoint: "m-s-foo",
   idleTimeoutSec: 30,
   subscriptionState: SubscriptionState.UNSUBSCRIBED,
-  subscriptionTier: SubscriptionTier.UNKNOWN_TIER,
+  subscriptionTier: SubscriptionTier.NONE,
   variant: Variant.GPU,
   machineShape: Shape.STANDARD,
   runtimeProxyInfo: {


### PR DESCRIPTION
As with the existing API surface... the Colab backend APIs are a little funky! The team's in the process of standardizing, normalizing and cleaning up the API surface. A big part of this is moving our APIs to One Platform (Google APIs, or GAPIs for short). In the extension, we need to know if the user is a pro/pro+ subscriber or not. Our existing frontend gets this through some funky side-loaded bits of information we don't have access to in the extension. Therefore, we need to integrate with the new GAPI for retrieving this user info.

I've done my best to compartmentalize all the funky API intricacies into `api.ts`, `transform`-ing and _normalizing_ across the two backends so the rest of the client code can be blissfully unaware of the differences.

Currently, this API requires a Drive-scoped OAuth token. This is due to some internal details that don't really matter, but it is a temporary requirement and we'll remove it before launch (hence the TODO).