### PR TITLE
chore: hookup mocha to VS Code testing adapter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
+    "hbenl.vscode-mocha-test-adapter",
     "ms-toolsai.jupyter"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,11 @@
   // in a flag .mts file and we run it natively as per
   // https://eslint.org/docs/latest/use/configure/configuration-files#native-typescript-support
   "eslint.execArgv": ["--experimental-strip-types"],
-  "eslint.options": { "flags": ["unstable_native_nodejs_ts_config"] }
+  "eslint.options": { "flags": ["unstable_native_nodejs_ts_config"] },
+  "mochaExplorer.files": "out/test/**/*.unit.test.js",
+  "mochaExplorer.require": [
+    "source-map-support/register",
+    "./out/test/test/unit-test-setup.js"
+  ],
+  "mochaExplorer.watch": "out/**/*.js"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "prettier": "3.4.2",
         "selenium-webdriver": "^4.34.0",
         "sinon": "^19.0.2",
+        "source-map-support": "^0.5.21",
         "tsx": "^4.19.4",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.15.0",
@@ -3539,6 +3540,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
       "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10020,6 +10028,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "prettier": "3.4.2",
     "selenium-webdriver": "^4.34.0",
     "sinon": "^19.0.2",
+    "source-map-support": "^0.5.21",
     "tsx": "^4.19.4",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.15.0",


### PR DESCRIPTION
This gives devs the ability to run unit tests from the VS Code testing UI.

I wasn't able to figure out how to give debug runs a timeout separate from standard runs. Figured it's best to at least get that out there and circle back.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/940740e3-8b2a-4e0c-91eb-734c5ec4460d" />

<br>

<img height="400" alt="image" src="https://github.com/user-attachments/assets/e1ce5c47-9a03-408c-b7b4-90160566551a" />
