### PR TITLE
feat: show progress notification when removing server

### DIFF
--- a/src/colab/commands/server.ts
+++ b/src/colab/commands/server.ts
@@ -63,7 +63,6 @@ export async function renameServerAlias(
 // TODO: Consider making this multi-select.
 // TODO: Handle bug where, if the server of the connected kernel is
 // removed, a fallback kernel is selected but does not connect.
-// TODO: Consider adding a notification that the server was removed.
 // TODO: Update MultiStepInput to handle a single-step case.
 export async function removeServer(
   vs: typeof vscode,
@@ -83,7 +82,14 @@ export async function removeServer(
         items: servers.map((s) => ({ label: s.label, value: s })),
       })
     ).value;
-    await assignmentManager.unassignServer(selectedServer);
+    await vs.window.withProgress(
+      {
+        cancellable: false,
+        location: vs.ProgressLocation.Notification,
+        title: `Removing server "${selectedServer.label}"...`,
+      },
+      () => assignmentManager.unassignServer(selectedServer),
+    );
     return undefined;
   });
 }

--- a/src/colab/commands/server.unit.test.ts
+++ b/src/colab/commands/server.unit.test.ts
@@ -209,6 +209,30 @@ describe("Server Commands", () => {
           defaultServer,
         );
       });
+
+      it("notifies the user while removing the server", async () => {
+        assignmentManagerStub.getAssignedServers.resolves([defaultServer]);
+
+        const remove = removeServer(
+          vsCodeStub.asVsCode(),
+          assignmentManagerStub,
+        );
+        await quickPickStub.nextShow();
+        quickPickStub.onDidChangeSelection.yield([
+          { label: defaultServer.label, value: defaultServer },
+        ]);
+
+        await expect(remove).to.eventually.be.fulfilled;
+        sinon.assert.calledWithMatch(
+          vsCodeStub.window.withProgress,
+          {
+            cancellable: false,
+            location: vsCodeStub.ProgressLocation.Notification,
+            title: `Removing server "${defaultServer.label}"...`,
+          },
+          sinon.match.func,
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Renders a progress notification when removing a server

why? to alert the user that the action's in progress (e.g., may not be obvious over slow network)

