### PR TITLE
chore: update .vscodeignore file post migration

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,8 +7,8 @@
 .vscode/
 cspell.config.yaml
 docs/
-esbuild.config.mjs
-eslint.config.mjs
+esbuild.config.mts
+eslint.config.mts
 node_modules/
 out/**/*.map
 out/test/
@@ -16,3 +16,4 @@ project-words.txt
 scripts/
 src/
 tsconfig*.json
+tsdoc.json


### PR DESCRIPTION
Forgot to update the ignore file following the license header changes and migrating `mjs` to `mts`.