### PR TITLE
feat: narrow user-info method to subscription tier

### DIFF
--- a/src/colab/api.ts
+++ b/src/colab/api.ts
@@ -167,10 +167,6 @@ export const UserInfoSchema = z.object({
     )
     .optional(),
 });
-/**
- * Top level information about a user's tier, usage and availability in Colab.
- */
-export type UserInfo = z.infer<typeof UserInfoSchema>;
 
 /** The schema of Colab Compute Units (CCU) information. */
 export const CcuInfoSchema = z.object({

--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -17,8 +17,8 @@ import {
   Kernel,
   SessionSchema,
   Session,
-  UserInfo,
   UserInfoSchema,
+  SubscriptionTier,
 } from "./api";
 
 const XSSI_PREFIX = ")]}'\n";
@@ -54,16 +54,17 @@ export class ColabClient {
   }
 
   /**
-   * Gets the user's usage information.
+   * Gets the user's subscription tier.
    *
-   * @returns The user's current usage information.
+   * @returns The user's subscription tier.
    */
-  async getUserInfo(): Promise<UserInfo> {
-    return this.issueRequest(
+  async getSubscriptionTier(signal?: AbortSignal): Promise<SubscriptionTier> {
+    const userInfo = await this.issueRequest(
       new URL("v1/user-info", this.colabGapiDomain),
-      { method: "GET" },
+      { method: "GET", signal },
       UserInfoSchema,
     );
+    return userInfo.subscriptionTier;
   }
 
   /**


### PR DESCRIPTION
The downstream changes to come only need the user's subscription tier,
not the full user-info object.

This also adds the unit test that was missing in
https://github.com/googlecolab/colab-vscode/pull/68.