### PR TITLE
ci: run PR checks when the base ref changes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,9 @@
-# Modular build and test workflow
+# For PRs.
 
-on: workflow_call
+name: Build and Test
+
+on:
+  workflow_call:
 
 env:
   # See supported Node.js release schedule at https://nodejs.org/en/about/releases

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,9 @@
-# For PRs.
-
-name: Pull Request Pre-Merge Checks
+name: PR Pre-Merge Checks
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [opened, synchronize, reopened, edited]
     branches:


### PR DESCRIPTION
I was able to submit https://github.com/googlecolab/colab-vscode/pull/68 after rebasing from `api` to `main` and updating the PR base ref to `main` without having the build and test checks run. This PR fixes that.

Why this was possible is best explained
[here](https://github.com/actions/runner/issues/980#issuecomment-777057271). Modularizing the build/test workflow and invoking it on all PR events, restricting the "edited" one to only `github.event.changes.base.ref` will prevent this from happening in the future.

As you can see in the checks and workflows for this PR (/branch), I opened the PR against `main` which ran the checks, rebased PR to another branch (`recaptcha`) which didn't, then when I rebased back to `main` - it ran the checks again.

![image](https://github.com/user-attachments/assets/cdb438c2-7aff-4d0f-87e5-53b57fa3d354)

This change puts the build/test jobs under a _Pull Request Pre-Merge Checks_ workflow which I actually like more, from a readability perspective.

![image](https://github.com/user-attachments/assets/a5ec84aa-166d-4dcc-beb3-b5dd2fb7899a)

The one negative trade-off with this change is when a PR edit comes in that isn't a change to the base ref or code (e.g. PR title) we re-run the checks. Time permitting, I'll follow-up trying to tune this. As you may be able to tell from the hectic PR history, I couldn't find a way to set this up. Skipping the workflow on non-base-ref edits doesn't work because a "skipped" workflow won't satisfy the required branch policy status check.