### PR TITLE
fix: string substitution for the redirect uri

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ const AUTH_CLIENT = new OAuth2Client(
   CLIENT_NOT_SO_SECRET,
   `${COLAB_DOMAIN}/vscode/redirect`,
 );
+
 // Called when the extension is activated.
 export async function activate(context: vscode.ExtensionContext) {
   const jupyter = await getJupyterApi(vscode);


### PR DESCRIPTION
redirect uri string was missing a $ to substitute COLAB_DOMAIN properly.