### PR TITLE
fix: specify client agent header in Colab requests

### DIFF
--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -24,6 +24,7 @@ import {
 import {
   ACCEPT_JSON_HEADER,
   AUTHORIZATION_HEADER,
+  COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
   COLAB_TUNNEL_HEADER,
   COLAB_XSRF_TOKEN_HEADER,
@@ -338,6 +339,10 @@ export class ColabClient {
     const requestHeaders = new Headers(init.headers);
     requestHeaders.set(ACCEPT_JSON_HEADER.key, ACCEPT_JSON_HEADER.value);
     requestHeaders.set(AUTHORIZATION_HEADER.key, `Bearer ${token}`);
+    requestHeaders.set(
+      COLAB_CLIENT_AGENT_HEADER.key,
+      COLAB_CLIENT_AGENT_HEADER.value,
+    );
     const request = new Request(endpoint, {
       ...init,
       headers: requestHeaders,

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -21,6 +21,7 @@ import { ColabClient, TooManyAssignmentsError } from "./client";
 import {
   ACCEPT_JSON_HEADER,
   AUTHORIZATION_HEADER,
+  COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
   COLAB_TUNNEL_HEADER,
   COLAB_XSRF_TOKEN_HEADER,
@@ -725,6 +726,12 @@ export function urlMatcher(expected: URLMatchOptions): SinonMatcher {
     if (actualAccept !== ACCEPT_JSON_HEADER.value) {
       reasons.push(
         `Accept header is "${actualAccept ?? ""}", expected "${ACCEPT_JSON_HEADER.value}"`,
+      );
+    }
+    const actualClientAgent = headers.get(COLAB_CLIENT_AGENT_HEADER.key);
+    if (actualClientAgent !== COLAB_CLIENT_AGENT_HEADER.value) {
+      reasons.push(
+        `Client-Agent header is "${actualClientAgent ?? ""}", expected "${COLAB_CLIENT_AGENT_HEADER.value}"`,
       );
     }
     if (expected.otherHeaders) {


### PR DESCRIPTION
Today, we set the header only on the assigned server requests, but not the ones to the Colab APIs. This change globally sets it for all outbound requests.