### PR TITLE
test: fix the subtle leak in the CodeManager

### DIFF
--- a/src/auth/code-manager.unit.test.ts
+++ b/src/auth/code-manager.unit.test.ts
@@ -19,11 +19,20 @@ describe("CodeManager", () => {
   });
 
   afterEach(() => {
+    manager.dispose();
     clock.restore();
     sinon.restore();
   });
 
-  it("throws when waiting for the same nonce", async () => {
+  it("rejects outstanding codes when disposed", async () => {
+    const code = manager.waitForCode("1", cancellationTokenSource.token);
+
+    manager.dispose();
+
+    await expect(code).to.be.rejectedWith(/disposed/);
+  });
+
+  it("rejects when waiting for the same nonce", async () => {
     const nonce = "1";
 
     void manager.waitForCode(nonce, cancellationTokenSource.token);

--- a/src/auth/flows/flows.ts
+++ b/src/auth/flows/flows.ts
@@ -34,7 +34,7 @@ export interface FlowResult {
 export interface OAuth2Flow {
   /** Triggers the OAuth2 flow. */
   trigger(options: OAuth2TriggerOptions): Promise<FlowResult>;
-  /** Disposes of the flow and cleans up resources. */
+  /** Disposes of the flow and cleans up owned resources. */
   dispose?(): void;
 }
 

--- a/src/auth/flows/loopback.unit.test.ts
+++ b/src/auth/flows/loopback.unit.test.ts
@@ -49,6 +49,7 @@ describe("LocalServerFlow", () => {
   });
 
   afterEach(() => {
+    flow.dispose();
     sinon.restore();
   });
 

--- a/src/auth/flows/proxied.unit.test.ts
+++ b/src/auth/flows/proxied.unit.test.ts
@@ -53,37 +53,22 @@ describe("ProxiedRedirectFlow", () => {
   });
 
   afterEach(() => {
+    flow.dispose();
     sinon.restore();
   });
 
-  it("disposes the URI handler when disposed", () => {
-    const eventStub = sinon.stub(uriHandler, "onReceivedUri");
-    const disposeStub = sinon.stub<[]>();
-    eventStub.returns({ dispose: disposeStub });
-    flow = new ProxiedRedirectFlow(
-      vs.asVsCode(),
-      PACKAGE_INFO,
-      oauth2Client,
-      uriHandler,
-    );
-
-    flow.dispose();
-
-    sinon.assert.calledOnce(disposeStub);
-  });
-
-  it("throws an error when the received URI is missing a nonce", () => {
+  it("ignores requests missing a nonce", () => {
     void flow.trigger(defaultTriggerOpts);
     const uri = TestUri.parse("vscode://google.colab");
 
-    expect(() => uriHandler.handleUri(uri)).to.throw(/nonce/);
+    expect(() => uriHandler.handleUri(uri)).not.to.throw();
   });
 
-  it("throws an error when the received URI is missing a code", () => {
+  it("ignores requests missing a code", () => {
     void flow.trigger(defaultTriggerOpts);
     const uri = TestUri.parse(`${EXTERNAL_CALLBACK_URI}&code=`);
 
-    expect(() => uriHandler.handleUri(uri)).to.throw(/code/);
+    expect(() => uriHandler.handleUri(uri)).not.to.throw();
   });
 
   it("throws an error when the code exchange times out", async () => {

--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -69,8 +69,6 @@ export async function login(
       const msg = `Sign-in attempt failed: ${innerMsg}.`;
       // Notify this attempt failed, but try other methods 🤞.
       vs.window.showErrorMessage(msg);
-    } finally {
-      flow.dispose?.();
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,6 +78,13 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     disposeUriHandler,
+    {
+      dispose: () => {
+        authFlows.forEach((flow) => {
+          flow.dispose?.();
+        });
+      },
+    },
     authProvider,
     assignmentManager,
     keepAlive,


### PR DESCRIPTION
🥂 Fun one to work on!

I started noticing the tests were reporting having ran in milliseconds, but the actual `npm run test:unit` command would hang for minutes.

I wrote a script to figure out what tests were slow:

```sh

grep_targets=("all" "top" "level" "target")

for target in "${grep_targets[@]}"
do
    start_time=$(date +%s.%N)
    eval npm run test:unit -- --grep \""$target"\" > /dev/null 2>&1
    end_time=$(date +%s.%N) # Store end time
    duration=$(echo "$end_time - $start_time" | bc)
    echo "${target}: ${duration}s"
done
```

This told me that both the `ProxiedRedirectFlow` and `LocalServerFlow` tests were slow, so I started looking at them.

The timing of both of them was 60s + a bit. This was pretty telling that a promise was hanging and it was likely the 60s timeout in the `CodeManager`. Sure enough, that was the bug. Now the `CodeManager` on dispose rejects any outstanding promises, effectively cleaning up any resources. I am far from an expert here, but as I understand Node's event loop will schedule future tasks with `setTimeout` and effectively hang while the timer is pending. Once all timers are cleared, all listeners are removed and all connections are closed, the event loop's list will be empty and the Node process can exit immediately. I'm sure there's more sophisticated tools for finding what's holidng a process than my hacky script + debugging, oh well!