### PR TITLE
test: remove select another kernel QuickPick from e2e test

### DIFF
--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -54,10 +54,6 @@ describe("Colab Extension", function () {
       // Select the Colab server provider from the kernel selector.
       await workbench.executeCommand("Notebook: Select Notebook Kernel");
       await selectQuickPickItem({
-        item: "Select Another Kernel...",
-        quickPick: "Change kernel",
-      });
-      await selectQuickPickItem({
         item: "Colab",
         quickPick: "Select Another Kernel",
       });


### PR DESCRIPTION
Here, we remove the "Select Another Kernel..." QuickPick from the e2e test.

Now that we're failing when QuickPick items aren't found (https://github.com/googlecolab/colab-vscode/pull/109), running the test in a Github workflow fails at this step.

When developing locally, I would get an extra QuickPick due to the Jupyter extension auto-connecting to my python environment. This extra step is not reflected in the workflow run; so, we remove it here.