### PR TITLE
fix: issue Jupyter API calls to the server directly

### DIFF
--- a/src/colab/keep-alive.ts
+++ b/src/colab/keep-alive.ts
@@ -84,10 +84,7 @@ export class ServerKeepAliveController implements Disposable {
     assignment: ColabAssignedServer,
     signal: AbortSignal,
   ): Promise<void> {
-    const kernels = await this.colabClient.listKernels(
-      assignment.endpoint,
-      signal,
-    );
+    const kernels = await this.colabClient.listKernels(assignment, signal);
     if (await this.shouldKeepAlive(assignment, kernels)) {
       await this.colabClient.sendKeepAlive(assignment.endpoint, signal);
     }

--- a/src/colab/keep-alive.unit.test.ts
+++ b/src/colab/keep-alive.unit.test.ts
@@ -97,7 +97,7 @@ describe("ServerKeepAliveController", () => {
     it("skips when a keep-alive is already in flight", async () => {
       assignmentStub.getAssignedServers.resolves([defaultServer]);
       colabClientStub.listKernels
-        .withArgs(defaultServer.endpoint)
+        .withArgs(defaultServer)
         .resolves([DEFAULT_KERNEL]);
       colabClientStub.sendKeepAlive.callsFake(ABORTING_KEEP_ALIVE);
       serverKeepAliveController = new ServerKeepAliveController(
@@ -121,7 +121,7 @@ describe("ServerKeepAliveController", () => {
     it("aborts slow keep-alive attempts", async () => {
       assignmentStub.getAssignedServers.resolves([defaultServer]);
       colabClientStub.listKernels
-        .withArgs(defaultServer.endpoint)
+        .withArgs(defaultServer)
         .resolves([DEFAULT_KERNEL]);
       colabClientStub.sendKeepAlive
         .onFirstCall()
@@ -164,7 +164,7 @@ describe("ServerKeepAliveController", () => {
     beforeEach(() => {
       assignmentStub.getAssignedServers.resolves([defaultServer]);
       colabClientStub.listKernels
-        .withArgs(defaultServer.endpoint)
+        .withArgs(defaultServer)
         .resolves([DEFAULT_KERNEL]);
       serverKeepAliveController = new ServerKeepAliveController(
         vsCodeStub.asVsCode(),
@@ -206,7 +206,7 @@ describe("ServerKeepAliveController", () => {
     beforeEach(() => {
       assignmentStub.getAssignedServers.resolves([defaultServer]);
       colabClientStub.listKernels
-        .withArgs(defaultServer.endpoint)
+        .withArgs(defaultServer)
         .resolves([idleKernel]);
       cancellationSource = new vsCodeStub.CancellationTokenSource();
       reportStub = sinon.stub();
@@ -288,7 +288,7 @@ describe("ServerKeepAliveController", () => {
           lastActivity: NOW.toString(),
         };
         colabClientStub.listKernels
-          .withArgs(defaultServer.endpoint)
+          .withArgs(defaultServer)
           .resolves([activeKernel]);
 
         await tickPast(CONFIG.keepAliveIntervalMs);
@@ -318,7 +318,7 @@ describe("ServerKeepAliveController", () => {
             lastActivity: NOW.toString(),
           };
           colabClientStub.listKernels
-            .withArgs(defaultServer.endpoint)
+            .withArgs(defaultServer)
             .resolves([activeKernel]);
           await tickPast(CONFIG.keepAliveIntervalMs);
         });
@@ -377,9 +377,7 @@ describe("ServerKeepAliveController", () => {
       idle2 = createServerWithKernel(4, "idle");
       const servers = [active1, active2, idle1, idle2];
       for (const { server, kernel } of servers) {
-        colabClientStub.listKernels
-          .withArgs(server.endpoint)
-          .resolves([kernel]);
+        colabClientStub.listKernels.withArgs(server).resolves([kernel]);
       }
       assignmentStub.getAssignedServers.resolves(servers.map((s) => s.server));
     });
@@ -486,9 +484,7 @@ describe("ServerKeepAliveController", () => {
           lastActivity: new Date(42).toString(),
         },
       ];
-      colabClientStub.listKernels
-        .withArgs(defaultServer.endpoint)
-        .resolves(kernels);
+      colabClientStub.listKernels.withArgs(defaultServer).resolves(kernels);
       serverKeepAliveController = new ServerKeepAliveController(
         vsCodeStub.asVsCode(),
         colabClientStub,
@@ -518,9 +514,7 @@ describe("ServerKeepAliveController", () => {
           lastActivity: new Date(43).toString(),
         },
       ];
-      colabClientStub.listKernels
-        .withArgs(defaultServer.endpoint)
-        .resolves(kernels);
+      colabClientStub.listKernels.withArgs(defaultServer).resolves(kernels);
       serverKeepAliveController = new ServerKeepAliveController(
         vsCodeStub.asVsCode(),
         colabClientStub,

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -236,8 +236,8 @@ export class AssignmentManager implements vscode.Disposable {
       changed: [],
     });
     await Promise.all(
-      (await this.client.listSessions(server.endpoint)).map((session) =>
-        this.client.deleteSession(server.endpoint, session.id),
+      (await this.client.listSessions(server)).map((session) =>
+        this.client.deleteSession(server, session.id),
       ),
     );
     await this.client.unassign(server.endpoint);

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -566,7 +566,7 @@ describe("AssignmentManager", () => {
           id: "mock-session-id-2",
         };
         colabClientStub.listSessions
-          .withArgs(defaultServer.endpoint)
+          .withArgs(defaultServer)
           .resolves([session1, session2]);
 
         await assignmentManager.unassignServer(defaultServer);
@@ -574,12 +574,12 @@ describe("AssignmentManager", () => {
         sinon.assert.calledTwice(colabClientStub.deleteSession);
         sinon.assert.calledWith(
           colabClientStub.deleteSession,
-          defaultServer.endpoint,
+          defaultServer,
           session1.id,
         );
         sinon.assert.calledWith(
           colabClientStub.deleteSession,
-          defaultServer.endpoint,
+          defaultServer,
           session2.id,
         );
       });


### PR DESCRIPTION
These initial calls went in when we were developing against local instances of Colab. Now that we've got auth sorted and are using _real_ Colab, it's clear we need to issue requests directly to the server, not the Colab tunnel.

I've manually tested both unassigning a server and verifying that listing kernels for the keep-alive calls works as expected (though keep-alive is still not working since we needed to allow-list that endpoint, which is done but not rolled out).