### PR TITLE
ci: add e2e tests to build-test workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -106,3 +106,47 @@ jobs:
       - name: npm run test:integration
         if: matrix.os != 'ubuntu-latest'
         run: npm run test:integration
+
+  e2eTests:
+    name: VS Code E2E Tests
+    strategy:
+      matrix:
+        # macos-latest and windows-latest can be added as we work towards a release.
+        # For now, there's no sense acruing the cost of the runners.
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    needs: generateConfig
+    env:
+      TEST_ACCOUNT_EMAIL: ${{ secrets.TEST_ACCOUNT_EMAIL }}
+      TEST_ACCOUNT_PASSWORD: ${{ secrets.TEST_ACCOUNT_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+      - run: npm ci
+      - name: Download generated config
+        uses: actions/download-artifact@v4
+        with:
+          name: generated-config
+          path: src
+      - name: npm run test:e2e:headless (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: npm run test:e2e:headless
+      - name: npm run test:e2e
+        if: matrix.os != 'ubuntu-latest'
+        run: npm run test:e2e
+      - name: upload screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots
+          path: /tmp/test-resources/screenshots/
+      - name: upload exthost.log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: exthost log
+          path: /tmp/test-resources/settings/logs/*/window1/exthost/exthost.log

--- a/project-words.txt
+++ b/project-words.txt
@@ -2,6 +2,7 @@ authuser
 chromedriver
 colab
 extest
+exthost
 gapi
 gaxios
 googlecolab


### PR DESCRIPTION
Adds a step for running E2E tests to the Build and Test workflow

When the test fails, screenshots and the extension host logs are uploaded as workflow artifacts
