### PR TITLE
fix: validate button clicked on input before flowing back

### DIFF
--- a/src/colab/server-picker.unit.test.ts
+++ b/src/colab/server-picker.unit.test.ts
@@ -385,7 +385,9 @@ describe("ServerPicker", () => {
         { value: Accelerator.T4, label: "T4" },
       ]);
       const secondVariantPickerShown = secondVariantQuickPickStub.nextShow();
-      secondAcceleratorQuickPickStub.onDidTriggerButton.yield();
+      secondAcceleratorQuickPickStub.onDidTriggerButton.yield(
+        vsCodeStub.QuickInputButtons.Back,
+      );
       await secondVariantPickerShown;
       expect(secondVariantQuickPickStub.activeItems).to.be.deep.equal([
         { value: Variant.GPU, label: "GPU" },

--- a/src/common/multi-step-quickpick.ts
+++ b/src/common/multi-step-quickpick.ts
@@ -233,14 +233,20 @@ export class MultiStepInput {
 
   /**
    * Configure the input for back navigation and hide events.
+   *
+   * This enables callers waiting on the provided input to handle it navigating
+   * back by throwing a {@link InputFlowAction.back} or hiding by throwing a
+   * {@link InputFlowAction.cancel}.
    */
   private configureNavigation(
     input: QuickInput & { onDidTriggerButton: Event<QuickInputButton> },
     reject: (reason?: unknown) => void,
   ): { onDidTriggerButton: Disposable; onDidHide: Disposable } {
     return {
-      onDidTriggerButton: input.onDidTriggerButton(() => {
-        reject(InputFlowAction.back);
+      onDidTriggerButton: input.onDidTriggerButton((e) => {
+        if (e === this.vs.QuickInputButtons.Back) {
+          reject(InputFlowAction.back);
+        }
       }),
       onDidHide: input.onDidHide(() => {
         reject(InputFlowAction.cancel);

--- a/src/common/multi-step-quickpick.unit.test.ts
+++ b/src/common/multi-step-quickpick.unit.test.ts
@@ -152,7 +152,7 @@ describe("MultiStepQuickPick", () => {
       const input = MultiStepInput.run(vsCodeStub.asVsCode(), step);
       // Once the quick pick has been shown, trigger the back button.
       await inputShown;
-      quickPickStub.onDidTriggerButton.yield();
+      quickPickStub.onDidTriggerButton.yield(vsCodeStub.QuickInputButtons.Back);
 
       await expect(input).to.eventually.be.rejectedWith(InputFlowAction.back);
       sinon.assert.calledOnce(quickPickStub.dispose);
@@ -298,7 +298,7 @@ describe("MultiStepQuickPick", () => {
       const input = MultiStepInput.run(vsCodeStub.asVsCode(), step);
       // Once the input box has been shown, trigger the back button.
       await inputShown;
-      inputBoxStub.onDidTriggerButton.yield();
+      inputBoxStub.onDidTriggerButton.yield(vsCodeStub.QuickInputButtons.Back);
 
       await expect(input).to.eventually.be.rejectedWith(InputFlowAction.back);
       sinon.assert.calledOnce(inputBoxStub.dispose);


### PR DESCRIPTION
I don't have intentions of adding a new button to any of our inputs anytime soon, but it's best to be explicit here and improve documentation of the supporting method.