### PR TITLE
chore: make events consistently readonly

### DIFF
--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -55,7 +55,7 @@ export class AssignmentManager implements vscode.Disposable {
   /**
    * Event that fires when the server assignments change.
    */
-  onDidAssignmentsChange: vscode.Event<AssignmentChangeEvent>;
+  readonly onDidAssignmentsChange: vscode.Event<AssignmentChangeEvent>;
 
   private readonly assignmentChange: vscode.EventEmitter<AssignmentChangeEvent>;
   private readonly disposables: vscode.Disposable[] = [];

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -40,7 +40,7 @@ export class ColabJupyterServerProvider
     JupyterServerCommandProvider,
     vscode.Disposable
 {
-  onDidChangeServers: vscode.Event<void>;
+  readonly onDidChangeServers: vscode.Event<void>;
 
   private readonly serverCollection: JupyterServerCollection;
   private readonly serverChangeEmitter: vscode.EventEmitter<void>;

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -102,7 +102,9 @@ describe("ColabJupyterServerProvider", () => {
       },
     );
     assignmentStub = sinon.createStubInstance(AssignmentManager);
-    assignmentStub.onDidAssignmentsChange = sinon.stub();
+    Object.defineProperty(assignmentStub, "onDidAssignmentsChange", {
+      value: sinon.stub(),
+    });
     colabClientStub = sinon.createStubInstance(ColabClient);
     serverPickerStub = sinon.createStubInstance(ServerPicker);
 


### PR DESCRIPTION
In cases where we need to stub out the event, it requires the nasty `Object.defineProperty`... I don't love that, but short of adding test seams (which I hate more) or building out a more involved mock/test object (juice is not worth the squeeze with a single caller), it feels like a reasonable sacrifice.