### PR TITLE
feat: change development target to sandbox

### DIFF
--- a/src/auth/provider.ts
+++ b/src/auth/provider.ts
@@ -16,7 +16,7 @@ export const REQUIRED_SCOPES = [
   "email",
   // This scope is temporary. It's temporarily needed to integrate with the
   // Colab GAPI used to query for user-info.
-  "https://www.googleapis.com/auth/drive.readonly",
+  "https://www.googleapis.com/auth/drive",
 ] as const;
 const PROVIDER_ID = "google";
 const PROVIDER_LABEL = "Google";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,9 @@ import { getJupyterApi } from "./jupyter/jupyter-extension";
 import { ColabJupyterServerProvider } from "./jupyter/provider";
 import { ServerStorage } from "./jupyter/storage";
 
+// TODO: Configure this per environment once it works beyond localhost.
+const COLAB_DOMAIN = "https://colab.sandbox.google.com";
+const COLAB_GAPI_DOMAIN = "https://staging-colab.sandbox.googleapis.com";
 /* cSpell:disable */
 const CLIENT_ID =
   "1014160490159-8bdmhbrghjfch5sb8ltuofo1mk1totmr.apps.googleusercontent.com";
@@ -21,8 +24,7 @@ const CLIENT_NOT_SO_SECRET = "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";
 const AUTH_CLIENT = new OAuth2Client(
   CLIENT_ID,
   CLIENT_NOT_SO_SECRET,
-  // TODO: Configure this per environment once it works beyond localhost.
-  "https://localhost:8888/vscode/redirect",
+  `"{COLAB_DOMAIN}/vscode/redirect`,
 );
 
 // Called when the extension is activated.
@@ -42,8 +44,8 @@ export async function activate(context: vscode.ExtensionContext) {
   // TODO: Align these URLs with the environment. Mismatch is no big deal during
   // development.
   const colabClient = new ColabClient(
-    new URL("https://localhost:8888"),
-    new URL("https://staging-colab.sandbox.googleapis.com"),
+    new URL(COLAB_DOMAIN),
+    new URL(COLAB_GAPI_DOMAIN),
     () =>
       GoogleAuthProvider.getOrCreateSession(vscode).then(
         (session) => session.accessToken,


### PR DESCRIPTION
We're in the process of reducing the scopes required to hit the Colab
backend(s). Currently, they require `drive`. This change temporarily adds that
scope and configures the extension to hit the sandbox environment. A follow-up
change will extract all of this environment-based config to `.env` files with
the supporting `launch.json` entries.