### PR TITLE
build: run e2e tests in an environment

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,10 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
-    env:
-      COLAB_EXTENSION_ENVIRONMENT: ${{ vars.COLAB_EXTENSION_ENVIRONMENT }}
-      COLAB_EXTENSION_CLIENT_ID: ${{ secrets.COLAB_EXTENSION_CLIENT_ID }}
-      COLAB_EXTENSION_CLIENT_NOT_SO_SECRET: ${{ secrets.COLAB_EXTENSION_CLIENT_NOT_SO_SECRET }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -46,7 +42,12 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
       - run: npm ci
-      - run: npm run generate:config
+      - name: Generate dummy config
+        run: npm run generate:config
+        env:
+          COLAB_EXTENSION_ENVIRONMENT: "production"
+          COLAB_EXTENSION_CLIENT_ID: "client-id"
+          COLAB_EXTENSION_CLIENT_NOT_SO_SECRET: "client-not-so-secret"
       - name: Upload generated config
         uses: actions/upload-artifact@v4
         with:
@@ -132,16 +133,25 @@ jobs:
     name: VS Code E2E Tests
     permissions:
       actions: write
+    # This environment is protected and requires approval for PRs from forks.
+    # It provides the necessary variables and secrets to run the end-to-end
+    # tests.
+    environment: E2E Tests
     strategy:
       matrix:
         # macos-latest and windows-latest can be added as we work towards a release.
         # For now, there's no sense acruing the cost of the runners.
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
-    needs: generateConfig
+    # Limit running the E2E tests until unit tests pass to save on resources.
+    needs: unitTests
     env:
+      # Secrets and variables are sourced from the "E2E Tests" environment.
       TEST_ACCOUNT_EMAIL: ${{ secrets.TEST_ACCOUNT_EMAIL }}
       TEST_ACCOUNT_PASSWORD: ${{ secrets.TEST_ACCOUNT_PASSWORD }}
+      COLAB_EXTENSION_ENVIRONMENT: ${{ vars.COLAB_EXTENSION_ENVIRONMENT }}
+      COLAB_EXTENSION_CLIENT_ID: ${{ secrets.COLAB_EXTENSION_CLIENT_ID }}
+      COLAB_EXTENSION_CLIENT_NOT_SO_SECRET: ${{ secrets.COLAB_EXTENSION_CLIENT_NOT_SO_SECRET }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -150,11 +160,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
       - run: npm ci
-      - name: Download generated config
-        uses: actions/download-artifact@v4
-        with:
-          name: generated-config
-          path: src
+      - name: Generate production config
+        run: npm run generate:config
       - name: npm run test:e2e:headless (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: npm run test:e2e:headless


### PR DESCRIPTION
This PR overhauls our CI workflow to securely enable running our full test suite on pull requests from external forks. Previously, our CI would fail on fork PRs because they cannot access the repository's secrets (GitHub's default security model). This change fixes that by adopting GitHub's recommended best practice: [_GitHub Environments_](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments).

This is resolved by creating a protected GitHub _Environment_ named "E2E Tests".                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                   
- All secrets and variables required for the E2E tests have been moved out of the general repository settings and into this new, protected environment.
- The CI pipeline is now split into two distinct phases:
  - 1 (Unprivileged Jobs): The `lint`, `unitTests`, and `vsCodeTests` jobs run immediately on all pull requests. They use placeholder configuration values and do not require any secrets. This provides rapid, preliminary feedback to all contributors.
  - 2 (Privileged Job): The `e2eTests` job is the only one that needs secrets. It is now configured to run within the "E2E Tests" environment and depends on the success of the unit tests in Phase 1.
                                                                                                                                                                                                                                                                                   
How This Works in Practice:
  
  - For Maintainers (Internal Branches): When a maintainer opens a PR from a branch within this repository, the entire workflow—including the E2E tests—runs automatically from start to finish.
  - For Contributors (Fork PRs): When a contributor opens a PR from their fork, the Phase 1 jobs are ran with maintainer approval. The workflow then automatically pauses just before starting the `e2eTests` job. A repository maintainer must review the code for safety and then manually approve the job to proceed. Once approved, the job gains access to the environment's secrets and runs the end-to-end tests.
     
This change allows us to safely validate all incoming code while ensuring our secrets remain secure, streamlining the contribution process for everyone.