### PR TITLE
chore: drive accelerators strictly from the API

### DIFF
--- a/src/colab/api.ts
+++ b/src/colab/api.ts
@@ -79,36 +79,6 @@ export enum Shape {
   // VERYHIGHMEM (2) is deprecated.
 }
 
-export enum Accelerator {
-  NONE = "NONE",
-  // GPU
-  // K80 is deprecated
-  // P100 is deprecated
-  // P4 is deprecated
-  T4 = "T4",
-  // V100 is deprecated
-  A100 = "A100",
-  L4 = "L4",
-  // TPU
-  V28 = "V28",
-  V5E1 = "V5E1",
-  V6E1 = "V6E1",
-}
-
-/**
- * Preprocess a native enum to get the enum value from a lower case string.
- *
- * @param enumObj - the native enum object schema to preprocess to.
- * @returns the zod effect to get the native enum from a lower case string.
- */
-function uppercaseEnum<T extends Record<string, string>>(
-  enumObj: T,
-): z.ZodType<T[keyof T]> {
-  return z
-    .string()
-    .transform((val) => val.toUpperCase())
-    .pipe(z.enum(Object.values(enumObj) as [T[keyof T], ...T[keyof T][]]));
-}
 /**
  * Normalize the similar but different representations of subscription tiers
  *
@@ -165,7 +135,7 @@ export const UserInfoSchema = z.object({
         /** The variant of the assignment. */
         variant: z.enum(ColabGapiVariant).transform(normalizeVariant),
         /** The assigned accelerator. */
-        models: z.array(z.enum(Accelerator)),
+        models: z.array(z.string().toUpperCase()),
       }),
     )
     .optional(),
