### PR TITLE
test: add safeClick method

### DIFF
--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -303,7 +303,7 @@ async function safeClick(
         if (e instanceof error.StaleElementReferenceError) {
           return false;
         }
-        return false;
+        throw e;
       }
     },
     ELEMENT_WAIT_MS,


### PR DESCRIPTION
The `waitAndClick` method is used in the E2E test's OAuth flow.

This has recently increased in flakiness, throwing `StaleElementReferenceError` when interacting with the consent page.

As a solution, we've renamed the method to `safeClick` and refactored it to use a `webdriver.wait` so that the flow is retried if it does not succeed