### PR TITLE
fix: correct prod Colab API domain

### DIFF
--- a/scripts/generate-config.mts
+++ b/scripts/generate-config.mts
@@ -30,8 +30,8 @@ try {
   }
   switch (envConfig.env) {
     case "production":
-      colabApiDomain = "https://colab.google.com";
-      colabGapiApiDomain = "https://colab.googleapis.com";
+      colabApiDomain = "https://colab.research.google.com";
+      colabGapiApiDomain = "https://colab.pa.googleapis.com";
       break;
     case "sandbox":
       colabApiDomain = "https://colab.sandbox.google.com";


### PR DESCRIPTION
While the webapp will redirect fine from colab.google.com, we're
returning a 200 with some JS to do that 🫨. To avoid the redirect we
can't easily follow (as if it were a 300), this change configures the
URL to the redirected endpoint.