### PR TITLE
fix: remove upper bound restriction for Jupyter

### DIFF
--- a/src/jupyter/jupyter-extension.ts
+++ b/src/jupyter/jupyter-extension.ts
@@ -9,9 +9,7 @@ import { satisfies as semVerSatisfies } from "semver";
 import vscode, { Extension } from "vscode";
 import { getPackageInfo } from "../config/package-info";
 
-// TODO: Remove the upper bound once VS Code / Jupyter resolve
-// https://github.com/microsoft/vscode/issues/270285.
-const JUPYTER_SEMVER_RANGE = ">=2025.0.0 <2025.9.0";
+const JUPYTER_SEMVER_RANGE = ">=2025.0.0";
 
 /**
  * Get the exported API from the Jupyter extension.

--- a/src/jupyter/jupyter-extension.unit.test.ts
+++ b/src/jupyter/jupyter-extension.unit.test.ts
@@ -76,22 +76,6 @@ describe("Jupyter Extension", () => {
       sinon.assert.notCalled(activateStub);
     });
 
-    // TODO: Remove the upper bound once VS Code / Jupyter resolve
-    // https://github.com/microsoft/vscode/issues/270285.
-    it("rejects if the Jupyter extension version is too high", async () => {
-      const ext = getJupyterExtension();
-      vsCodeStub.extensions.getExtension.returns({
-        ...ext,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        packageJSON: { ...ext.packageJSON, version: "2023.9.0" },
-      } as vscode.Extension<Jupyter>);
-
-      await expect(getJupyterApi(vsCodeStub.asVsCode())).to.be.rejectedWith(
-        /satisfy required version/,
-      );
-      sinon.assert.notCalled(activateStub);
-    });
-
     it("activates the extension if it is not active", async () => {
       const ext = getJupyterExtension(ExtensionStatus.Inactive);
       vsCodeStub.extensions.getExtension.returns(


### PR DESCRIPTION
Now that VS Code 1.105 is released, https://github.com/microsoft/vscode/issues/270285 is fixed. Keeping the lower bound check so that users are at least on modern Jupyter.