### PR TITLE
test: run a larger headless screen resolution

### DIFF
--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -115,7 +115,7 @@ build_test_cmd() {
 run_tests() {
   if [[ "$HEADLESS" -eq 1 ]]; then
     echo "🏃 Running tests in headless mode..." >&2
-    xvfb-run -a -s '-screen 0 1024x768x24' "$@"
+    xvfb-run -a -s '-screen 0 1920x1080x24' "$@"
   else
     echo "🏃 Running tests..." >&2
     "$@"


### PR DESCRIPTION
The existing size cuts off some of the browser in the event of OAuth failure screenshots.