### PR TITLE
feat: add a logging module

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,32 @@
     "onNotebook:interactive"
   ],
   "contributes": {
+    "configuration": {
+      "title": "Colab",
+      "properties": {
+        "colab.logging.level": {
+          "type": "string",
+          "default": "info",
+          "enum": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug",
+            "trace"
+          ],
+          "enumDescriptions": [
+            "Nothing is logged.",
+            "Error logs only are logged.",
+            "Warning logs and higher (error) are logged.",
+            "Info logs and higher (warning and error) are logged.",
+            "Debug logs and higher (info, warning and error).",
+            "Trace logs and higher (debug, info, warning and error) are logged."
+          ],
+          "description": "Controls the verbosity of logs from the Colab extension. These can be found in the 'Colab' output channel."
+        }
+      }
+    },
     "authentication": [
       {
         "label": "Google",

--- a/src/common/logging/console.ts
+++ b/src/common/logging/console.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { buildTimestampLevelPrefix } from "./util";
+import { ActionableLogLevel, Logger, LogLevel } from ".";
+
+/**
+ * A logger that emits to the global {@link console}.
+ *
+ * Leans on the console's built-in rich formatting in the debug console.
+ */
+export class ConsoleLogger implements Logger {
+  error(msg: string, ...args: unknown[]): void {
+    this.log(LogLevel.Error, msg, ...args);
+  }
+  warn(msg: string, ...args: unknown[]): void {
+    this.log(LogLevel.Warning, msg, ...args);
+  }
+  info(msg: string, ...args: unknown[]): void {
+    this.log(LogLevel.Info, msg, ...args);
+  }
+  debug(msg: string, ...args: unknown[]): void {
+    this.log(LogLevel.Debug, msg, ...args);
+  }
+  trace(msg: string, ...args: unknown[]): void {
+    this.log(LogLevel.Trace, msg, ...args);
+  }
+
+  private log(
+    level: ActionableLogLevel,
+    msg: string,
+    ...args: unknown[]
+  ): void {
+    const prefix = buildTimestampLevelPrefix(level);
+    let consoleLog: typeof console.info;
+    switch (level) {
+      case LogLevel.Error:
+        consoleLog = console.error;
+        break;
+      case LogLevel.Warning:
+        consoleLog = console.warn;
+        break;
+      case LogLevel.Info:
+        consoleLog = console.info;
+        break;
+      case LogLevel.Debug:
+        consoleLog = console.debug;
+        break;
+      case LogLevel.Trace:
+        consoleLog = console.trace;
+        break;
+    }
+
+    consoleLog(`${prefix} ${msg}`, ...args);
+  }
+}

--- a/src/common/logging/index.ts
+++ b/src/common/logging/index.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from "vscode";
+import { Disposable, ExtensionMode } from "vscode";
+import { ConsoleLogger } from "./console";
+import { OutputChannelLogger } from "./output-channel";
+
+/**
+ * Supports logging a message at varying severity levels.
+ */
+export interface Logger {
+  error(msg: string, ...args: unknown[]): void;
+  warn(msg: string, ...args: unknown[]): void;
+  info(msg: string, ...args: unknown[]): void;
+  debug(msg: string, ...args: unknown[]): void;
+  trace(msg: string, ...args: unknown[]): void;
+}
+
+/**
+ * The various log levels.
+ */
+export enum LogLevel {
+  /** Nothing is logged. */
+  Off = 0,
+  /** Trace logs and higher (debug, info, warning, error). */
+  Trace = 1,
+  /** Debug logs and higher (info, warning, error). */
+  Debug = 2,
+  /** Info logs and higher (warning, error). */
+  Info = 3,
+  /** Warning logs and higher (error). */
+  Warning = 4,
+  /** Error logs. */
+  Error = 5,
+}
+
+/**
+ * The various log levels which emit logs.
+ */
+export type ActionableLogLevel = Exclude<LogLevel, LogLevel.Off>;
+
+/** The configured log level. */
+let level: LogLevel = LogLevel.Info;
+
+const loggers: Logger[] = [];
+
+export function initializeLogger(
+  vs: typeof vscode,
+  mode: ExtensionMode,
+): Disposable {
+  if (loggers.length > 0) {
+    throw new Error("Loggers have already been initialized.");
+  }
+
+  level = getConfiguredLogLevel(vs);
+  const configListener = vs.workspace.onDidChangeConfiguration((e) => {
+    if (e.affectsConfiguration("colab.logging")) {
+      level = getConfiguredLogLevel(vs);
+    }
+  });
+
+  // Create the output channel once.
+  const outputChannel = vs.window.createOutputChannel("Colab");
+  loggers.push(new OutputChannelLogger(outputChannel));
+
+  if (mode === vs.ExtensionMode.Development) {
+    outputChannel.show(true);
+    loggers.push(new ConsoleLogger());
+  }
+
+  return {
+    dispose: () => {
+      configListener.dispose();
+      outputChannel.dispose();
+      loggers.length = 0;
+    },
+  };
+}
+
+/**
+ * The global logger instance.
+ *
+ * Can be used directly after calling `initializeLogger()`.
+ */
+export const log: Logger = {
+  error: (msg: string, ...args: unknown[]) => {
+    doLog(LogLevel.Error, "error", msg, ...args);
+  },
+  warn: (msg: string, ...args: unknown[]) => {
+    doLog(LogLevel.Warning, "warn", msg, ...args);
+  },
+  info: (msg: string, ...args: unknown[]) => {
+    doLog(LogLevel.Info, "info", msg, ...args);
+  },
+  debug: (msg: string, ...args: unknown[]) => {
+    doLog(LogLevel.Debug, "debug", msg, ...args);
+  },
+  trace: (msg: string, ...args: unknown[]) => {
+    doLog(LogLevel.Trace, "trace", msg, ...args);
+  },
+};
+
+function doLog(
+  threshold: LogLevel,
+  method: keyof Logger,
+  msg: string,
+  ...args: unknown[]
+): void {
+  if (loggers.length === 0) {
+    throw new Error(
+      "Logger not initialized. Call initializeLogger() before logging.",
+    );
+  }
+  if (level === LogLevel.Off || level > threshold) {
+    return;
+  }
+  for (const l of loggers) {
+    l[method](msg, ...args);
+  }
+}
+
+const LOG_CONFIG_TO_LEVEL: Record<
+  Lowercase<keyof typeof LogLevel>,
+  LogLevel
+> = {
+  off: LogLevel.Off,
+  trace: LogLevel.Trace,
+  debug: LogLevel.Debug,
+  info: LogLevel.Info,
+  warning: LogLevel.Warning,
+  error: LogLevel.Error,
+};
+
+function getConfiguredLogLevel(vs: typeof vscode): LogLevel {
+  const configLevel = vs.workspace
+    .getConfiguration("colab.logging")
+    .get<Lowercase<keyof typeof LogLevel>>("level", "info");
+
+  return LOG_CONFIG_TO_LEVEL[configLevel];
+}

--- a/src/common/logging/logging.unit.test.ts
+++ b/src/common/logging/logging.unit.test.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from "chai";
+import sinon, { SinonFakeTimers, SinonStubbedInstance } from "sinon";
+import {
+  ConfigurationChangeEvent,
+  WorkspaceConfiguration,
+  Disposable,
+  ConfigurationScope,
+} from "vscode";
+import { TestEventEmitter } from "../../test/helpers/events";
+import { FakeLogOutputChannel } from "../../test/helpers/output-channel";
+import { newVsCodeStub, VsCodeStub } from "../../test/helpers/vscode";
+import { initializeLogger, log, LogLevel } from ".";
+
+const TEST_ISO_TIME = "1994-08-24T14:34:00.010Z";
+const TEST_DATE = new Date(TEST_ISO_TIME);
+
+describe("Logging Module", () => {
+  let fakeClock: SinonFakeTimers;
+  let consoleStub: SinonStubbedInstance<Console>;
+  let logSink: FakeLogOutputChannel;
+  let configChangeEmitter: TestEventEmitter<ConfigurationChangeEvent>;
+  let logging: Disposable | undefined;
+  let logLevel: Lowercase<keyof typeof LogLevel> = "info";
+  let vs: VsCodeStub;
+
+  beforeEach(() => {
+    fakeClock = sinon.useFakeTimers({ now: TEST_DATE, toFake: [] });
+    vs = newVsCodeStub();
+    logSink = new FakeLogOutputChannel();
+    (vs.window.createOutputChannel as sinon.SinonStub).returns(logSink);
+    vs.workspace.getConfiguration.withArgs("colab.logging").returns({
+      get: () => logLevel,
+    } as Pick<WorkspaceConfiguration, "get"> as WorkspaceConfiguration);
+    consoleStub = sinon.stub(console);
+    configChangeEmitter = new TestEventEmitter<ConfigurationChangeEvent>();
+    vs.workspace.onDidChangeConfiguration.callsFake(configChangeEmitter.event);
+  });
+
+  afterEach(() => {
+    logging?.dispose();
+    fakeClock.restore();
+    sinon.restore();
+  });
+
+  describe("lifecycle", () => {
+    it("throws if doubly initialized", () => {
+      logging = initializeLogger(vs.asVsCode(), vs.ExtensionMode.Production);
+
+      expect(() =>
+        initializeLogger(vs.asVsCode(), vs.ExtensionMode.Production),
+      ).to.throw(/already/);
+    });
+
+    it("throws if used before being initialized", () => {
+      expect(() => {
+        log.info("test");
+      }).to.throw(
+        "Logger not initialized. Call initializeLogger() before logging.",
+      );
+    });
+
+    it("disposes config listener and output channel when disposed", () => {
+      logging = initializeLogger(vs.asVsCode(), vs.ExtensionMode.Production);
+
+      logging.dispose();
+
+      expect(configChangeEmitter.hasListeners()).to.be.false;
+      sinon.assert.calledOnce(logSink.dispose);
+    });
+  });
+
+  describe("in dev mode", () => {
+    beforeEach(() => {
+      logging = initializeLogger(vs.asVsCode(), vs.ExtensionMode.Development);
+    });
+
+    it("logs to console", () => {
+      log.info("test");
+
+      sinon.assert.calledOnce(consoleStub.info);
+    });
+
+    it("focuses output channel", () => {
+      sinon.assert.calledOnceWithMatch(logSink.show);
+    });
+  });
+
+  describe("logs", () => {
+    it("each of the log levels", () => {
+      logLevel = "trace";
+      logging = initializeLogger(vs.asVsCode(), vs.ExtensionMode.Production);
+
+      log.error("error");
+      log.warn("warn");
+      log.info("info");
+      log.debug("debug");
+      log.trace("trace");
+
+      expect(logSink.content).to.equal(
+        `
+[${TEST_ISO_TIME}] [Error] error
+[${TEST_ISO_TIME}] [Warning] warn
+[${TEST_ISO_TIME}] [Info] info
+[${TEST_ISO_TIME}] [Debug] debug
+[${TEST_ISO_TIME}] [Trace] trace
+      `.trim(),
+      );
+    });
+
+    it("only logs messages at or above the configured level", () => {
+      logLevel = "warning";
+      logging = initializeLogger(vs.asVsCode(), vs.ExtensionMode.Production);
+
+      log.error("error");
+      log.warn("warn");
+      log.info("info");
+      log.debug("debug");
+      log.trace("trace");
+
+      expect(logSink.content).to.equal(
+        `
+[${TEST_ISO_TIME}] [Error] error
+[${TEST_ISO_TIME}] [Warning] warn
+      `.trim(),
+      );
+    });
+
+    it("respects logging level configuration changes", () => {
+      logLevel = "info";
+      logging = initializeLogger(vs.asVsCode(), vs.ExtensionMode.Production);
+      log.info("first info");
+
+      logLevel = "error";
+
+      const s: sinon.SinonStub<[string, ConfigurationScope], boolean> =
+        sinon.stub();
+      s.withArgs("colab.logging").returns(true);
+      configChangeEmitter.fire({ affectsConfiguration: s });
+      log.info("second info");
+      log.error("first error");
+
+      expect(logSink.content).to.equal(
+        `
+[${TEST_ISO_TIME}] [Info] first info
+[${TEST_ISO_TIME}] [Error] first error
+      `.trim(),
+      );
+    });
+  });
+});

--- a/src/common/logging/output-channel.ts
+++ b/src/common/logging/output-channel.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OutputChannel } from "vscode";
+import { buildTimestampLevelPrefix } from "./util";
+import { ActionableLogLevel, Logger, LogLevel } from ".";
+
+/**
+ * A logger that appends to the provided VS Code {@link OutputChannel}.
+ */
+export class OutputChannelLogger implements Logger {
+  constructor(private readonly channel: OutputChannel) {}
+
+  error(msg: string, ...args: unknown[]): void {
+    this.log(LogLevel.Error, msg, ...args);
+  }
+  warn(msg: string, ...args: unknown[]): void {
+    this.log(LogLevel.Warning, msg, ...args);
+  }
+  info(msg: string, ...args: unknown[]): void {
+    this.log(LogLevel.Info, msg, ...args);
+  }
+  debug(msg: string, ...args: unknown[]): void {
+    this.log(LogLevel.Debug, msg, ...args);
+  }
+  // TODO: Consider implementing a trace decorator which logs the decorated
+  // function call, its args, the return value and optionally the execution
+  // time.
+  trace(msg: string, ...args: unknown[]): void {
+    this.log(LogLevel.Trace, msg, ...args);
+  }
+
+  private log(
+    level: ActionableLogLevel,
+    msg: string,
+    ...args: unknown[]
+  ): void {
+    this.channel.appendLine(format(level, msg, args));
+  }
+}
+
+function format(
+  level: ActionableLogLevel,
+  message: string,
+  args: unknown[],
+): string {
+  const prefix = buildTimestampLevelPrefix(level);
+  const padding = " ".repeat(prefix.length + 1);
+
+  let res = `${prefix} ${message}`;
+
+  for (const arg of args) {
+    let argsStr: string;
+
+    if (arg instanceof Error) {
+      argsStr = arg.stack ?? arg.message;
+    } else if (typeof arg === "object" && arg !== null) {
+      try {
+        argsStr = JSON.stringify(arg, null, 2);
+      } catch (_: unknown) {
+        argsStr = "[Unserializable Object]";
+      }
+    } else {
+      // Simply convert primitives to a string.
+      argsStr = String(arg);
+    }
+
+    res += `\n${padding}${argsStr.split("\n").join(`\n${padding}`)}`;
+  }
+
+  return res;
+}

--- a/src/common/logging/util.ts
+++ b/src/common/logging/util.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ActionableLogLevel, LogLevel } from ".";
+
+/**
+ * Builds a log prefix containing a timestamp and log level.
+ *
+ * @param level - The log level to include in the prefix.
+ * @returns The formatted prefix string, e.g.
+ *          "[2025-10-22T19:22:35.375Z] [Warning]".
+ */
+export function buildTimestampLevelPrefix(level: ActionableLogLevel): string {
+  const timestamp = new Date().toISOString();
+  const levelStr = getLogLevelString(level);
+  return `[${timestamp}] [${levelStr}]`;
+}
+
+const LOG_LEVEL_STRING_MAP: Record<ActionableLogLevel, string> = {
+  [LogLevel.Trace]: "Trace",
+  [LogLevel.Debug]: "Debug",
+  [LogLevel.Info]: "Info",
+  [LogLevel.Warning]: "Warning",
+  [LogLevel.Error]: "Error",
+};
+
+/**
+ * Gets the string representation for a {@link LogLevel}.
+ */
+function getLogLevelString(level: ActionableLogLevel): string {
+  return LOG_LEVEL_STRING_MAP[level];
+}

