### PR TITLE
fix: keep long-running executions alive in Colab

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -1,4 +1,5 @@
 authuser
+autorestarting
 chromedriver
 colab
 extest


### PR DESCRIPTION
Since we were just looking at `lastActivity` and not considering the `executionState`, a cell which takes a long time to execute (e.g. 3 hour model training) would be in "busy" state with a `lastActivity` that would cause the keep-alive check to think it's stale.

Test diff looks a lot bigger than it is. I had most of the tests incorrectly nested in the `lifecycle` block.