### PR TITLE
feat: remove Drive as a required scope.

### DIFF
--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -6,13 +6,7 @@ import { z } from "zod";
 import { Credentials } from "./login";
 import { AuthStorage, RefreshableAuthenticationSession } from "./storage";
 
-export const REQUIRED_SCOPES = [
-  "profile",
-  "email",
-  // This scope is temporary. It's temporarily needed to integrate with the
-  // Colab GAPI used to query for user-info.
-  "https://www.googleapis.com/auth/drive",
-] as const;
+export const REQUIRED_SCOPES = ["profile", "email"] as const;
 const PROVIDER_ID = "google";
 const PROVIDER_LABEL = "Google";
 const REFRESH_MARGIN_MS = 5 * 60 * 1000; // 5 minutes


### PR DESCRIPTION
Yay! We cleaned up our APIs a bit and no longer require Drive for the endpoints the extension depends on.