--- a/src/test/helpers/output-channel.ts
+++ b/src/test/helpers/output-channel.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as sinon from "sinon";
+import { OutputChannel } from "vscode";
+
+export class FakeLogOutputChannel implements OutputChannel {
+  readonly name = "fake";
+  readonly append = sinon.stub();
+  readonly appendLine = sinon.stub<[string]>();
+  readonly replace = sinon.stub();
+  readonly clear = sinon.stub();
+  readonly show = sinon.stub();
+  readonly hide = sinon.stub();
+  readonly dispose = sinon.stub();
+
+  private readonly lines: string[] = [];
+
+  constructor() {
+    this.appendLine.callsFake((line: string) => {
+      this.lines.push(line);
+    });
+  }
+
+  get content(): string {
+    return this.lines.join("\n");
+  }
+}

--- a/src/test/helpers/vscode.ts
+++ b/src/test/helpers/vscode.ts
@@ -25,6 +25,12 @@ enum UIKind {
   Web = 2,
 }
 
+export enum ExtensionMode {
+  Production = 1,
+  Development = 2,
+  Test = 3,
+}
+
 enum ProgressLocation {
   SourceControl = 1,
   Window = 10,
@@ -69,6 +75,9 @@ export interface VsCodeStub {
       typeof vscode.window.showErrorMessage
     >;
     showQuickPick: sinon.SinonStubbedMember<typeof vscode.window.showQuickPick>;
+    createOutputChannel: sinon.SinonStubbedMember<
+      typeof vscode.window.createOutputChannel
+    >;
     createInputBox: sinon.SinonStubbedMember<
       typeof vscode.window.createInputBox
     >;
@@ -76,6 +85,15 @@ export interface VsCodeStub {
       typeof vscode.window.createQuickPick
     >;
   };
+  workspace: {
+    getConfiguration: sinon.SinonStubbedMember<
+      typeof vscode.workspace.getConfiguration
+    >;
+    onDidChangeConfiguration: sinon.SinonStubbedMember<
+      typeof vscode.workspace.onDidChangeConfiguration
+    >;
+  };
+  ExtensionMode: typeof vscode.ExtensionMode;
   ProgressLocation: typeof ProgressLocation;
   QuickInputButtons: typeof TestQuickInputButtons;
   extensions: {
@@ -106,10 +124,17 @@ export function newVsCodeStub(): VsCodeStub {
         env: { ...this.env } as Partial<typeof vscode.env> as typeof vscode.env,
         window: {
           ...this.window,
-          // The unknown cast is necessary due to the complex overloading.
+          // The unknown casts are necessary due to the complex overloading.
+          /* eslint-disable @/max-len */
+          createOutputChannel: this.window
+            .createOutputChannel as unknown as typeof vscode.window.createOutputChannel,
+          /* eslint-enable @/max-len */
           showQuickPick: this.window
             .showQuickPick as unknown as typeof vscode.window.showQuickPick,
         } as Partial<typeof vscode.window> as typeof vscode.window,
+        workspace: this.workspace as Partial<
+          typeof vscode.workspace
+        > as typeof vscode.workspace,
         commands: { ...this.commands } as Partial<
           typeof vscode.commands
         > as typeof vscode.commands,
@@ -141,9 +166,15 @@ export function newVsCodeStub(): VsCodeStub {
       showWarningMessage: sinon.stub(),
       showErrorMessage: sinon.stub(),
       showQuickPick: sinon.stub(),
+      createOutputChannel: sinon.stub(),
       createInputBox: sinon.stub(),
       createQuickPick: sinon.stub(),
     },
+    workspace: {
+      getConfiguration: sinon.stub(),
+      onDidChangeConfiguration: sinon.stub(),
+    },
+    ExtensionMode: ExtensionMode,
     ProgressLocation: ProgressLocation,
     QuickInputButtons: TestQuickInputButtons,
     extensions: {


### PR DESCRIPTION
This adds an _Output_ channel for "Colab" and continues to log to console for dev builds. Subsequent PR(s) will utilize the module where we're currently using `console`.

The logging module exports a constant `log` object we can freely import and use throughout the rest of the codebase. In `activate`, we'll initialize it once and capture its `Disposable` so it's torn down when the extension is.

Users can configure the log level with a setting

<img width="960" height="407" alt="image" src="https://github.com/user-attachments/assets/997add94-f402-4fda-b764-47440971f2aa" />
