### PR TITLE
fix: properly generate the auth-success URL for non-code installs

### DIFF
--- a/src/auth/flows/flows.ts
+++ b/src/auth/flows/flows.ts
@@ -9,6 +9,7 @@ import { CodeChallengeMethod, GenerateAuthUrlOpts } from "google-auth-library";
 import { OAuth2Client } from "google-auth-library";
 import vscode from "vscode";
 import { PackageInfo } from "../../config/package-info";
+import { buildExtensionUri } from "../../system/uri";
 import { LocalServerFlow } from "./loopback";
 import { ProxiedRedirectFlow } from "./proxied";
 
@@ -59,12 +60,18 @@ export function getOAuth2Flows(
   packageInfo: PackageInfo,
   oAuth2Client: OAuth2Client,
 ): OAuth2Flow[] {
+  const extensionUri = buildExtensionUri(vs, packageInfo);
   const flows: OAuth2Flow[] = [];
   if (vs.env.uiKind === vs.UIKind.Desktop) {
     flows.push(
-      new LocalServerFlow(vs, path.join(__dirname, "auth/media"), oAuth2Client),
+      new LocalServerFlow(
+        vs,
+        path.join(__dirname, "auth/media"),
+        oAuth2Client,
+        extensionUri,
+      ),
     );
   }
-  flows.push(new ProxiedRedirectFlow(vs, packageInfo, oAuth2Client));
+  flows.push(new ProxiedRedirectFlow(vs, oAuth2Client, extensionUri));
   return flows;
 }

