### PR TITLE
test: add a selectQuickPickItem util

### DIFF
--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -117,6 +117,8 @@ describe("Colab Extension", function () {
     return driver.wait(
       async () => {
         const inputBox = await InputBox.create();
+        // We check for the item's presence before selecting it, since
+        // InputBox.selectQuickPick will not throw if the item is not found.
         const quickPickItem = await inputBox.findQuickPick(item);
         if (!quickPickItem) {
           return false;


### PR DESCRIPTION
Adds a selectQuickPickItem util so we can check for an item's existence before proceeding.

Before, when a QuickPick item was not found, the test would silently proceed and fail elsewhere, complicating debugging.

Now, the test fails at the QuickPick with a helpful error message.

<img width="826" height="140" alt="Screenshot 2025-07-31 at 5 21 27 PM" src="https://github.com/user-attachments/assets/fdb9fb6c-8277-4df1-8d45-3a39cdcd4fb5" />
