### PR TITLE
feat: capture the token expiry for a server

### DIFF
--- a/src/colab/api.ts
+++ b/src/colab/api.ts
@@ -267,7 +267,7 @@ export const RuntimeProxyInfoSchema = z.object({
   /** Token for the runtime proxy. */
   token: z.string(),
   /** Token expiration time in seconds. */
-  tokenExpiresInSeconds: z.number().optional(),
+  tokenExpiresInSeconds: z.number(),
   /** URL of the runtime proxy. */
   url: z.string(),
 });

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -450,6 +450,7 @@ describe("ColabClient", () => {
         connectionInformation: {
           baseUrl: TestUri.parse(assignedServerUrl.toString()),
           token: "123",
+          tokenExpiry: new Date(Date.now() + 1000 * 60 * 60),
         },
         dateAssigned: new Date(),
       };

--- a/src/colab/commands/server.unit.test.ts
+++ b/src/colab/commands/server.unit.test.ts
@@ -52,6 +52,7 @@ describe("Server Commands", () => {
       connectionInformation: {
         baseUrl: vsCodeStub.Uri.parse("https://example.com"),
         token: "123",
+        tokenExpiry: new Date(Date.now() + 1000 * 60 * 60),
         headers: { foo: "bar" },
       },
       dateAssigned: new Date(),

--- a/src/colab/keep-alive.unit.test.ts
+++ b/src/colab/keep-alive.unit.test.ts
@@ -76,6 +76,7 @@ describe("ServerKeepAliveController", () => {
       connectionInformation: {
         baseUrl: vsCodeStub.Uri.parse("https://example.com"),
         token: "123",
+        tokenExpiry: new Date(Date.now() + 1000 * 60 * 60),
         headers: {
           [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: "123",
           [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -412,6 +412,9 @@ export class AssignmentManager implements vscode.Disposable {
       connectionInformation: {
         baseUrl: this.vs.Uri.parse(url),
         token,
+        tokenExpiry: new Date(
+          Date.now() + connectionInfo.tokenExpiresInSeconds * 1000,
+        ),
         headers,
         fetch: colabProxyFetch(token),
       },

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -53,6 +53,7 @@ const DEFAULT_SERVER: ColabAssignedServer = {
   connectionInformation: {
     baseUrl: TestUri.parse("https://example.com"),
     token: "123",
+    tokenExpiry: new Date(Date.now() + 1000 * 60 * 60),
     headers: {
       [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: "123",
       [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,

--- a/src/jupyter/servers.ts
+++ b/src/jupyter/servers.ts
@@ -39,6 +39,7 @@ export type ColabAssignedServer = ColabJupyterServer & {
   readonly endpoint: string;
   readonly connectionInformation: JupyterServerConnectionInformation & {
     readonly token: string;
+    readonly tokenExpiry: Date;
   };
   readonly dateAssigned: Date;
 };

--- a/src/jupyter/storage.ts
+++ b/src/jupyter/storage.ts
@@ -26,6 +26,7 @@ const AssignedServers = z.array(
     connectionInformation: z.object({
       baseUrl: z.string().nonempty(),
       token: z.string().nonempty(),
+      tokenExpiry: z.coerce.date(),
       headers: z
         .record(z.string().nonempty(), z.string().nonempty())
         .optional(),
@@ -68,6 +69,7 @@ export class ServerStorage {
       connectionInformation: {
         baseUrl: this.vs.Uri.parse(server.connectionInformation.baseUrl),
         token: server.connectionInformation.token,
+        tokenExpiry: server.connectionInformation.tokenExpiry,
         headers: server.connectionInformation.headers,
       },
       dateAssigned: server.dateAssigned,
@@ -112,6 +114,7 @@ export class ServerStorage {
         connectionInformation: {
           baseUrl: server.connectionInformation.baseUrl.toString(),
           token: server.connectionInformation.token,
+          tokenExpiry: server.connectionInformation.tokenExpiry,
           headers: server.connectionInformation.headers,
         },
         dateAssigned,

--- a/src/jupyter/storage.unit.test.ts
+++ b/src/jupyter/storage.unit.test.ts
@@ -38,6 +38,7 @@ describe("ServerStorage", () => {
       connectionInformation: {
         baseUrl: vsCodeStub.Uri.parse("https://example.com"),
         token: "123",
+        tokenExpiry: new Date(DEFAULT_ASSIGNED_DATE.getTime() + 1000 * 60 * 60),
         headers: { foo: "bar" },
       },
       dateAssigned: DEFAULT_ASSIGNED_DATE,


### PR DESCRIPTION
A prerequisite to properly scheduling the connection refreshes.