--- a/src/auth/flows/loopback.ts
+++ b/src/auth/flows/loopback.ts
@@ -42,8 +42,14 @@ export class LocalServerFlow implements OAuth2Flow, vscode.Disposable {
     private readonly vs: typeof vscode,
     private readonly serveRoot: string,
     private readonly oAuth2Client: OAuth2Client,
+    extensionUri: string,
   ) {
-    this.handler = new Handler(vs, this.serveRoot, this.codeManager);
+    this.handler = new Handler(
+      vs,
+      this.serveRoot,
+      this.codeManager,
+      extensionUri,
+    );
   }
 
   dispose() {
@@ -98,6 +104,7 @@ class Handler implements LoopbackHandler {
     private readonly vs: typeof vscode,
     private readonly serveRoot: string,
     private readonly codeProvider: CodeManager,
+    private readonly extensionUri: string,
   ) {}
 
   handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
@@ -145,7 +152,7 @@ class Handler implements LoopbackHandler {
 
   async redirectSuccessfulAuth(res: http.ServerResponse): Promise<void> {
     const authSuccessUri = await this.vs.env.asExternalUri(
-      this.vs.Uri.parse("vscode://google.colab/auth-success"),
+      this.vs.Uri.parse(`${this.extensionUri}/auth-success`),
     );
     const successState = encodeURIComponent(authSuccessUri.toString());
     const redirectUri = `${CONFIG.ColabApiDomain}/vscode/auth-success?state=${successState}`;

--- a/src/auth/flows/loopback.unit.test.ts
+++ b/src/auth/flows/loopback.unit.test.ts
@@ -53,7 +53,12 @@ describe("LocalServerFlow", () => {
       pkceChallenge: "1 + 1 = ?",
     };
     resStub = sinon.createStubInstance(http.ServerResponse);
-    flow = new LocalServerFlow(vs.asVsCode(), "out/test/media", oauth2Client);
+    flow = new LocalServerFlow(
+      vs.asVsCode(),
+      "out/test/media",
+      oauth2Client,
+      "vscode://google.colab",
+    );
   });
 
   afterEach(() => {

--- a/src/auth/flows/proxied.ts
+++ b/src/auth/flows/proxied.ts
@@ -11,7 +11,6 @@ import {
   MultiStepInput,
   InputFlowAction,
 } from "../../common/multi-step-quickpick";
-import { PackageInfo } from "../../config/package-info";
 import { CodeManager } from "../code-manager";
 import {
   DEFAULT_AUTH_URL_OPTS,
@@ -23,19 +22,13 @@ import {
 const PROXIED_REDIRECT_URI = `${CONFIG.ColabApiDomain}/vscode/redirect`;
 
 export class ProxiedRedirectFlow implements OAuth2Flow, vscode.Disposable {
-  private readonly baseUri: string;
   private readonly codeManager = new CodeManager();
 
   constructor(
     private readonly vs: typeof vscode,
-    private readonly packageInfo: PackageInfo,
     private readonly oAuth2Client: OAuth2Client,
-  ) {
-    const scheme = this.vs.env.uriScheme;
-    const pub = this.packageInfo.publisher;
-    const name = this.packageInfo.name;
-    this.baseUri = `${scheme}://${pub}.${name}`;
-  }
+    private readonly extensionUri: string,
+  ) {}
 
   dispose() {
     this.codeManager.dispose();
@@ -52,7 +45,7 @@ export class ProxiedRedirectFlow implements OAuth2Flow, vscode.Disposable {
         cancelTokenSource.token,
       );
       const vsCodeRedirectUri = this.vs.Uri.parse(
-        `${this.baseUri}?nonce=${options.nonce}`,
+        `${this.extensionUri}?nonce=${options.nonce}`,
       );
       const externalProxiedRedirectUri =
         await this.vs.env.asExternalUri(vsCodeRedirectUri);

--- a/src/auth/flows/proxied.unit.test.ts
+++ b/src/auth/flows/proxied.unit.test.ts
@@ -9,8 +9,7 @@ import { OAuth2Client } from "google-auth-library";
 import * as sinon from "sinon";
 import { InputBox } from "vscode";
 import { CONFIG } from "../../colab-config";
-import { PackageInfo } from "../../config/package-info";
-import { ExtensionUriHandler } from "../../system/uri-handler";
+import { ExtensionUriHandler } from "../../system/uri";
 import { TestCancellationTokenSource } from "../../test/helpers/cancellation";
 import {
   buildInputBoxStub,
@@ -21,11 +20,6 @@ import { newVsCodeStub, VsCodeStub } from "../../test/helpers/vscode";
 import { FlowResult, OAuth2TriggerOptions } from "./flows";
 import { ProxiedRedirectFlow } from "./proxied";
 
-const PACKAGE_INFO: PackageInfo = {
-  publisher: "google",
-  name: "colab",
-  version: "0.1.0",
-};
 const NONCE = "nonce";
 const CODE = "42";
 const EXTERNAL_CALLBACK_URI = `vscode://google.colab?nonce=${NONCE}&windowId=1`;
@@ -58,7 +52,11 @@ describe("ProxiedRedirectFlow", () => {
       scopes: SCOPES,
       pkceChallenge: "1 + 1 = ?",
     };
-    flow = new ProxiedRedirectFlow(vs.asVsCode(), PACKAGE_INFO, oauth2Client);
+    flow = new ProxiedRedirectFlow(
+      vs.asVsCode(),
+      oauth2Client,
+      "vscode://google.colab",
+    );
     vs.env.asExternalUri
       .withArgs(matchUri(/vscode:\/\/google\.colab\?nonce=nonce/))
       .resolves(vs.Uri.parse(EXTERNAL_CALLBACK_URI));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import { AssignmentManager } from "./jupyter/assignments";
 import { getJupyterApi } from "./jupyter/jupyter-extension";
 import { ColabJupyterServerProvider } from "./jupyter/provider";
 import { ServerStorage } from "./jupyter/storage";
-import { ExtensionUriHandler } from "./system/uri-handler";
+import { ExtensionUriHandler } from "./system/uri";
 
 // Called when the extension is activated.
 export async function activate(context: vscode.ExtensionContext) {

--- a/src/system/uri.ts
+++ b/src/system/uri.ts
@@ -5,6 +5,20 @@
  */
 
 import vscode from "vscode";
+import { PackageInfo } from "../config/package-info";
+
+/**
+ * Builds the extension URI that can be used to redirect users back to VS Code,
+ * to the extension's registered URI handler.
+ */
+export function buildExtensionUri(vs: typeof vscode, packageInfo: PackageInfo) {
+  {
+    const scheme = vs.env.uriScheme;
+    const pub = packageInfo.publisher;
+    const name = packageInfo.name;
+    return `${scheme}://${pub}.${name}`;
+  }
+}
 
 /**
  * A {@link vscode.UriHandler} for handling custom URI events within the

--- a/src/system/uri.unit.test.ts
+++ b/src/system/uri.unit.test.ts
@@ -4,11 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { expect } from "chai";
 import * as sinon from "sinon";
 import { Uri } from "vscode";
+import { PackageInfo } from "../config/package-info";
 import { TestUri } from "../test/helpers/uri";
 import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
-import { ExtensionUriHandler } from "./uri-handler";
+import { buildExtensionUri, ExtensionUriHandler } from "./uri";
+
+it("buildExtensionUri", () => {
+  const vs = newVsCodeStub();
+  vs.env.uriScheme = "vscode-insiders";
+  const packageInfo: PackageInfo = {
+    publisher: "google",
+    name: "colab",
+    version: "0.0.1",
+  };
+
+  expect(buildExtensionUri(vs.asVsCode(), packageInfo)).to.equal(
+    "vscode-insiders://google.colab",
+  );
+});
 
 describe("ExtensionUriHandler", () => {
   let vs: VsCodeStub;


### PR DESCRIPTION
This is needed for `code-insiders` or the VS Code derivative editors (e.g. Cursor).