### PR TITLE
test: check the loopback server response in the e2e test

### DIFF
--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -217,8 +217,14 @@ describe("Colab Extension", function () {
       );
       await continueButton.click();
 
-      // The test account should be authenticated. Close the browser window.
+      // Check that the test account's authenticated. Close the browser window.
       await oauthDriver.wait(until.urlContains("127.0.0.1"), ELEMENT_WAIT_MS);
+      const body = await oauthDriver.findElement(By.css("body"));
+      assert.equal(
+        await body.getText(),
+        "You may now return to the application.",
+        "Unexpected loopback server response.",
+      );
       await oauthDriver.quit();
     } catch (_) {
       // If the OAuth flow fails, ensure we grab a screenshot for debugging.


### PR DESCRIPTION
Checks the response we get back from the loopback server.

Why? We encountered a test failure where navigation was blocked, and this was not obvious during debugging. So, we add an assertion here to catch an unexpected response.