### PR TITLE
feat: warn of server removals

### DIFF
--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -94,7 +94,7 @@ export class ColabClient {
     variant: Variant,
     accelerator?: Accelerator,
     signal?: AbortSignal,
-  ): Promise<Assignment> {
+  ): Promise<{ assignment: Assignment; isNew: boolean }> {
     const assignment = await this.getAssignment(
       notebookHash,
       variant,
@@ -106,16 +106,19 @@ export class ColabClient {
         // Not required, but we want to remove the type field we use internally
         // to discriminate the union of types returned from getAssignment.
         const { kind: _, ...rest } = assignment;
-        return rest;
+        return { assignment: rest, isNew: false };
       }
       case "to_assign": {
-        return await this.postAssignment(
-          notebookHash,
-          assignment.xsrfToken,
-          variant,
-          accelerator,
-          signal,
-        );
+        return {
+          assignment: await this.postAssignment(
+            notebookHash,
+            assignment.xsrfToken,
+            variant,
+            accelerator,
+            signal,
+          ),
+          isNew: true,
+        };
       }
     }
   }

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -144,7 +144,10 @@ describe("ColabClient", () => {
 
       await expect(
         client.assign(NOTEBOOK_HASH, Variant.GPU, Accelerator.A100),
-      ).to.eventually.deep.equal(DEFAULT_ASSIGNMENT);
+      ).to.eventually.deep.equal({
+        assignment: DEFAULT_ASSIGNMENT,
+        isNew: false,
+      });
 
       sinon.assert.calledOnce(fetchStub);
     });
@@ -178,7 +181,10 @@ describe("ColabClient", () => {
 
       await expect(
         client.assign(NOTEBOOK_HASH, Variant.GPU, Accelerator.A100),
-      ).to.eventually.deep.equal(DEFAULT_ASSIGNMENT);
+      ).to.eventually.deep.equal({
+        assignment: DEFAULT_ASSIGNMENT,
+        isNew: true,
+      });
 
       sinon.assert.calledTwice(fetchStub);
     });

--- a/src/test/helpers/vscode.ts
+++ b/src/test/helpers/vscode.ts
@@ -56,6 +56,9 @@ export interface VsCodeStub {
     showInformationMessage: sinon.SinonStubbedMember<
       typeof vscode.window.showInformationMessage
     >;
+    showWarningMessage: sinon.SinonStubbedMember<
+      typeof vscode.window.showWarningMessage
+    >;
     showErrorMessage: sinon.SinonStubbedMember<
       typeof vscode.window.showErrorMessage
     >;
@@ -129,6 +132,7 @@ export function newVsCodeStub(): VsCodeStub {
     window: {
       withProgress: sinon.stub(),
       showInformationMessage: sinon.stub(),
+      showWarningMessage: sinon.stub(),
       showErrorMessage: sinon.stub(),
       showQuickPick: sinon.stub(),
       createInputBox: sinon.stub(),


### PR DESCRIPTION
Included in this change is also a step to reconcile the servers before listing them. This ensures that the server list is always up to date when the Jupyter extension needs it.

Now when a removal is detected which was not initiated by the user, a warning is displayed to inform them of the change. The more likely case of automatic removal is when a user stops using VS Code, then comes back after some period of time (e.g. the next day) and Colab has pruned the server. In those cases, no notification is shown since we reconcile on activation before registering the `ColabJupyterServerProvider` which binds this event / dispatches the notification.