### PR TITLE
feat: implement a generalized async toggle

### DIFF
--- a/src/common/toggleable.unit.test.ts
+++ b/src/common/toggleable.unit.test.ts
@@ -154,7 +154,7 @@ describe("AsyncToggleable", () => {
 
       await expect(toggleable.initializationComplete).to.eventually.be.rejected;
       // It should be treated as an abort, not an error
-      expect(logs.output).to.match(/Initialization aborted by error/);
+      expect(logs.output).to.match(/Initialization.+aborted/);
       expect(logs.output).to.not.match(/Unable to initialize/);
     });
   });


### PR DESCRIPTION
To support toggling while authorized (reacting to a synchronous event), turning `on` asynchronously is a bit of a challenge. This abstract class solve that problem generically. This will be consumed in a downstream PR which refreshes the connection for servers.