### PR TITLE
chore: properly exempt names from no-unused-vars that start with _

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -46,7 +46,15 @@ export default tseslint.config(
       ],
       "@typescript-eslint/no-unused-vars": [
         "error",
-        { varsIgnorePattern: "^_", argsIgnorePattern: "^_" },
+        {
+          args: "all",
+          argsIgnorePattern: "^_",
+          caughtErrors: "all",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
       ],
       "@typescript-eslint/explicit-member-accessibility": [
         "error",


### PR DESCRIPTION
https://typescript-eslint.io/rules/no-unused-vars/#what-benefits-does-this-rule-have-over-typescript