### PR TITLE
test: upload output logs as workflow artifact

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -163,7 +163,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: exthost log
+          name: exthost_log
           path: /tmp/test-resources/settings/logs/*/window1/exthost/exthost.log
       - name: upload output logs
         if: failure()


### PR DESCRIPTION
When the e2e test fails, uploads the outputs logs as artifacts

See [this workflow run](http://github.com/googlecolab/colab-vscode/actions/runs/19049133116/job/54404751510) as an example