### PR TITLE
refactor: separate the listed assignment from GET

### DIFF
--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -19,7 +19,6 @@ import {
   CcuInfoSchema,
   AssignmentSchema,
   GetAssignmentResponseSchema,
-  AssignmentsSchema,
   KernelSchema,
   Kernel,
   SessionSchema,
@@ -29,6 +28,8 @@ import {
   PostAssignmentResponse,
   Outcome,
   PostAssignmentResponseSchema,
+  ListedAssignmentsSchema,
+  ListedAssignment,
 } from "./api";
 import {
   ACCEPT_JSON_HEADER,
@@ -201,11 +202,11 @@ export class ColabClient {
    *
    * @returns The list of assignments.
    */
-  async listAssignments(signal?: AbortSignal): Promise<Assignment[]> {
+  async listAssignments(signal?: AbortSignal): Promise<ListedAssignment[]> {
     const assignments = await this.issueRequest(
       new URL(`${TUN_ENDPOINT}/assignments`, this.colabDomain),
       { method: "GET", signal },
-      AssignmentsSchema,
+      ListedAssignmentsSchema,
     );
     return assignments.assignments;
   }

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -23,6 +23,7 @@ import {
   Kernel,
   Session,
   Outcome,
+  ListedAssignments,
 } from "./api";
 import {
   ColabClient,
@@ -57,18 +58,22 @@ const DEFAULT_ASSIGNMENT_RESPONSE = {
     url: "https://mock-url.com",
   },
 };
-const { fit, runtimeProxyInfo, sub, subTier, ...rest } =
-  DEFAULT_ASSIGNMENT_RESPONSE;
-const { tokenExpiresInSeconds, ...rpRest } = runtimeProxyInfo;
+const DEFAULT_LIST_ASSIGNMENTS_RESPONSE: ListedAssignments = {
+  assignments: [
+    {
+      accelerator: DEFAULT_ASSIGNMENT_RESPONSE.accelerator,
+      endpoint: DEFAULT_ASSIGNMENT_RESPONSE.endpoint,
+      variant: DEFAULT_ASSIGNMENT_RESPONSE.variant,
+      machineShape: DEFAULT_ASSIGNMENT_RESPONSE.machineShape,
+    },
+  ],
+};
+const { fit, sub, subTier, ...rest } = DEFAULT_ASSIGNMENT_RESPONSE;
 const DEFAULT_ASSIGNMENT: Assignment = {
   ...rest,
   idleTimeoutSec: fit,
   subscriptionState: sub,
   subscriptionTier: subTier,
-  runtimeProxyInfo: {
-    ...rpRest,
-    expirySec: tokenExpiresInSeconds,
-  },
 };
 
 describe("ColabClient", () => {
@@ -387,18 +392,16 @@ describe("ColabClient", () => {
       )
       .resolves(
         new Response(
-          withXSSI(
-            JSON.stringify({ assignments: [DEFAULT_ASSIGNMENT_RESPONSE] }),
-          ),
+          withXSSI(JSON.stringify(DEFAULT_LIST_ASSIGNMENTS_RESPONSE)),
           {
             status: 200,
           },
         ),
       );
 
-    await expect(client.listAssignments()).to.eventually.deep.equal([
-      DEFAULT_ASSIGNMENT,
-    ]);
+    await expect(client.listAssignments()).to.eventually.deep.equal(
+      DEFAULT_LIST_ASSIGNMENTS_RESPONSE.assignments,
+    );
 
     sinon.assert.calledOnce(fetchStub);
   });

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -304,10 +304,7 @@ export class AssignmentManager implements vscode.Disposable {
     server: ColabJupyterServer,
     assignment: Assignment,
   ): ColabAssignedServer {
-    const { url, token } = assignment.runtimeProxyInfo ?? {};
-    if (!url || !token) {
-      throw new Error("Unable to obtain connection information for server.");
-    }
+    const { url, token } = assignment.runtimeProxyInfo;
     const headers: Record<string, string> =
       server.connectionInformation?.headers ?? {};
     headers[COLAB_RUNTIME_PROXY_TOKEN_HEADER.key] = token;

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -55,7 +55,7 @@ const defaultAssignment: Assignment & { runtimeProxyInfo: RuntimeProxyInfo } = {
   machineShape: Shape.STANDARD,
   runtimeProxyInfo: {
     token: "mock-token",
-    expirySec: 42,
+    tokenExpiresInSeconds: 42,
     url: "https://example.com",
   },
 };
@@ -421,26 +421,6 @@ describe("AssignmentManager", () => {
   });
 
   describe("assignServer", () => {
-    it("throws an error when the assignment does not include runtime proxy info", () => {
-      colabClientStub.assign
-        .withArgs(
-          sinon.match(isUUID),
-          defaultAssignment.variant,
-          defaultAssignment.accelerator,
-        )
-        .resolves({
-          assignment: { ...defaultAssignment, runtimeProxyInfo: undefined },
-          isNew: false,
-        });
-
-      expect(
-        assignmentManager.assignServer(
-          randomUUID(),
-          defaultAssignmentDescriptor,
-        ),
-      ).to.be.rejectedWith(/connection info/);
-    });
-
     it("throws an error when the assignment does not include a URL to connect to", () => {
       colabClientStub.assign
         .withArgs(


### PR DESCRIPTION
Cleans up the API across call sites and better reflects what's
available.