### PR TITLE
refactor: simplify async toggling

### DIFF
--- a/src/common/async.ts
+++ b/src/common/async.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { log } from "./logging";
+
+/**
+ * Run an async worker task, canceling in-flight work with an
+ * {@link AbortSignal}.
+ */
+export class LatestCancelable<T extends unknown[]> {
+  private curAbort?: AbortController;
+
+  constructor(
+    private readonly name: string,
+    private readonly worker: (...args: [...T, AbortSignal]) => Promise<void>,
+  ) {}
+
+  /**
+   * Fire the worker, aborting the previous if running.
+   */
+  async run(...args: T): Promise<void> {
+    // Abort previous.
+    if (this.curAbort) {
+      this.curAbort.abort();
+    }
+
+    const abort = new AbortController();
+    this.curAbort = abort;
+
+    try {
+      await this.worker(...args, abort.signal);
+    } catch (err: unknown) {
+      if (
+        abort.signal.aborted ||
+        (err instanceof Error && err.name === "AbortError")
+      ) {
+        // Throwing an abort is expected.
+      } else {
+        log.error(`LatestCancelable worker error for "${this.name}"`, err);
+      }
+    } finally {
+      // Only clear the controller if it is still the most recent one.
+      if (this.curAbort === abort) {
+        this.curAbort = undefined;
+      }
+    }
+  }
+
+  /**
+   * True when there's an active worker task running.
+   */
+  isRunning(): boolean {
+    return !!this.curAbort && !this.curAbort.signal.aborted;
+  }
+
+  /**
+   * Cancels an in-flight worker task if one is running.
+   */
+  cancel(): void {
+    this.curAbort?.abort();
+  }
+}

--- a/src/common/async.unit.test.ts
+++ b/src/common/async.unit.test.ts
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from "chai";
+import sinon from "sinon";
+import { Deferred } from "../test/helpers/async";
+import { ColabLogWatcher } from "../test/helpers/logging";
+import { newVsCodeStub } from "../test/helpers/vscode";
+import { LatestCancelable } from "./async";
+import { LogLevel } from "./logging";
+
+describe("LatestCancelable", () => {
+  let logs: ColabLogWatcher;
+  let worker: sinon.SinonStub<[...unknown[], AbortSignal], Promise<void>>;
+  let cancelable: LatestCancelable<unknown[]>;
+
+  beforeEach(() => {
+    logs = new ColabLogWatcher(newVsCodeStub(), LogLevel.Trace);
+    worker = sinon.stub();
+    cancelable = new LatestCancelable("test-worker", worker);
+  });
+
+  afterEach(() => {
+    logs.dispose();
+  });
+
+  it("should run the worker", async () => {
+    worker.resolves();
+
+    await cancelable.run();
+    sinon.assert.calledOnce(worker);
+  });
+
+  it("should cancel previous worker and not affect the running state of a new task", async () => {
+    const firstRunStarted = new Deferred<void>();
+    const firstRunCompleter = new Deferred<void>();
+    const secondRunStarted = new Deferred<void>();
+    const secondRunCompleter = new Deferred<void>();
+
+    worker
+      .onFirstCall()
+      .callsFake(async (...args: [...unknown[], AbortSignal]) => {
+        firstRunStarted.resolve();
+        const signal = args.pop() as AbortSignal;
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => {
+            resolve();
+          });
+        });
+        await firstRunCompleter.promise;
+      });
+
+    worker.onSecondCall().callsFake(async () => {
+      secondRunStarted.resolve();
+      await secondRunCompleter.promise;
+    });
+
+    const firstPromise = cancelable.run();
+    await firstRunStarted.promise;
+
+    const secondPromise = cancelable.run();
+    await secondRunStarted.promise;
+
+    expect(cancelable.isRunning()).to.be.true;
+
+    firstRunCompleter.resolve();
+    await firstPromise;
+
+    expect(cancelable.isRunning()).to.be.true;
+
+    secondRunCompleter.resolve();
+    await secondPromise;
+
+    expect(cancelable.isRunning()).to.be.false;
+    sinon.assert.calledTwice(worker);
+    const firstSignal = worker.firstCall.args[0] as AbortSignal;
+    expect(firstSignal.aborted).to.be.true;
+  });
+
+  it("should be a no-op when cancelling and no task is running", () => {
+    expect(() => {
+      cancelable.cancel();
+    }).to.not.throw();
+  });
+
+  it("should forward arguments to the worker", async () => {
+    worker.resolves();
+    await cancelable.run("foo", 123);
+    sinon.assert.calledOnceWithExactly(worker, "foo", 123, sinon.match.any);
+  });
+
+  it("should report running state correctly", async () => {
+    const d = new Deferred<void>();
+    const workerStarted = new Deferred<void>();
+    worker.callsFake(async () => {
+      workerStarted.resolve();
+      await d.promise;
+    });
+
+    expect(cancelable.isRunning()).to.be.false;
+
+    const promise = cancelable.run();
+
+    await workerStarted.promise;
+    expect(cancelable.isRunning()).to.be.true;
+
+    d.resolve();
+    await promise;
+
+    expect(cancelable.isRunning()).to.be.false;
+  });
+
+  it("should cancel in-flight work", async () => {
+    const d = new Deferred<void>();
+    const workerStarted = new Deferred<void>();
+    worker.callsFake(async (...args) => {
+      workerStarted.resolve();
+      const signal = args.pop() as AbortSignal;
+      signal.addEventListener("abort", () => {
+        d.resolve();
+      });
+      await d.promise;
+    });
+
+    const promise = cancelable.run();
+    await workerStarted.promise;
+    expect(cancelable.isRunning()).to.be.true;
+
+    cancelable.cancel();
+
+    await d.promise;
+    await promise;
+
+    const signal = worker.firstCall.args[0] as AbortSignal;
+    expect(signal.aborted).to.be.true;
+    expect(cancelable.isRunning()).to.be.false;
+  });
+
+  it("should handle errors gracefully", async () => {
+    worker.rejects(new Error("🤮"));
+    await cancelable.run();
+    expect(logs.output).to.match(/LatestCancelable worker error/);
+  });
+
+  it("should ignore abort errors", async () => {
+    worker.callsFake((...args) => {
+      const signal = args.pop() as AbortSignal;
+      return new Promise((_resolve, reject) => {
+        const err = new Error("AbortError");
+        err.name = "AbortError";
+        signal.addEventListener("abort", () => {
+          reject(err);
+        });
+      });
+    });
+
+    const promise = cancelable.run();
+    cancelable.cancel();
+
+    await promise;
+    expect(logs.output).to.not.match(/LatestCancelable worker error/);
+  });
+});