@@ -191,17 +161,17 @@ export const CcuInfoSchema = z.object({
    */
   assignmentsCount: z.number(),
   /** The list of eligible GPU accelerators. */
-  eligibleGpus: z.array(uppercaseEnum(Accelerator)),
+  eligibleGpus: z.array(z.string().toUpperCase()),
   /** The list of ineligible GPU accelerators. */
-  ineligibleGpus: z.array(uppercaseEnum(Accelerator)).optional(),
+  ineligibleGpus: z.array(z.string().toUpperCase()).optional(),
   /**
    * The list of eligible TPU accelerators.
    */
-  eligibleTpus: z.array(uppercaseEnum(Accelerator)),
+  eligibleTpus: z.array(z.string().toUpperCase()),
   /**
    * The list of ineligible TPU accelerators.
    */
-  ineligibleTpus: z.array(uppercaseEnum(Accelerator)).optional(),
+  ineligibleTpus: z.array(z.string().toUpperCase()).optional(),
   /** Free CCU quota information if applicable. */
   freeCcuQuotaInfo: z
     .object({
@@ -239,7 +209,7 @@ export type CcuInfo = z.infer<typeof CcuInfoSchema>;
 export const GetAssignmentResponseSchema = z
   .object({
     /** The pool's accelerator. */
-    acc: uppercaseEnum(Accelerator),
+    acc: z.string().toUpperCase(),
     /** The notebook ID hash. */
     nbh: z.string(),
     /** Whether or not Recaptcha should prompt. */
@@ -276,7 +246,7 @@ export type RuntimeProxyInfo = z.infer<typeof RuntimeProxyInfoSchema>;
 /** The response when creating an assignment. */
 export const PostAssignmentResponseSchema = z.object({
   /** The assigned accelerator. */
-  accelerator: uppercaseEnum(Accelerator).optional(),
+  accelerator: z.string().toUpperCase().optional(),
   /** The endpoint URL. */
   endpoint: z.string().optional(),
   /** Frontend idle timeout in seconds. */

--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -15,7 +15,6 @@ import {
   Assignment,
   CcuInfo,
   Variant,
-  Accelerator,
   GetAssignmentResponse,
   CcuInfoSchema,
   AssignmentSchema,
@@ -120,7 +119,7 @@ export class ColabClient {
   async assign(
     notebookHash: UUID,
     variant: Variant,
-    accelerator?: Accelerator,
+    accelerator?: string,
     signal?: AbortSignal,
   ): Promise<{ assignment: Assignment; isNew: boolean }> {
     const assignment = await this.getAssignment(
@@ -352,7 +351,7 @@ export class ColabClient {
   private async getAssignment(
     notebookHash: UUID,
     variant: Variant,
-    accelerator?: Accelerator,
+    accelerator?: string,
     signal?: AbortSignal,
   ): Promise<AssignmentToken | AssignedAssignment> {
     const url = this.buildAssignUrl(notebookHash, variant, accelerator);
@@ -372,7 +371,7 @@ export class ColabClient {
     notebookHash: UUID,
     xsrfToken: string,
     variant: Variant,
-    accelerator?: Accelerator,
+    accelerator?: string,
     signal?: AbortSignal,
   ): Promise<PostAssignmentResponse> {
     const url = this.buildAssignUrl(notebookHash, variant, accelerator);
@@ -390,7 +389,7 @@ export class ColabClient {
   private buildAssignUrl(
     notebookHash: UUID,
     variant: Variant,
-    accelerator?: Accelerator,
+    accelerator?: string,
   ): URL {
     const url = new URL(`${TUN_ENDPOINT}/assign`, this.colabDomain);
     url.searchParams.append("nbh", uuidToWebSafeBase64(notebookHash));

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -13,7 +13,6 @@ import { ColabAssignedServer } from "../jupyter/servers";
 import { TestUri } from "../test/helpers/uri";
 import { uuidToWebSafeBase64 } from "../utils/uuid";
 import {
-  Accelerator,
   CcuInfo,
   Assignment,
   Shape,
@@ -46,7 +45,7 @@ const GOOGLE_APIS_HOST = "colab.example.googleapis.com";
 const BEARER_TOKEN = "access-token";
 const NOTEBOOK_HASH = randomUUID();
 const DEFAULT_ASSIGNMENT_RESPONSE = {
-  accelerator: Accelerator.A100,
+  accelerator: "A100",
   endpoint: "mock-server",
   fit: 30,
   sub: SubscriptionState.UNSUBSCRIBED,
@@ -100,9 +99,7 @@ describe("ColabClient", () => {
     const mockResponse = {
       subscriptionTier: "SUBSCRIPTION_TIER_NONE",
       paidComputeUnitsBalance: 0,
-      eligibleAccelerators: [
-        { variant: "VARIANT_GPU", models: [Accelerator.T4] },
-      ],
+      eligibleAccelerators: [{ variant: "VARIANT_GPU", models: ["T4"] }],
     };
     fetchStub
       .withArgs(
@@ -129,10 +126,10 @@ describe("ColabClient", () => {
       currentBalance: 1,
       consumptionRateHourly: 2,
       assignmentsCount: 3,
-      eligibleGpus: [Accelerator.T4],
-      ineligibleGpus: [Accelerator.A100, Accelerator.L4],
-      eligibleTpus: [Accelerator.V6E1, Accelerator.V28],
-      ineligibleTpus: [Accelerator.V5E1],
+      eligibleGpus: ["T4"],
+      ineligibleGpus: ["A100", "L4"],
+      eligibleTpus: ["V6E1", "V28"],
+      ineligibleTpus: ["V5E1"],
       freeCcuQuotaInfo: {
         remainingTokens: "4",
         nextRefillTimestampSec: 5,
@@ -193,7 +190,7 @@ describe("ColabClient", () => {
         );
 
       await expect(
-        client.assign(NOTEBOOK_HASH, Variant.GPU, Accelerator.A100),
+        client.assign(NOTEBOOK_HASH, Variant.GPU, "A100"),
       ).to.eventually.deep.equal({
         assignment: DEFAULT_ASSIGNMENT,
         isNew: false,
@@ -205,7 +202,7 @@ describe("ColabClient", () => {
     describe("without an existing assignment", () => {
       beforeEach(() => {
         const mockGetResponse = {
-          acc: Accelerator.NONE,
+          acc: "NONE",
           nbh: wireNbh,
           p: false,
           token: "mock-xsrf-token",
@@ -227,10 +224,10 @@ describe("ColabClient", () => {
           );
       });
 
-      const assignmentTests: [Variant, Accelerator?][] = [
+      const assignmentTests: [Variant, string?][] = [
         [Variant.DEFAULT, undefined],
-        [Variant.GPU, Accelerator.T4],
-        [Variant.TPU, Accelerator.V28],
+        [Variant.GPU, "T4"],
+        [Variant.TPU, "V28"],
       ];
       for (const [variant, accelerator] of assignmentTests) {
         const assignment = `${variant}${accelerator ? ` (${accelerator})` : ""}`;
@@ -248,7 +245,7 @@ describe("ColabClient", () => {
           const assignmentResponse = {
             ...DEFAULT_ASSIGNMENT_RESPONSE,
             variant,
-            accelerator: accelerator ?? Accelerator.NONE,
+            accelerator: accelerator ?? "NONE",
           };
           fetchStub
             .withArgs(
@@ -271,7 +268,7 @@ describe("ColabClient", () => {
           const expectedAssignment: Assignment = {
             ...DEFAULT_ASSIGNMENT,
             variant,
-            accelerator: accelerator ?? Accelerator.NONE,
+            accelerator: accelerator ?? "NONE",
           };
           await expect(
             client.assign(NOTEBOOK_HASH, variant, accelerator),
@@ -641,10 +638,10 @@ describe("ColabClient", () => {
       currentBalance: 1,
       consumptionRateHourly: 2,
       assignmentsCount: 3,
-      eligibleGpus: [Accelerator.T4],
-      ineligibleGpus: [Accelerator.A100, Accelerator.L4],
-      eligibleTpus: [Accelerator.V6E1, Accelerator.V28],
-      ineligibleTpus: [Accelerator.V5E1],
+      eligibleGpus: ["T4"],
+      ineligibleGpus: ["A100", "L4"],
+      eligibleTpus: ["V6E1", "V28"],
+      ineligibleTpus: ["V5E1"],
     };
     fetchStub
       .withArgs(
@@ -702,7 +699,7 @@ describe("ColabClient", () => {
     const mockResponse: Partial<CcuInfo> = {
       currentBalance: 1,
       consumptionRateHourly: 2,
-      eligibleGpus: [Accelerator.T4],
+      eligibleGpus: ["T4"],
     };
     fetchStub
       .withArgs(

--- a/src/colab/connection-refresher.unit.test.ts
+++ b/src/colab/connection-refresher.unit.test.ts
@@ -14,7 +14,7 @@ import {
 import { ColabAssignedServer } from "../jupyter/servers";
 import { TestEventEmitter } from "../test/helpers/events";
 import { TestUri } from "../test/helpers/uri";
-import { Accelerator, Variant } from "./api";
+import { Variant } from "./api";
 import { NotFoundError } from "./client";
 import {
   ConnectionRefreshController,
@@ -30,7 +30,7 @@ const DEFAULT_SERVER: ColabAssignedServer = {
   id: randomUUID(),
   label: "Colab GPU A100",
   variant: Variant.GPU,
-  accelerator: Accelerator.A100,
+  accelerator: "A100",
   endpoint: "m-s-foo",
   connectionInformation: {
     baseUrl: TestUri.parse("https://example.com"),

--- a/src/colab/consumption/poller.unit.test.ts
+++ b/src/colab/consumption/poller.unit.test.ts
@@ -12,7 +12,7 @@ import {
   createStubInstance,
 } from "sinon";
 import { newVsCodeStub, VsCodeStub } from "../../test/helpers/vscode";
-import { Accelerator, CcuInfo } from "../api";
+import { CcuInfo } from "../api";
 import { ColabClient } from "../client";
 import { ConsumptionPoller } from "./poller";
 
@@ -22,10 +22,10 @@ const DEFAULT_CCU_INFO: CcuInfo = {
   currentBalance: 1,
   consumptionRateHourly: 2,
   assignmentsCount: 3,
-  eligibleGpus: [Accelerator.T4],
-  ineligibleGpus: [Accelerator.A100, Accelerator.L4],
-  eligibleTpus: [Accelerator.V6E1, Accelerator.V28],
-  ineligibleTpus: [Accelerator.V5E1],
+  eligibleGpus: ["T4"],
+  ineligibleGpus: ["A100", "L4"],
+  eligibleTpus: ["V6E1", "V28"],
+  ineligibleTpus: ["V5E1"],
   freeCcuQuotaInfo: {
     remainingTokens: 4,
     nextRefillTimestampSec: 5,

--- a/src/colab/keep-alive.unit.test.ts
+++ b/src/colab/keep-alive.unit.test.ts
@@ -11,7 +11,7 @@ import { AssignmentManager } from "../jupyter/assignments";
 import { ColabAssignedServer } from "../jupyter/servers";
 import { TestCancellationTokenSource } from "../test/helpers/cancellation";
 import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
-import { Accelerator, Kernel, Variant } from "./api";
+import { Kernel, Variant } from "./api";
 import { ColabClient } from "./client";
 import {
   COLAB_CLIENT_AGENT_HEADER,
@@ -71,7 +71,7 @@ describe("ServerKeepAliveController", () => {
       id: randomUUID(),
       label: "Colab GPU A100",
       variant: Variant.GPU,
-      accelerator: Accelerator.A100,
+      accelerator: "A100",
       endpoint: "m-s-foo",
       connectionInformation: {
         baseUrl: vsCodeStub.Uri.parse("https://example.com"),

--- a/src/colab/server-picker.ts
+++ b/src/colab/server-picker.ts
@@ -8,7 +8,7 @@ import vscode, { QuickPickItem } from "vscode";
 import { InputStep, MultiStepInput } from "../common/multi-step-quickpick";
 import { AssignmentManager } from "../jupyter/assignments";
 import { ColabServerDescriptor } from "../jupyter/servers";
-import { Accelerator, Variant, variantToMachineType } from "./api";
+import { Variant, variantToMachineType } from "./api";
 
 /** Provides an explanation to the user on updating the server alias. */
 export const PROMPT_SERVER_ALIAS =
@@ -37,11 +37,11 @@ export class ServerPicker {
   async prompt(
     availableServers: ColabServerDescriptor[],
   ): Promise<ColabServerDescriptor | undefined> {
-    const variantToAccelerators = new Map<Variant, Set<Accelerator>>();
+    const variantToAccelerators = new Map<Variant, Set<string>>();
     for (const server of availableServers) {
       const accelerators =
         variantToAccelerators.get(server.variant) ?? new Set();
-      accelerators.add(server.accelerator ?? Accelerator.NONE);
+      accelerators.add(server.accelerator ?? "NONE");
       variantToAccelerators.set(server.variant, accelerators);
     }
     if (variantToAccelerators.size === 0) {
@@ -69,7 +69,7 @@ export class ServerPicker {
   private async promptForVariant(
     input: MultiStepInput,
     state: Partial<Server>,
-    acceleratorsByVariant: Map<Variant, Set<Accelerator>>,
+    acceleratorsByVariant: Map<Variant, Set<string>>,
   ): Promise<InputStep | undefined> {
     const items: VariantPick[] = [];
     for (const variant of acceleratorsByVariant.keys()) {
@@ -93,7 +93,7 @@ export class ServerPicker {
     }
     // Skip prompting for an accelerator for the default variant (CPU).
     if (state.variant === Variant.DEFAULT) {
-      state.accelerator = Accelerator.NONE;
+      state.accelerator = "NONE";
       return (input: MultiStepInput) => this.promptForAlias(input, state);
     }
     return (input: MultiStepInput) =>
@@ -103,7 +103,7 @@ export class ServerPicker {
   private async promptForAccelerator(
     input: MultiStepInput,
     state: PartialServerWith<"variant">,
-    acceleratorsByVariant: Map<Variant, Set<Accelerator>>,
+    acceleratorsByVariant: Map<Variant, Set<string>>,
   ): Promise<InputStep | undefined> {
     const accelerators = acceleratorsByVariant.get(state.variant) ?? new Set();
     const items: AcceleratorPick[] = [];
@@ -138,8 +138,7 @@ export class ServerPicker {
       state.variant,
       state.accelerator,
     );
-    const step =
-      state.accelerator && state.accelerator !== Accelerator.NONE ? 3 : 2;
+    const step = state.accelerator && state.accelerator !== "NONE" ? 3 : 2;
     const alias = await input.showInputBox({
       title: "Alias your server",
       step,
@@ -157,7 +156,7 @@ export class ServerPicker {
 
 interface Server {
   variant: Variant;
-  accelerator: Accelerator;
+  accelerator: string;
   alias: string;
 }
 
@@ -184,5 +183,5 @@ interface VariantPick extends QuickPickItem {
 }
 
 interface AcceleratorPick extends QuickPickItem {
-  value: Accelerator;
+  value: string;
 }

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -15,7 +15,7 @@ import { assert, expect } from "chai";
 import { SinonStubbedInstance } from "sinon";
 import * as sinon from "sinon";
 import { CancellationToken, CancellationTokenSource } from "vscode";
-import { Accelerator, SubscriptionTier, Variant } from "../colab/api";
+import { SubscriptionTier, Variant } from "../colab/api";
 import { ColabClient } from "../colab/client";
 import {
   AUTO_CONNECT,
@@ -38,17 +38,13 @@ import {
 } from "../test/helpers/vscode";
 import { AssignmentChangeEvent, AssignmentManager } from "./assignments";
 import { ColabJupyterServerProvider } from "./provider";
-import {
-  COLAB_SERVERS,
-  ColabAssignedServer,
-  ColabServerDescriptor,
-} from "./servers";
+import { ColabAssignedServer, ColabServerDescriptor } from "./servers";
 
 const DEFAULT_SERVER: ColabAssignedServer = {
   id: randomUUID(),
   label: "Colab GPU A100",
   variant: Variant.GPU,
-  accelerator: Accelerator.A100,
+  accelerator: "A100",
   endpoint: "m-s-foo",
   connectionInformation: {
     baseUrl: TestUri.parse("https://example.com"),
@@ -461,7 +457,7 @@ describe("ColabJupyterServerProvider", () => {
         });
 
         it("completes assigning a server", async () => {
-          const availableServers = Array.from(COLAB_SERVERS);
+          const availableServers = [DEFAULT_SERVER];
           assignmentStub.getAvailableServerDescriptors.resolves(
             availableServers,
           );

--- a/src/jupyter/servers.ts
+++ b/src/jupyter/servers.ts
@@ -9,7 +9,7 @@ import {
   JupyterServer,
   JupyterServerConnectionInformation,
 } from "@vscode/jupyter-extension";
-import { Accelerator, Variant } from "../colab/api";
+import { Variant } from "../colab/api";
 
 /**
  * Colab's Jupyter server descriptor which includes machine-specific
@@ -18,7 +18,7 @@ import { Accelerator, Variant } from "../colab/api";
 export interface ColabServerDescriptor {
   readonly label: string;
   readonly variant: Variant;
-  readonly accelerator?: Accelerator;
+  readonly accelerator?: string;
 }
 
 /**
@@ -48,43 +48,3 @@ export const DEFAULT_CPU_SERVER: ColabServerDescriptor = {
   label: "Colab CPU",
   variant: Variant.DEFAULT,
 };
-
-/**
- * The mapping of all potentially available ID to Colab Jupyter servers.
- */
-export const COLAB_SERVERS = new Set<ColabServerDescriptor>([
-  // CPUs
-  DEFAULT_CPU_SERVER,
-  // GPUs
-  {
-    label: "Colab GPU T4",
-    variant: Variant.GPU,
-    accelerator: Accelerator.T4,
-  },
-  {
-    label: "Colab GPU L4",
-    variant: Variant.GPU,
-    accelerator: Accelerator.L4,
-  },
-  {
-    label: "Colab GPU A100",
-    variant: Variant.GPU,
-    accelerator: Accelerator.A100,
-  },
-  // TPUs
-  {
-    label: "Colab TPU v2-8",
-    variant: Variant.TPU,
-    accelerator: Accelerator.V28,
-  },
-  {
-    label: "Colab TPU v5e-1",
-    variant: Variant.TPU,
-    accelerator: Accelerator.V5E1,
-  },
-  {
-    label: "Colab TPU v6e-1",
-    variant: Variant.TPU,
-    accelerator: Accelerator.V6E1,
-  },
-]);

--- a/src/jupyter/storage.ts
+++ b/src/jupyter/storage.ts
@@ -7,7 +7,7 @@
 import { UUID } from "crypto";
 import vscode from "vscode";
 import { z } from "zod";
-import { Accelerator, Variant } from "../colab/api";
+import { Variant } from "../colab/api";
 import { PROVIDER_ID } from "../config/constants";
 import { isUUID } from "../utils/uuid";
 import { ColabAssignedServer } from "./servers";
@@ -21,7 +21,7 @@ const AssignedServers = z.array(
       .transform((s) => s as UUID),
     label: z.string().nonempty(),
     variant: z.enum(Variant),
-    accelerator: z.enum(Accelerator).optional(),
+    accelerator: z.string().optional(),
     endpoint: z.string().nonempty(),
     connectionInformation: z.object({
       baseUrl: z.string().nonempty(),


### PR DESCRIPTION
This change allows VS Code to pickup machine changes as the API supports them.

I'd like to be careful with this this change... some review validation checking out the branch and testing it out would be appreciated! To ensure the `enum` -> `string` change for Jupyter storage was okay, I created some Colab servers off `main`, then checked out my branch and things worked fine. That's because `string` is really just the relaxed string `enum`.