### PR TITLE
build: typecheck during lint job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,6 +67,7 @@ jobs:
           path: src
       - run: npm run lint
       - run: npm run format:check
+      - run: npm run typecheck
       # While spell check runs in lint, here we run it as a separate step to
       # make it easier to see the results and treat violations as errors
       # instead of warnings.


### PR DESCRIPTION
Before this change, we'd only get typecheck errors during integration and e2e tests which run the full `build`.