--- a/src/common/toggleable.ts
+++ b/src/common/toggleable.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Disposable } from "vscode";
-import { log } from "./logging";
+import { LatestCancelable } from "./async";
 
 /**
  * An entity which can be turned "on" and "off".
@@ -22,82 +21,41 @@ export interface Toggleable {
   off(): void;
 }
 
+type ToggleDirection = Lowercase<keyof Toggleable>;
+
 /**
- * Manages a resource that is created asynchronously and can be turned on and
- * off. It handles the race condition between initialization and toggling on and
- * off.
+ * Manages toggling on and off asynchronously.
+ *
+ * Derived classes are responsible for object lifecycle of any resources created
+ * when toggling.
  */
-export abstract class AsyncToggleable<T extends Disposable>
-  implements Toggleable, Disposable
-{
-  private resource: T | undefined = undefined;
-  private inFlightTurnOn: AbortController | undefined;
-  protected initializationComplete: Promise<void> | undefined;
-
-  /**
-   * The asynchronous operation that creates and initializes the resource.
-   * @param signal - Aborts if off is called during initialization.
-   */
-  protected abstract initialize(signal: AbortSignal): Promise<T>;
-
-  /**
-   * Toggles the component on by initializing the resource.
-   * No-ops if already on.
-   * If `off()` is called during initialization, it is aborted.
-   */
-  on() {
-    if (this.inFlightTurnOn) {
-      return;
-    }
-    this.inFlightTurnOn = new AbortController();
-    this.initializationComplete = this.doInit(this.inFlightTurnOn.signal);
-  }
-
-  /**
-   * Turns the component off.
-   * If initialization is in progress, it aborts it.
-   * Any existing resource is disposed.
-   */
-  off() {
-    if (this.inFlightTurnOn) {
-      this.inFlightTurnOn.abort(
-        new Error(
-          `${this.constructor.name} turned off while it was turning on`,
-        ),
-      );
-      this.inFlightTurnOn = undefined;
-    }
-    this.resource?.dispose();
-    this.resource = undefined;
-  }
-
-  /**
-   * Disposes the component by turning it off.
-   */
-  dispose() {
-    this.off();
-  }
-
-  private async doInit(signal: AbortSignal): Promise<void> {
-    try {
-      const resource = await this.initialize(signal);
-      if (!this.inFlightTurnOn || signal.aborted) {
-        log.trace(
-          `Initialization of ${this.constructor.name} aborted, disposing resource`,
-        );
-        resource.dispose();
+export abstract class AsyncToggle implements Toggleable {
+  private lastToggle?: "on" | "off";
+  private runner = new LatestCancelable<[ToggleDirection]>(
+    "AsyncToggle",
+    async (to, signal) => {
+      if (this.lastToggle === to) {
         return;
       }
-      this.resource = resource;
-    } catch (err: unknown) {
-      if (!this.inFlightTurnOn || signal.aborted) {
-        log.trace(`Initialization of ${this.constructor.name} aborted`, err);
-      } else {
-        log.error(`Unable to initialize ${this.constructor.name}`, err);
+      this.lastToggle = to;
+      switch (to) {
+        case "on":
+          await this.turnOn(signal);
+          break;
+        case "off":
+          await this.turnOff(signal);
+          break;
       }
-      throw err;
-    } finally {
-      this.inFlightTurnOn = undefined;
-    }
+    },
+  );
+
+  on(): void {
+    void this.runner.run("on");
   }
+  off(): void {
+    void this.runner.run("off");
+  }
+
+  protected abstract turnOn(signal: AbortSignal): Promise<void>;
+  protected abstract turnOff(signal: AbortSignal): Promise<void>;
 }

--- a/src/test/helpers/async.ts
+++ b/src/test/helpers/async.ts
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AsyncToggle } from "../../common/toggleable";
+
+/**
+ * A simple Deferred promise helper.
+ */
+export class Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+/**
+ * A handle for an individual call.
+ */
+export interface ControllableCall {
+  /**
+   * Wait for the method to start.
+   */
+  waitForStart(): Promise<void>;
+
+  /**
+   * Wait for the method to complete.
+   */
+  waitForCompletion(): Promise<void>;
+}
+
+/**
+ * A spy for a method whose lifecycle of handled calls can be controlled.
+ */
+export interface ControllableMethod {
+  /**
+   * Get the handle for a specific invocation.
+   *
+   * Creates it if it doesn't exist yet (allowing you to pre-fetch handles)
+   *
+   * @param index - The (0-based) index of the call to get when spying on a
+   * method.
+   */
+  call(index: number): ControllableCall;
+
+  /**
+   * Get the call count for the method.
+   */
+  get callCount(): number;
+}
+
+/**
+ * Simplifies testing {@link AsyncToggle}s by wrapping the protected methods to
+ * turn on and off which enables tests to easily wait for the corresponding
+ * execution lifecycle.
+ */
+export class ControllableAsyncToggle {
+  private _turnOn: ControllableMethod;
+  private _turnOff: ControllableMethod;
+  private openInstance: PublicToggle;
+
+  constructor(instance: AsyncToggle) {
+    // Cast to be able to wrap protected member so the async toggles are
+    // controllable.
+    this.openInstance = instance as PublicToggle;
+    this._turnOn = this.wrap("turnOn");
+    this._turnOff = this.wrap("turnOff");
+  }
+
+  get turnOn(): ControllableMethod {
+    return this._turnOn;
+  }
+
+  get turnOff(): ControllableMethod {
+    return this._turnOff;
+  }
+
+  private wrap(methodName: "turnOn" | "turnOff"): ControllableMethod {
+    const originalMethod = this.openInstance[methodName].bind(
+      this.openInstance,
+    );
+    const spy = new MethodSpyImpl();
+
+    this.openInstance[methodName] = async (signal) => {
+      // The handle for this invocation.
+      const handle = spy.next();
+
+      // The async method has been invoked.
+      handle.started.resolve();
+
+      try {
+        await originalMethod(signal);
+      } finally {
+        // In both success and failure cases, mark the method as completed.
+        handle.completed.resolve();
+      }
+    };
+    return spy;
+  }
+}
+
+/**
+ * Lift the protected methods tests need to control to public, to enable safer
+ * stubbing over the protected members.
+ */
+abstract class PublicToggle extends AsyncToggle {
+  abstract override turnOn(signal: AbortSignal): Promise<void>;
+  abstract override turnOff(signal: AbortSignal): Promise<void>;
+}
+
+/**
+ * A handle for an individual call.
+ */
+class CallHandleImpl implements ControllableCall {
+  started = new Deferred<void>();
+  completed = new Deferred<void>();
+
+  /**
+   * Wait for the method to start.
+   */
+  async waitForStart() {
+    return this.started.promise;
+  }
+
+  /**
+   * Wait for the method to complete.
+   */
+  async waitForCompletion() {
+    return this.completed.promise;
+  }
+}
+
+/**
+ * The spy for all calls to a method.
+ */
+class MethodSpyImpl implements ControllableMethod {
+  private calls: CallHandleImpl[] = [];
+  private count = 0;
+
+  // Get the handle for a specific invocation (0-based index)
+  // Creates it if it doesn't exist yet (allowing you to pre-fetch handles)
+  call(index: number): CallHandleImpl {
+    if (!this.calls[index]) {
+      this.calls[index] = new CallHandleImpl();
+    }
+    return this.calls[index];
+  }
+
+  get callCount(): number {
+    return this.count;
+  }
+
+  next(): CallHandleImpl {
+    return this.call(this.count++);
+  }
+}


### PR DESCRIPTION
I wasn't happy with `AsyncToggleable`. There were a few things I didn't like, but the fact that it is generic (`<T extends Disposable>`) highlights the biggest issue. It conflated resource lifecycle with execution lifecycle.

By making it singly-responsible for execution lifecycle, the code reads more easily and yields flexibility to callers who can control when and how their resources are managed. Gone is the implicit indirection.

This is achieved by adding `LatestCancelable` which simply looks after running one async task at a time by cancelling the in-flight one. I feel that this pattern feels natural when you look at the call-sites, e.g.: `this.runner.run("my", "params")`. When ran from a sync context, as is often the case from sync event listeners, the `void` makes this _runner_ more obvious -  we're fire-and-forgetting these async _runs_.

I added a flexible test helper / spy (`ControllableAsyncToggle`), used to make writing `AsyncToggle`-based unit tests a bit less painful.