### PR TITLE
fix: handle when OAuth access is revoked

### DIFF
--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -128,7 +128,11 @@ export class GoogleAuthProvider
       let shouldClearSession = false;
       let reason = "";
 
-      if (err instanceof GaxiosError && err.status === 400) {
+      if (
+        err instanceof GaxiosError &&
+        err.status === 400 &&
+        err.message.includes("invalid_grant")
+      ) {
         reason = "OAuth app access to Colab was revoked";
         shouldClearSession = true;
       } else if (err instanceof GaxiosError && err.status === 401) {

--- a/src/auth/auth-provider.unit.test.ts
+++ b/src/auth/auth-provider.unit.test.ts
@@ -257,7 +257,7 @@ describe("GoogleAuthProvider", () => {
           });
         }
 
-        it("re-throws non 401 errors when refreshing the access token", async () => {
+        it("re-throws non handled errors when refreshing the access token", async () => {
           sinon
             .stub(oauth2Client, "refreshAccessToken")
             .throws(new Error("🤮"));


### PR DESCRIPTION
When initializing the auth provider, we now clear sessions when encountering a 400 error.

This error can be encountered when the user revokes OAuth app access to Colaboratory. See https://github.com/googlecolab/colab-vscode/issues/207 for additional details on how to reproduce.

Now, when the user reloads VS Code, sessions with an invalid grant are cleared, allowing creation of a new session.