### PR TITLE
test: swallow errors in selectQuickPickItem

### DIFF
--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -135,8 +135,7 @@ describe("Colab Extension", function () {
           await quickPickItem.select();
           return true;
         } catch (_) {
-          // Swallow the InputBox.create error since we want to fail when our
-          // timeout's reached.
+          // Swallow errors since we want to fail when our timeout's reached.
           return false;
         }
       },


### PR DESCRIPTION
This PR updates the `selectQuickPickItem` helper to swallow any errors thrown by `InputBox.create`.

