### PR TITLE
chore: update dependencies

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,6 @@
 import eslint from "@eslint/js";
 import eslintConfigPrettier from "eslint-config-prettier";
-import stylisticTs from "@stylistic/eslint-plugin-ts";
+import stylisticTs from "@stylistic/eslint-plugin";
 import tseslint from "typescript-eslint";
 import tsDocPlugin from "eslint-plugin-tsdoc";
 import importPlugin from "eslint-plugin-import";

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@cspell/eslint-plugin": "^8.17.3",
         "@eslint/js": "^9.15.0",
-        "@stylistic/eslint-plugin-ts": "^4.0.1",
+        "@stylistic/eslint-plugin": "^5.2.2",
         "@types/chai": "^4.3.20",
         "@types/chai-as-promised": "^7.1.8",
         "@types/mocha": "^10.0.10",
@@ -2091,22 +2091,38 @@
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
-    "node_modules/@stylistic/eslint-plugin-ts": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-4.4.1.tgz",
-      "integrity": "sha512-2r6cLcmdF6til66lx8esBYvBvsn7xCmLT50gw/n1rGGlTq/OxeNjBIh4c3VEaDGMa/5TybrZTia6sQUHdIWx1w==",
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.2.2.tgz",
+      "integrity": "sha512-bE2DUjruqXlHYP3Q2Gpqiuj2bHq7/88FnuaS0FjeGGLCy+X6a07bGVuwtiOYnPSLHR6jmx5Bwdv+j7l8H+G97A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.32.1",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/types": "^8.37.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
         "eslint": ">=9.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@szmarczak/http-timer": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   "devDependencies": {
     "@cspell/eslint-plugin": "^8.17.3",
     "@eslint/js": "^9.15.0",
-    "@stylistic/eslint-plugin-ts": "^4.0.1",
+    "@stylistic/eslint-plugin": "^5.2.2",
     "@types/chai": "^4.3.20",
     "@types/chai-as-promised": "^7.1.8",
     "@types/mocha": "^10.0.10",

--- a/project-words.txt
+++ b/project-words.txt
@@ -22,5 +22,6 @@ unassigning
 unassignment
 unassigns
 veryhighmem
+vscode
 vulnz
 xssi

--- a/src/test/helpers/authentication.ts
+++ b/src/test/helpers/authentication.ts
@@ -72,9 +72,7 @@ export class FakeAuthenticationProviderManager {
     if (!provider) {
       throw new Error(`No provider registered for id: ${providerId}`);
     }
-    const sessionOptions: vscode.AuthenticationProviderSessionOptions = options
-      ? options
-      : {};
+    const sessionOptions = options ?? {};
     let sessions = await provider.getSessions(scopes, sessionOptions);
 
     if (sessions.length === 0) {


### PR DESCRIPTION
This should ideally just be done with Dependabot. But I've got some stuff to figure out since as you can see in https://github.com/googlecolab/colab-vscode/pull/100, the dependabot PRs can't run the necessary prerequisite _Generate Config_ build step. I'll figure out a better long-term solution, but until then I'll manually update dependencies when I spot _Critical_ updates.

Here I also address the warning about using the deprecated ES lint plugin for TS in favour of the main package.