### PR TITLE
test: block on notebook load before using it

### DIFF
--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -52,20 +52,9 @@ describe("Colab Extension", function () {
       // Create an executable notebook. Note that it's created with a single
       // code cell by default.
       await workbench.executeCommand("Create: New Jupyter Notebook");
-
       // Wait for the notebook editor to finish loading before we interact with
       // it.
-      await driver.wait(
-        async () => {
-          const editors = await driver.findElements(
-            By.className("notebook-editor"),
-          );
-          return editors.length > 0;
-        },
-        ELEMENT_WAIT_MS,
-        "Notebook editor did not load in time",
-      );
-
+      await notebookLoaded(driver);
       await workbench.executeCommand("Notebook: Edit Cell");
       const cell = await driver.switchTo().activeElement();
       await cell.sendKeys("1 + 1");
@@ -270,4 +259,17 @@ function getOAuthDriver(): Promise<WebDriver> {
       new chrome.Options().addArguments(...authDriverArgs) as chrome.Options,
     )
     .build();
+}
+
+async function notebookLoaded(driver: WebDriver): Promise<void> {
+  await driver.wait(
+    async () => {
+      const editors = await driver.findElements(
+        By.className("notebook-editor"),
+      );
+      return editors.length > 0;
+    },
+    ELEMENT_WAIT_MS,
+    "Notebook editor did not load in time",
+  );
 }


### PR DESCRIPTION
I've hit a few flakes on the _Notebook: Edit Cell_ command where we get
`element not interactable` errors. I believe it's because during
notebook load we immediately start to run the _edit cell_ command so
there's a race.