### PR TITLE
build: bump version to `0.1.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "glob": "^11.1.0",
         "google-auth-library": "^9.15.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
Created with `npm version patch`.

User-impacting changes since last bump/release:

- feat: add the ability to remove external servers (#274)
- fix: remove server bug (#278, #279, #277)

Commit log since last bump/release:

```txt
commit 22ee342e4a25e62abc9edfc8feab3c9458c56885
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Thu Dec 4 11:04:48 2025 -0800

    build(deps): bump jws (#290)

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

commit e665198d678b415262ecdb792d664466d3330d7a
Author: Kevin Eger <egerkevinjames@gmail.com>
Date:   Wed Dec 3 16:06:33 2025 -0800

    build: add some helpful Mocha test snippets (#286)

commit 3e8b2b96797dbd4a00c30254452327a530264a19
Author: Jack Yang <77074952+hjjackyang@users.noreply.github.com>
Date:   Wed Dec 3 14:34:09 2025 -0800

    feat: add the ability to remove external servers (#274)

    Signed-off-by: Jack Yang <77074952+hjjackyang@users.noreply.github.com>
    Co-authored-by: Kevin Eger <egerkevinjames@gmail.com>

commit 09f56df337ea1eacbca53aa3edcfbb2031a1f75c
Author: Kevin Eger <egerkevinjames@gmail.com>
Date:   Wed Dec 3 12:16:05 2025 -0800

    refactor: lift "has servers" context to provider (#278)

commit ea0a4e13d8f296e48c561716e46d1fcaa0b12824
Author: Kevin Eger <egerkevinjames@gmail.com>
Date:   Mon Dec 1 15:53:48 2025 -0800

    refactor: simplify async toggling (#279)

commit 0fa5a23804becba2006ce3f9cffe267c33210095
Author: Kevin Eger <egerkevinjames@gmail.com>
Date:   Mon Dec 1 12:00:40 2025 -0800

    feat: include in auth events if there's a valid active session (#277)

commit b4cc45a94397edcfa987995e04458e953b0dd2e8
Author: Kevin Eger <egerkevinjames@gmail.com>
Date:   Tue Nov 25 11:18:46 2025 -0800

    build: run e2e tests in an environment (#272)

commit 4762d8955a08e6819c4681ea44316abbd641e484
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Tue Nov 18 08:09:35 2025 -0800

    build(deps): bump glob (#244)

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

commit b6b8aa7b9f76b4caadeabcb90b8b3654e187147d
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Tue Nov 18 08:04:42 2025 -0800

    build(deps-dev): bump js-yaml from 3.14.1 to 3.14.2 (#240)

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

commit 56fb91fb6244e339bd132aa126658b3102373619
Author: Kevin Eger <egerkevinjames@gmail.com>
Date:   Mon Nov 17 17:08:22 2025 -0800

    chore: restrict workflow permissions (#239)
```