### PR TITLE
feat: only prompt relevant auth flows

### DIFF
--- a/src/auth/flows/flows.unit.test.ts
+++ b/src/auth/flows/flows.unit.test.ts
@@ -1,0 +1,50 @@
+import { expect } from "chai";
+import { OAuth2Client } from "google-auth-library";
+import sinon from "sinon";
+import vscode from "vscode";
+import { PackageInfo } from "../../config/package-info";
+import { ExtensionUriHandler } from "../../system/uri-handler";
+import { newVsCodeStub, VsCodeStub } from "../../test/helpers/vscode";
+import { getOAuth2Flows, OAuth2Flow } from "./flows";
+
+const PACKAGE_INFO: PackageInfo = {
+  publisher: "google",
+  name: "colab",
+};
+
+describe("getOAuth2Flows", () => {
+  let vs: VsCodeStub;
+
+  beforeEach(() => {
+    vs = newVsCodeStub();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  function getOAuth2FlowsFor(uiKind: vscode.UIKind): OAuth2Flow[] {
+    vs.env.uiKind = uiKind;
+    return getOAuth2Flows(
+      vs.asVsCode(),
+      PACKAGE_INFO,
+      new ExtensionUriHandler(vs.asVsCode()),
+      sinon.createStubInstance(OAuth2Client),
+    );
+  }
+
+  it("returns the local server and proxied redirect flows when running on desktop", () => {
+    const flows = getOAuth2FlowsFor(vs.UIKind.Desktop);
+
+    expect(flows).to.have.lengthOf(2);
+    expect(flows[0].constructor.name).to.equal("LocalServerFlow");
+    expect(flows[1].constructor.name).to.equal("ProxiedRedirectFlow");
+  });
+
+  it("returns the proxied redirect flow when running on web", () => {
+    const flows = getOAuth2FlowsFor(vs.UIKind.Web);
+
+    expect(flows).to.have.lengthOf(1);
+    expect(flows[0].constructor.name).to.equal("ProxiedRedirectFlow");
+  });
+});

--- a/src/auth/flows/loopback.ts
+++ b/src/auth/flows/loopback.ts
@@ -9,7 +9,6 @@ import { CodeManager } from "../code-manager";
 import {
   DEFAULT_AUTH_URL_OPTS,
   OAuth2Flow,
-  OAuth2EnvCapabilities,
   OAuth2TriggerOptions,
   FlowResult,
 } from "./flows";
@@ -18,14 +17,6 @@ import {
  * An OAuth2 flow that uses a local server to handle the redirect URI.
  */
 export class LocalServerFlow implements OAuth2Flow {
-  options: OAuth2EnvCapabilities = {
-    // Opening a port on the remote side can't be opened in the browser on
-    // the client side so this flow doesn't work in remote extension hosts.
-    supportsRemoteExtensionHost: false,
-    // A Web Worker can't open a port to listen for the redirect.
-    supportsWebWorkerExtensionHost: false,
-  };
-
   private readonly handler: Handler;
   private readonly codeManager = new CodeManager();
   private readonly disposables: vscode.Disposable[] = [];

--- a/src/auth/flows/proxied.ts
+++ b/src/auth/flows/proxied.ts
@@ -7,7 +7,6 @@ import { CodeManager } from "../code-manager";
 import {
   DEFAULT_AUTH_URL_OPTS,
   OAuth2Flow,
-  OAuth2EnvCapabilities,
   OAuth2TriggerOptions,
   FlowResult,
 } from "./flows";
@@ -15,13 +14,8 @@ import {
 const PROXIED_REDIRECT_URI = `${CONFIG.ColabApiDomain}/vscode/redirect`;
 
 export class ProxiedRedirectFlow implements OAuth2Flow, vscode.Disposable {
-  readonly options: Readonly<OAuth2EnvCapabilities> = {
-    supportsWebWorkerExtensionHost: true,
-    supportsRemoteExtensionHost: true,
-  } as const;
-
   private readonly baseUri: string;
-  private readonly uriHandler: vscode.Disposable;
+  private readonly uriListener: vscode.Disposable;
   private readonly codeManager = new CodeManager();
 
   constructor(
@@ -34,11 +28,11 @@ export class ProxiedRedirectFlow implements OAuth2Flow, vscode.Disposable {
     const pub = this.packageInfo.publisher;
     const name = this.packageInfo.name;
     this.baseUri = `${scheme}://${pub}.${name}`;
-    this.uriHandler = uriHandler.onReceivedUri(this.resolveCode.bind(this));
+    this.uriListener = uriHandler.onReceivedUri(this.resolveCode.bind(this));
   }
 
   dispose() {
-    this.uriHandler.dispose();
+    this.uriListener.dispose();
   }
 
   async trigger(options: OAuth2TriggerOptions): Promise<FlowResult> {

--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -4,11 +4,7 @@ import {
 } from "google-auth-library";
 import { v4 as uuid } from "uuid";
 import vscode from "vscode";
-import {
-  OAuth2TriggerOptions,
-  FlowResult,
-  OAuth2FlowProvider,
-} from "./flows/flows";
+import { OAuth2TriggerOptions, FlowResult, OAuth2Flow } from "./flows/flows";
 
 /**
  * A complete set of credentials produced from completing OAuth2 authentication.
@@ -30,11 +26,10 @@ export type Credentials = OAuth2Credentials & {
  */
 export async function login(
   vs: typeof vscode,
-  flowProvider: OAuth2FlowProvider,
+  flows: OAuth2Flow[],
   client: OAuth2Client,
   scopes: string[],
 ): Promise<Credentials> {
-  const flows = flowProvider.getSupportedFlows();
   if (flows.length === 0) {
     throw new Error("No authentication flows available.");
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import { OAuth2Client } from "google-auth-library";
 import vscode from "vscode";
 import { GoogleAuthProvider } from "./auth/auth-provider";
-import { OAuth2FlowProvider } from "./auth/flows/flows";
+import { getOAuth2Flows } from "./auth/flows/flows";
 import { login } from "./auth/login";
 import { AuthStorage } from "./auth/storage";
 import { ColabClient } from "./colab/client";
@@ -31,7 +31,7 @@ export async function activate(context: vscode.ExtensionContext) {
     CONFIG.ClientId,
     CONFIG.ClientNotSoSecret,
   );
-  const authFlows = new OAuth2FlowProvider(
+  const authFlows = getOAuth2Flows(
     vscode,
     getPackageInfo(context),
     uriHandler,

--- a/src/test/helpers/vscode.ts
+++ b/src/test/helpers/vscode.ts
@@ -14,6 +14,11 @@ class TestQuickInputButtons implements vscode.QuickInputButtons {
   };
 }
 
+enum UIKind {
+  Desktop = 1,
+  Web = 2,
+}
+
 enum ProgressLocation {
   SourceControl = 1,
   Window = 10,
@@ -39,8 +44,10 @@ export interface VsCodeStub {
       typeof vscode.commands.executeCommand
     >;
   };
+  UIKind: typeof UIKind;
   env: {
-    uriScheme: "vscode";
+    uriScheme: string;
+    uiKind: vscode.UIKind;
     openExternal: sinon.SinonStubbedMember<typeof vscode.env.openExternal>;
     asExternalUri: sinon.SinonStubbedMember<typeof vscode.env.asExternalUri>;
   };
@@ -112,8 +119,10 @@ export function newVsCodeStub(): VsCodeStub {
     commands: {
       executeCommand: sinon.stub(),
     },
+    UIKind: UIKind,
     env: {
       uriScheme: "vscode",
+      uiKind: UIKind.Desktop,
       openExternal: sinon.stub(),
       asExternalUri: sinon.stub(),
     },


### PR DESCRIPTION
On activation, we determine where we're running (web or desktop). The flows are obtained once and provied statically to the login flow.

In working on this change, interestingly enough I found that with port forwarding enabled, you can actually spin up a local server in GitHub Codespaces. Despite that, it makes more sense to only use the proxied approach in Web environments. It avoids the need to accept port forwarding, aligns with web standards and will produce a more secure auth road-bump in the proxied redirect.

In this change I did away with the `OAuth2FlowProvider` in favour of the simple function that's called once on activation.