### PR TITLE
test: fail e2e test when environment is not set to production

### DIFF
--- a/scripts/generate-config.mts
+++ b/scripts/generate-config.mts
@@ -57,6 +57,7 @@ const config = {
   ColabGapiDomain: colabGapiApiDomain,
   ClientId: envConfig.clientId,
   ClientNotSoSecret: envConfig.clientNotSoSecret,
+  Environment: envConfig.env,
 };
 
 const output = `// AUTO-GENERATED. Do not edit.

--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -13,6 +13,7 @@ import {
   VSBrowser,
   until,
 } from "vscode-extension-tester";
+import { CONFIG } from "../colab-config";
 
 const ELEMENT_WAIT_MS = 10000;
 
@@ -25,9 +26,9 @@ describe("Colab Extension", function () {
 
   before(async () => {
     assert.equal(
-      process.env.COLAB_EXTENSION_ENVIRONMENT,
+      CONFIG.Environment,
       "production",
-      "The COLAB_EXTENSION_ENVIRONMENT environment variable must be set to 'production' for e2e tests.",
+      'Unexpected extension environment. Run `npm run generate:config` with COLAB_EXTENSION_ENVIRONMENT="production".',
     );
     // Wait for the extension to be installed.
     workbench = new Workbench();


### PR DESCRIPTION
The test account only works in the production environment. When the test fails due to an unexpected environment, the failure is not obvious (e.g., kernel selection will hang). Because of this, we should fail the test when we detect an unexpected environment.