### PR TITLE
refactor: lift "has servers" context to provider

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,6 @@ export async function activate(context: vscode.ExtensionContext) {
     authClient,
     (scopes: string[]) => login(vscode, authFlows, authClient, scopes),
   );
-  await authProvider.initialize();
   const colabClient = new ColabClient(
     new URL(CONFIG.ColabApiDomain),
     new URL(CONFIG.ColabGapiDomain),
@@ -73,7 +72,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   const serverProvider = new ColabJupyterServerProvider(
     vscode,
-    authProvider.whileAuthorized.bind(authProvider),
+    authProvider.onDidChangeSessions,
     assignmentManager,
     colabClient,
     new ServerPicker(vscode, assignmentManager),
@@ -86,6 +85,7 @@ export async function activate(context: vscode.ExtensionContext) {
     assignmentManager,
   );
   const consumptionMonitor = watchConsumption(colabClient);
+  await authProvider.initialize();
   // Sending server "keep-alive" pings and monitoring consumption requires
   // issuing authenticated requests to Colab. This can only be done after the
   // user has signed in. We don't block extension activation on completing the

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -152,7 +152,7 @@ export class AssignmentManager implements vscode.Disposable {
 
     await this.storage.clear();
     await this.storage.store(reconciled);
-    await this.signalChange({
+    this.assignmentChange.fire({
       added: [],
       removed: removed.map((s) => ({ server: s, userInitiated: false })),
       changed: [],
@@ -254,7 +254,7 @@ export class AssignmentManager implements vscode.Disposable {
       new Date(),
     );
     await this.storage.store([server]);
-    await this.signalChange({
+    this.assignmentChange.fire({
       added: [server],
       removed: [],
       changed: [],
@@ -330,26 +330,13 @@ export class AssignmentManager implements vscode.Disposable {
       server.dateAssigned,
     );
     await this.storage.store([updatedServer]);
-    await this.signalChange({
+    this.assignmentChange.fire({
       added: [],
       removed: [],
       changed: [updatedServer],
     });
     return updatedServer;
   }
-
-  /**
-   * Sets a context key indicating whether or not the user has at least one
-   * assigned server originating from VS Code.
-   */
-  async setHasAssignedServerContext(signal?: AbortSignal): Promise<void> {
-    await this.vs.commands.executeCommand(
-      "setContext",
-      "colab.hasAssignedServer",
-      await this.hasAssignedServer(signal),
-    );
-  }
-
   /**
    * Unassigns the given server.
    *
@@ -366,7 +353,7 @@ export class AssignmentManager implements vscode.Disposable {
     if (!removed) {
       return;
     }
-    await this.signalChange({
+    this.assignmentChange.fire({
       added: [],
       removed: [{ server, userInitiated: true }],
       changed: [],
@@ -413,13 +400,6 @@ export class AssignmentManager implements vscode.Disposable {
       return labelBase;
     }
     return `${labelBase} (${placeholderIdx.toString()})`;
-  }
-
-  private async signalChange(e: AssignmentChangeEvent): Promise<void> {
-    // Since signalling a change happens after the change was actually
-    // committed, we don't specify an abort signal.
-    await this.setHasAssignedServerContext();
-    this.assignmentChange.fire(e);
   }
 
   private toAssignedServer(

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -213,12 +213,6 @@ describe("AssignmentManager", () => {
 
       await expect(assignmentManager.getAssignedServers()).to.eventually.be
         .empty;
-      sinon.assert.calledOnceWithExactly(
-        vsCodeStub.commands.executeCommand,
-        "setContext",
-        "colab.hasAssignedServer",
-        false,
-      );
       sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
         added: [],
         removed: [{ server: defaultServer, userInitiated: false }],
@@ -269,12 +263,6 @@ describe("AssignmentManager", () => {
 
         const serversAfter = await assignmentManager.getAssignedServers();
         expect(stripFetches(serversAfter)).to.deep.equal([servers[0]]);
-        sinon.assert.calledOnceWithExactly(
-          vsCodeStub.commands.executeCommand,
-          "setContext",
-          "colab.hasAssignedServer",
-          true,
-        );
         sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
           added: [],
           removed: [{ server: servers[1], userInitiated: false }],
@@ -298,12 +286,6 @@ describe("AssignmentManager", () => {
 
         await expect(assignmentManager.getAssignedServers()).to.eventually.be
           .empty;
-        sinon.assert.calledOnceWithExactly(
-          vsCodeStub.commands.executeCommand,
-          "setContext",
-          "colab.hasAssignedServer",
-          false,
-        );
         sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
           added: [],
           removed: threeServers.map((s) => ({
@@ -343,12 +325,6 @@ describe("AssignmentManager", () => {
           servers[0],
           servers[1],
         ]);
-        sinon.assert.calledOnceWithExactly(
-          vsCodeStub.commands.executeCommand,
-          "setContext",
-          "colab.hasAssignedServer",
-          true,
-        );
         sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
           added: [],
           removed: [{ server: thirdServer, userInitiated: false }],
@@ -376,12 +352,6 @@ describe("AssignmentManager", () => {
 
         await expect(assignmentManager.getAssignedServers()).to.eventually.be
           .empty;
-        sinon.assert.calledOnceWithExactly(
-          vsCodeStub.commands.executeCommand,
-          "setContext",
-          "colab.hasAssignedServer",
-          false,
-        );
         sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
           added: [],
           removed: servers.map((s) => ({ server: s, userInitiated: false })),
@@ -587,15 +557,6 @@ describe("AssignmentManager", () => {
         expect(assignedId).to.satisfy(isUUID);
       });
 
-      it("sets the hasAssignedServer context to true", () => {
-        sinon.assert.calledOnceWithExactly(
-          vsCodeStub.commands.executeCommand,
-          "setContext",
-          "colab.hasAssignedServer",
-          true,
-        );
-      });
-
       it("emits an assignment change event", () => {
         const { id: defaultId, ...want } = defaultServer;
         sinon.assert.calledOnceWithMatch(assignmentChangeListener, {
@@ -797,12 +758,6 @@ describe("AssignmentManager", () => {
         sinon.assert.calledOnceWithMatch(
           colabClientStub.unassign,
           defaultServer.endpoint,
-        );
-        sinon.assert.calledOnceWithExactly(
-          vsCodeStub.commands.executeCommand,
-          "setContext",
-          "colab.hasAssignedServer",
-          false,
         );
         sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
           added: [],


### PR DESCRIPTION
The `AssignmentManager` deals strictly with APIs surrounding assignments, and doesn't concern itself with auth. It takes in a `ColabClient` and uses it. If the user isn't auth'd, they're prompted to sign-in when that client goes to get a token. This background is important when you consider what it means to claim there are assigned servers. Imagine the user has a server, but signs out. Do they have a sever? What about in 5 minutes? 60? We can't know unless we're authorized to check (query the API).

The `ColabJupyterServerProvider` is the natural place for making this determination, since it provides whatever servers it can, given the current authorization. When it's unauth'd it provides `[]`. This makes it the authoritative voice of whether or not there are assigned servers, so setting the context makes the most sense there.

This change actually solves an issue that caused me to move the functionality in the first place. Before, if you had a server and re-loaded the extension, the `Colab: Remove Server` command wouldn't be available, since the context wasn't re-evaluated on activation. Sure we could have done some kind of _initialization_ step but I think this lift makes more sense.

This change also removes the unnecessary _toggling_ indirection, something I make look to do where it makes sense for the other toggles. Though for those that are pure _are you auth'd_ toggles (and not looking at other signals), it's less of a smell.