### PR TITLE
test: deflake dialog button push in e2e test

### DIFF
--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -106,8 +106,8 @@ describe("Colab Extension", function () {
     button: string;
     dialog: string;
   }) {
-    // ModalDialog.pushButton will throw if the dialog is not found; so, to
-    // reduce flakes, we attempt this until it succeeds or the times out.
+    // ModalDialog.pushButton will throw if the dialog is not found; to reduce
+    // flakes we attempt this until it succeeds or times out.
     return driver.wait(
       async () => {
         try {


### PR DESCRIPTION
Adds a util to wait for a successful dialog button press before proceeding with the test.

why? we noticed this was flaky yesterday and want to mitigate that before this runs in a pipeline. The util also generates an error message to notify us which dialog failed.

error before (generic): 
<img width="903" height="178" alt="Screenshot 2025-07-31 at 11 26 05 AM" src="https://github.com/user-attachments/assets/312827ad-57a1-40d6-bbcd-dbc9c1f2de62" />

error after (identifies dialog):
<img width="839" height="160" alt="Screenshot 2025-07-31 at 11 24 15 AM" src="https://github.com/user-attachments/assets/d7f09054-f009-4678-9719-9be9ee186c53" />

