### PR TITLE
chore: update prettier to use single quotes for TS/JS

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,11 @@
 {
-  "printWidth": 80
+  "printWidth": 80,
+  "overrides": [
+    {
+      "files": ["**/*.ts", "**/*.mts", "**/*.js", "**/*.mjs"],
+      "options": {
+        "singleQuote": true
+      }
+    }
+  ]
 }

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -8,9 +8,9 @@
 // working directory. This file provides the configuration for the test runner,
 // and you can find the entire definition here.
 
-import { defineConfig } from "@vscode/test-cli";
+import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
-  files: "out/test/**/*vscode.test.js",
-  installExtensions: ["google.colab"],
+  files: 'out/test/**/*vscode.test.js',
+  installExtensions: ['google.colab'],
 });

--- a/esbuild.config.mts
+++ b/esbuild.config.mts
@@ -4,21 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { existsSync, mkdirSync, cpSync } from "fs";
-import * as path from "path";
-import * as esbuild from "esbuild";
-import { nodeExternalsPlugin } from "esbuild-node-externals";
-import { glob } from "glob";
+import { existsSync, mkdirSync, cpSync } from 'fs';
+import * as path from 'path';
+import * as esbuild from 'esbuild';
+import { nodeExternalsPlugin } from 'esbuild-node-externals';
+import { glob } from 'glob';
 
-const isProduction: boolean = process.argv.includes("--production");
-const isTestBuild: boolean = process.argv.includes("--tests");
-const isWatch: boolean = process.argv.includes("--watch");
+const isProduction: boolean = process.argv.includes('--production');
+const isTestBuild: boolean = process.argv.includes('--tests');
+const isWatch: boolean = process.argv.includes('--watch');
 
 // Create output directories.
-mkdirSync("out/auth/media", { recursive: true });
+mkdirSync('out/auth/media', { recursive: true });
 if (isTestBuild) {
-  mkdirSync("out/test/media", { recursive: true });
-  cpSync("src/auth/media/favicon.ico", "out/test/media/favicon.ico");
+  mkdirSync('out/test/media', { recursive: true });
+  cpSync('src/auth/media/favicon.ico', 'out/test/media/favicon.ico');
 }
 
 /**
@@ -29,7 +29,7 @@ if (isTestBuild) {
  */
 function logBuildMetadata(
   name: string,
-  outputs: esbuild.Metafile["outputs"],
+  outputs: esbuild.Metafile['outputs'],
 ): void {
   for (const [fileName, output] of Object.entries(outputs)) {
     if (!output.bytes) {
@@ -47,7 +47,7 @@ function logBuildMetadata(
  */
 function buildReporter(name: string): esbuild.Plugin {
   return {
-    name: "build-reporter",
+    name: 'build-reporter',
     setup(build: esbuild.PluginBuild) {
       build.onEnd((result: esbuild.BuildResult) => {
         if (result.errors.length > 0) {
@@ -74,20 +74,20 @@ function buildReporter(name: string): esbuild.Plugin {
 const baseOptions: esbuild.BuildOptions = {
   bundle: true,
   sourcemap: true,
-  platform: "node",
-  format: "cjs", // CommonJS format, requires for VS Code extensions.
+  platform: 'node',
+  format: 'cjs', // CommonJS format, requires for VS Code extensions.
   minify: isProduction,
   treeShaking: true,
-  external: ["vscode"], // 'vscode' is provided by the VS Code runtime.
+  external: ['vscode'], // 'vscode' is provided by the VS Code runtime.
   color: true,
 };
 
 // Options specific to the main extension build
 const extensionOptions: esbuild.BuildOptions = {
   ...baseOptions,
-  entryPoints: ["src/extension.ts"],
-  outfile: "out/extension.js",
-  plugins: [buildReporter("Extension")],
+  entryPoints: ['src/extension.ts'],
+  outfile: 'out/extension.js',
+  plugins: [buildReporter('Extension')],
   metafile: !isWatch,
 };
 
@@ -96,13 +96,13 @@ const extensionOptions: esbuild.BuildOptions = {
  * Throws an error if the file is not found.
  */
 function ensureConfigExists(): void {
-  if (existsSync("./src/colab-config.ts")) {
+  if (existsSync('./src/colab-config.ts')) {
     return;
   }
   console.error(
-    "📣 Required source configuration file not found. Run `npm run generate:config`.",
+    '📣 Required source configuration file not found. Run `npm run generate:config`.',
   );
-  throw new Error("Configuration file not found: src/colab-config.ts");
+  throw new Error('Configuration file not found: src/colab-config.ts');
 }
 
 /**
@@ -120,7 +120,7 @@ function testOptions(
     entryPoints: Array.isArray(entrypointGlobPattern)
       ? entrypointGlobPattern
       : glob.sync(entrypointGlobPattern),
-    outdir: "out/test",
+    outdir: 'out/test',
     plugins: [buildReporter(name), nodeExternalsPlugin()],
   };
 }
@@ -140,7 +140,7 @@ function testSetupOptions(
   return {
     ...baseOptions,
     entryPoints: [entrypoint],
-    outfile: path.join("out/test", outfile),
+    outfile: path.join('out/test', outfile),
     bundle: false, // Do not bundle, just transpile for test setup files.
     external: undefined, // 'external' cannot be used when 'bundle' is false.
     plugins: [buildReporter(name), nodeExternalsPlugin()],
@@ -155,32 +155,32 @@ async function main(): Promise<void> {
   try {
     ensureConfigExists();
     // Copy favicon for both main and test builds
-    cpSync("src/auth/media/favicon.ico", "out/auth/media/favicon.ico");
+    cpSync('src/auth/media/favicon.ico', 'out/auth/media/favicon.ico');
     if (isTestBuild) {
-      cpSync("src/auth/media/favicon.ico", "out/test/media/favicon.ico");
+      cpSync('src/auth/media/favicon.ico', 'out/test/media/favicon.ico');
     }
 
     // Determine which build options to use based on 'isTestBuild' flag
     const options: esbuild.BuildOptions[] = isTestBuild
       ? [
           testSetupOptions(
-            "Unit Test Setup",
-            "src/test/unit-test-setup.ts",
-            "test/unit-test-setup.js",
+            'Unit Test Setup',
+            'src/test/unit-test-setup.ts',
+            'test/unit-test-setup.js',
           ),
           testSetupOptions(
-            "Integration Test Setup",
-            "src/test/integration-test-runner.ts",
-            "test/integration-test-runner.js",
+            'Integration Test Setup',
+            'src/test/integration-test-runner.ts',
+            'test/integration-test-runner.js',
           ),
-          testOptions("Unit Tests", "src/**/*.unit.test.ts"),
-          testOptions("Integration Tests", [
-            "src/**/*.vscode.test.ts",
-            "src/test/suite/**/*.ts",
+          testOptions('Unit Tests', 'src/**/*.unit.test.ts'),
+          testOptions('Integration Tests', [
+            'src/**/*.vscode.test.ts',
+            'src/test/suite/**/*.ts',
           ]),
-          testOptions("E2E Tests", [
-            "src/test/*.e2e.test.ts",
-            "src/test/e2e.mocharc.js",
+          testOptions('E2E Tests', [
+            'src/test/*.e2e.test.ts',
+            'src/test/e2e.mocharc.js',
           ]),
         ]
       : [extensionOptions];
@@ -191,12 +191,12 @@ async function main(): Promise<void> {
         // Start watch mode
         const context = await esbuild.context(opts);
         await context.watch();
-        console.log("👀 Watching for changes...");
+        console.log('👀 Watching for changes...');
 
         // Handle process exit gracefully in watch mode
-        process.on("SIGINT", () => {
+        process.on('SIGINT', () => {
           void context.dispose();
-          console.log("\n🛑 Watch mode stopped");
+          console.log('\n🛑 Watch mode stopped');
           process.exit(0);
         });
       } else {
@@ -211,7 +211,7 @@ async function main(): Promise<void> {
     }
   } catch (error) {
     // Log any errors and exit with a non-zero code
-    console.error("🚨 Build process encountered an error:", error);
+    console.error('🚨 Build process encountered an error:', error);
     process.exit(1);
   }
 }

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import cspellESLintPluginRecommended from "@cspell/eslint-plugin/recommended";
-import eslint from "@eslint/js";
-import stylisticTs from "@stylistic/eslint-plugin";
-import eslintConfigPrettier from "eslint-config-prettier";
-import checkFile from "eslint-plugin-check-file";
-import importPlugin from "eslint-plugin-import";
+import cspellESLintPluginRecommended from '@cspell/eslint-plugin/recommended';
+import eslint from '@eslint/js';
+import stylisticTs from '@stylistic/eslint-plugin';
+import eslintConfigPrettier from 'eslint-config-prettier';
+import checkFile from 'eslint-plugin-check-file';
+import importPlugin from 'eslint-plugin-import';
 // @ts-expect-error: No type definitions available for this plugin.
-import licenseHeader from "eslint-plugin-license-header";
-import tsDocPlugin from "eslint-plugin-tsdoc";
-import globals from "globals";
-import tseslint from "typescript-eslint";
+import licenseHeader from 'eslint-plugin-license-header';
+import tsDocPlugin from 'eslint-plugin-tsdoc';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   eslint.configs.recommended,
@@ -24,7 +24,7 @@ export default tseslint.config(
   {
     languageOptions: {
       parserOptions: {
-        project: "./tsconfig.json",
+        project: './tsconfig.json',
         tsconfigRootDir: import.meta.dirname,
       },
       globals: {
@@ -32,22 +32,22 @@ export default tseslint.config(
       },
     },
     plugins: {
-      "@stylistic/ts": stylisticTs,
-      "check-file": checkFile,
+      '@stylistic/ts': stylisticTs,
+      'check-file': checkFile,
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      "license-header": licenseHeader,
+      'license-header': licenseHeader,
       import: importPlugin,
       tsdoc: tsDocPlugin,
     },
     rules: {
-      "import/order": [
-        "error",
+      'import/order': [
+        'error',
         {
-          alphabetize: { order: "asc", caseInsensitive: true },
+          alphabetize: { order: 'asc', caseInsensitive: true },
         },
       ],
-      "@/max-len": [
-        "error",
+      '@/max-len': [
+        'error',
         {
           ignoreTrailingComments: true,
           ignoreStrings: true,
@@ -55,63 +55,63 @@ export default tseslint.config(
           ignoreUrls: true,
           // Generics and regex literals are often long and can be hard to
           // split.
-          ignorePattern: "(<.*>)|(/.+/)",
+          ignorePattern: '(<.*>)|(/.+/)',
         },
       ],
-      "@typescript-eslint/no-unused-vars": [
-        "error",
+      '@typescript-eslint/no-unused-vars': [
+        'error',
         {
-          args: "all",
-          argsIgnorePattern: "^_",
-          caughtErrors: "all",
-          caughtErrorsIgnorePattern: "^_",
-          destructuredArrayIgnorePattern: "^_",
-          varsIgnorePattern: "^_",
+          args: 'all',
+          argsIgnorePattern: '^_',
+          caughtErrors: 'all',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
           ignoreRestSiblings: true,
         },
       ],
-      "@typescript-eslint/explicit-member-accessibility": [
-        "error",
-        { accessibility: "no-public" },
+      '@typescript-eslint/explicit-member-accessibility': [
+        'error',
+        { accessibility: 'no-public' },
       ],
-      "tsdoc/syntax": "warn",
-      "check-file/filename-naming-convention": [
-        "error",
+      'tsdoc/syntax': 'warn',
+      'check-file/filename-naming-convention': [
+        'error',
         {
-          "src/**/*.ts": "KEBAB_CASE",
+          'src/**/*.ts': 'KEBAB_CASE',
         },
         { ignoreMiddleExtensions: true },
       ],
     },
   },
   {
-    files: ["**/*.unit.test.ts"],
+    files: ['**/*.unit.test.ts'],
     rules: {
-      "@typescript-eslint/unbound-method": "off",
-      "@typescript-eslint/no-unused-expressions": "off",
+      '@typescript-eslint/unbound-method': 'off',
+      '@typescript-eslint/no-unused-expressions': 'off',
     },
   },
   {
-    files: ["**/*.mjs"],
+    files: ['**/*.mjs'],
     languageOptions: {
       ecmaVersion: 2022,
-      sourceType: "module",
+      sourceType: 'module',
       globals: {
         ...globals.node,
       },
     },
   },
   {
-    files: ["**/*.{ts,js,mocharc.js,mjs,mts}"],
+    files: ['**/*.{ts,js,mocharc.js,mjs,mts}'],
     rules: {
-      "license-header/header": [
-        "error",
+      'license-header/header': [
+        'error',
         [
-          "/**",
-          " * @license",
-          " * Copyright " + new Date().getFullYear().toString() + " Google LLC",
-          " * SPDX-License-Identifier: Apache-2.0",
-          " */",
+          '/**',
+          ' * @license',
+          ' * Copyright ' + new Date().getFullYear().toString() + ' Google LLC',
+          ' * SPDX-License-Identifier: Apache-2.0',
+          ' */',
         ],
       ],
     },

--- a/scripts/generate-config.mts
+++ b/scripts/generate-config.mts
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import fs from "fs/promises";
-import path from "path";
-import { fileURLToPath } from "url";
-import dotenv from "dotenv";
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 dotenv.config();
 
-const ColabEnvironments = ["production", "sandbox", "local"] as const;
+const ColabEnvironments = ['production', 'sandbox', 'local'] as const;
 
 const envConfig = {
   env: process.env.COLAB_EXTENSION_ENVIRONMENT,
@@ -26,31 +26,31 @@ let colabApiDomain: string;
 let colabGapiApiDomain: string;
 try {
   if (!envConfig.env) {
-    throw new Error("COLAB_EXTENSION_ENVIRONMENT is not set");
+    throw new Error('COLAB_EXTENSION_ENVIRONMENT is not set');
   }
   if (!envConfig.clientId) {
-    throw new Error("COLAB_EXTENSION_CLIENT_ID is not set");
+    throw new Error('COLAB_EXTENSION_CLIENT_ID is not set');
   }
   if (!envConfig.clientNotSoSecret) {
-    throw new Error("COLAB_EXTENSION_CLIENT_NOT_SO_SECRET is not set");
+    throw new Error('COLAB_EXTENSION_CLIENT_NOT_SO_SECRET is not set');
   }
   switch (envConfig.env) {
-    case "production":
-      colabApiDomain = "https://colab.research.google.com";
-      colabGapiApiDomain = "https://colab.pa.googleapis.com";
+    case 'production':
+      colabApiDomain = 'https://colab.research.google.com';
+      colabGapiApiDomain = 'https://colab.pa.googleapis.com';
       break;
-    case "sandbox":
-      colabApiDomain = "https://colab.sandbox.google.com";
-      colabGapiApiDomain = "https://staging-colab.sandbox.googleapis.com";
+    case 'sandbox':
+      colabApiDomain = 'https://colab.sandbox.google.com';
+      colabGapiApiDomain = 'https://staging-colab.sandbox.googleapis.com';
       break;
-    case "local":
-      colabApiDomain = "https://localhost:8888";
+    case 'local':
+      colabApiDomain = 'https://localhost:8888';
       // It's not feasible to run this locally.
-      colabGapiApiDomain = "https://staging-colab.sandbox.googleapis.com";
+      colabGapiApiDomain = 'https://staging-colab.sandbox.googleapis.com';
       break;
     default:
       throw new Error(
-        `Unknown COLAB_EXTENSION_ENVIRONMENT: "${envConfig.env}", expected one of: ${Object.values(ColabEnvironments).join(", ")}`,
+        `Unknown COLAB_EXTENSION_ENVIRONMENT: "${envConfig.env}", expected one of: ${Object.values(ColabEnvironments).join(', ')}`,
       );
   }
 } catch (err: unknown) {
@@ -84,7 +84,7 @@ const output = `${licenseHeader}
 export const CONFIG = ${JSON.stringify(config, null, 2)} as const;
 `;
 
-const configFile = path.join(__dirname, "../src/colab-config.ts");
+const configFile = path.join(__dirname, '../src/colab-config.ts');
 
 await fs.writeFile(configFile, output);
-console.log("✅ Wrote src/colab-config.ts");
+console.log('✅ Wrote src/colab-config.ts');

--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GaxiosError } from "gaxios";
-import { OAuth2Client } from "google-auth-library";
-import fetch from "node-fetch";
-import { v4 as uuid } from "uuid";
+import { GaxiosError } from 'gaxios';
+import { OAuth2Client } from 'google-auth-library';
+import fetch from 'node-fetch';
+import { v4 as uuid } from 'uuid';
 import vscode, {
   AuthenticationProvider,
   AuthenticationProviderAuthenticationSessionsChangeEvent,
@@ -16,21 +16,21 @@ import vscode, {
   Disposable,
   Event,
   EventEmitter,
-} from "vscode";
-import { z } from "zod";
-import { AUTHORIZATION_HEADER } from "../colab/headers";
-import { log } from "../common/logging";
-import { Toggleable } from "../common/toggleable";
-import { Credentials } from "./login";
-import { AuthStorage, RefreshableAuthenticationSession } from "./storage";
+} from 'vscode';
+import { z } from 'zod';
+import { AUTHORIZATION_HEADER } from '../colab/headers';
+import { log } from '../common/logging';
+import { Toggleable } from '../common/toggleable';
+import { Credentials } from './login';
+import { AuthStorage, RefreshableAuthenticationSession } from './storage';
 
 export const REQUIRED_SCOPES = [
-  "profile",
-  "email",
-  "https://www.googleapis.com/auth/colaboratory",
+  'profile',
+  'email',
+  'https://www.googleapis.com/auth/colaboratory',
 ] as const;
-const PROVIDER_ID = "google";
-const PROVIDER_LABEL = "Google";
+const PROVIDER_ID = 'google';
+const PROVIDER_LABEL = 'Google';
 const REFRESH_MARGIN_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
@@ -120,7 +120,7 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
    */
   dispose() {
     this.authProvider.dispose();
-    this.disposeController.abort(new Error("GoogleAuthProvider was disposed."));
+    this.disposeController.abort(new Error('GoogleAuthProvider was disposed.'));
   }
 
   /**
@@ -141,26 +141,26 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
     }
     this.oAuth2Client.setCredentials({
       refresh_token: session.refreshToken,
-      token_type: "Bearer",
-      scope: session.scopes.join(" "),
+      token_type: 'Bearer',
+      scope: session.scopes.join(' '),
     });
     try {
       await this.oAuth2Client.refreshAccessToken();
     } catch (err: unknown) {
       let shouldClearSession = false;
-      let reason = "";
+      let reason = '';
 
       if (
         err instanceof GaxiosError &&
         err.status === 400 &&
-        err.message.includes("invalid_grant")
+        err.message.includes('invalid_grant')
       ) {
-        reason = "OAuth app access to Colab was revoked";
+        reason = 'OAuth app access to Colab was revoked';
         shouldClearSession = true;
       } else if (err instanceof GaxiosError && err.status === 401) {
         // This should only ever be the case when developer building from source
         // switches the OAuth client ID / secret.
-        reason = "The configured OAuth client has changed";
+        reason = 'The configured OAuth client has changed';
         shouldClearSession = true;
       }
 
@@ -170,12 +170,12 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
         await this.initialize();
         return;
       }
-      log.error("Unable to refresh access token", err);
+      log.error('Unable to refresh access token', err);
       throw err;
     }
     const accessToken = this.oAuth2Client.credentials.access_token;
     if (!accessToken) {
-      throw new Error("Failed to refresh Google OAuth token.");
+      throw new Error('Failed to refresh Google OAuth token.');
     }
     this.session = {
       id: session.id,
@@ -258,7 +258,7 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
       const sortedScopes = scopes.sort();
       if (!matchesRequiredScopes(sortedScopes)) {
         throw new Error(
-          `Only supports the following scopes: ${sortedScopes.join(", ")}`,
+          `Only supports the following scopes: ${sortedScopes.join(', ')}`,
         );
       }
       const tokenInfo = await this.login(sortedScopes);
@@ -297,10 +297,10 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
           hasValidSession: true,
         });
       }
-      this.vs.window.showInformationMessage("Signed in to Google!");
+      this.vs.window.showInformationMessage('Signed in to Google!');
       return this.session;
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "unknown error";
+      const msg = err instanceof Error ? err.message : 'unknown error';
       this.vs.window.showErrorMessage(`Sign in failed: ${msg}`);
       throw err;
     }
@@ -346,8 +346,8 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
 
   private async setSignedInContext() {
     await this.vs.commands.executeCommand(
-      "setContext",
-      "colab.isSignedIn",
+      'setContext',
+      'colab.isSignedIn',
       !!this.session,
     );
   }
@@ -363,7 +363,7 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
     await this.oAuth2Client.refreshAccessToken();
     const accessToken = this.oAuth2Client.credentials.access_token;
     if (!accessToken) {
-      throw new Error("Failed to refresh Google OAuth token.");
+      throw new Error('Failed to refresh Google OAuth token.');
     }
     this.session = {
       ...this.session,
@@ -374,7 +374,7 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
   private async getUserInfo(
     token: string,
   ): Promise<z.infer<typeof UserInfoSchema>> {
-    const url = "https://www.googleapis.com/oauth2/v2/userinfo";
+    const url = 'https://www.googleapis.com/oauth2/v2/userinfo';
     const response = await fetch(url, {
       headers: {
         [AUTHORIZATION_HEADER.key]: `Bearer ${token}`,

--- a/src/auth/auth-provider.unit.test.ts
+++ b/src/auth/auth-provider.unit.test.ts
@@ -4,39 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import { GaxiosError } from "gaxios";
-import { OAuth2Client } from "google-auth-library";
-import fetch, { RequestInfo, RequestInit, Response } from "node-fetch";
-import { SinonStub, SinonStubbedInstance, SinonFakeTimers } from "sinon";
-import * as sinon from "sinon";
-import vscode from "vscode";
+import { expect } from 'chai';
+import { GaxiosError } from 'gaxios';
+import { OAuth2Client } from 'google-auth-library';
+import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
+import { SinonStub, SinonStubbedInstance, SinonFakeTimers } from 'sinon';
+import * as sinon from 'sinon';
+import vscode from 'vscode';
 import {
   AUTHORIZATION_HEADER,
   CONTENT_TYPE_JSON_HEADER,
-} from "../colab/headers";
-import { Toggleable } from "../common/toggleable";
-import { PROVIDER_ID } from "../config/constants";
-import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
+} from '../colab/headers';
+import { Toggleable } from '../common/toggleable';
+import { PROVIDER_ID } from '../config/constants';
+import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
 import {
   AuthChangeEvent,
   GoogleAuthProvider,
   REQUIRED_SCOPES,
-} from "./auth-provider";
-import { Credentials } from "./login";
-import { AuthStorage, RefreshableAuthenticationSession } from "./storage";
+} from './auth-provider';
+import { Credentials } from './login';
+import { AuthStorage, RefreshableAuthenticationSession } from './storage';
 
-const CLIENT_ID = "testClientId";
+const CLIENT_ID = 'testClientId';
 const SCOPES = Array.from(REQUIRED_SCOPES);
 const NOW = Date.now();
 const HOUR_MS = 60 * 60 * 1000;
-const DEFAULT_ACCESS_TOKEN = "42";
+const DEFAULT_ACCESS_TOKEN = '42';
 const DEFAULT_REFRESH_SESSION: RefreshableAuthenticationSession = {
-  id: "1",
-  refreshToken: "1//23",
+  id: '1',
+  refreshToken: '1//23',
   account: {
-    label: "Foo Bar",
-    id: "foo@example.com",
+    label: 'Foo Bar',
+    id: 'foo@example.com',
   },
   scopes: SCOPES,
 };
@@ -44,8 +44,8 @@ const DEFAULT_CREDENTIALS = {
   refresh_token: DEFAULT_REFRESH_SESSION.refreshToken,
   access_token: DEFAULT_ACCESS_TOKEN,
   expiry_date: NOW + HOUR_MS,
-  id_token: "eh",
-  scope: SCOPES.join(" "),
+  id_token: 'eh',
+  scope: SCOPES.join(' '),
 };
 const DEFAULT_AUTH_SESSION: vscode.AuthenticationSession = {
   id: DEFAULT_REFRESH_SESSION.id,
@@ -54,17 +54,17 @@ const DEFAULT_AUTH_SESSION: vscode.AuthenticationSession = {
   scopes: DEFAULT_REFRESH_SESSION.scopes.sort(),
 };
 const DEFAULT_USER_INFO = {
-  id: "1337",
-  email: "foo@example.com",
+  id: '1337',
+  email: 'foo@example.com',
   verified_email: true,
-  name: "Foo Bar",
-  given_name: "Foo",
-  family_name: "Bar",
-  picture: "https://example.com/foo.jpg",
-  hd: "google.com",
+  name: 'Foo Bar',
+  given_name: 'Foo',
+  family_name: 'Bar',
+  picture: 'https://example.com/foo.jpg',
+  hd: 'google.com',
 };
 
-describe("GoogleAuthProvider", () => {
+describe('GoogleAuthProvider', () => {
   let fakeClock: SinonFakeTimers;
   let vsCodeStub: VsCodeStub;
   let fetchStub: SinonStub<
@@ -90,7 +90,7 @@ describe("GoogleAuthProvider", () => {
   function signedInContextCalledWith(): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       vsCodeStub.commands.executeCommand
-        .withArgs("setContext", "colab.isSignedIn")
+        .withArgs('setContext', 'colab.isSignedIn')
         .callsFake((_command: string, _contextKey: string, value: boolean) => {
           resolve(value);
           return Promise.resolve();
@@ -101,12 +101,12 @@ describe("GoogleAuthProvider", () => {
   beforeEach(() => {
     fakeClock = sinon.useFakeTimers({ now: NOW, toFake: [] });
     vsCodeStub = newVsCodeStub();
-    fetchStub = sinon.stub(fetch, "default");
+    fetchStub = sinon.stub(fetch, 'default');
     storageStub = sinon.createStubInstance(AuthStorage);
     oauth2Client = new OAuth2Client(
       CLIENT_ID,
-      "testClientSecret",
-      "https://localhost:8888/vscode/redirect",
+      'testClientSecret',
+      'https://localhost:8888/vscode/redirect',
     );
     loginStub = sinon.stub();
     onDidChangeSessionsStub = sinon.stub();
@@ -126,7 +126,7 @@ describe("GoogleAuthProvider", () => {
     sinon.restore();
   });
 
-  describe("lifecycle", () => {
+  describe('lifecycle', () => {
     it('registers the "Google" authentication provider', async () => {
       await authProvider.initialize();
       // Expect the provider-specific rejection surrounding the scopes not
@@ -134,9 +134,9 @@ describe("GoogleAuthProvider", () => {
       // registered and is being used.
       await expect(
         vsCodeStub.authentication.getSession(PROVIDER_ID, [
-          "make",
-          "it",
-          "error",
+          'make',
+          'it',
+          'error',
         ]),
       ).to.eventually.be.rejectedWith(/scopes/);
     });
@@ -149,7 +149,7 @@ describe("GoogleAuthProvider", () => {
       ).to.eventually.be.rejectedWith(/No provider/);
     });
 
-    it("is not functional until initialized", async () => {
+    it('is not functional until initialized', async () => {
       await expect(
         authProvider.getSessions(undefined, {}),
       ).to.eventually.be.rejectedWith(/call initialize/);
@@ -157,12 +157,12 @@ describe("GoogleAuthProvider", () => {
         authProvider.createSession([]),
       ).to.eventually.be.rejectedWith(/call initialize/);
       await expect(
-        authProvider.removeSession(""),
+        authProvider.removeSession(''),
       ).to.eventually.be.rejectedWith(/call initialize/);
     });
 
-    describe("initialize", () => {
-      it("throws an error if disposed", async () => {
+    describe('initialize', () => {
+      it('throws an error if disposed', async () => {
         authProvider.dispose();
 
         await expect(authProvider.initialize()).to.eventually.be.rejectedWith(
@@ -170,11 +170,11 @@ describe("GoogleAuthProvider", () => {
         );
       });
 
-      it("does not doubly initialize", async () => {
+      it('does not doubly initialize', async () => {
         storageStub.getSession.resolves(DEFAULT_REFRESH_SESSION);
-        const setCredentialsSpy = sinon.spy(oauth2Client, "setCredentials");
+        const setCredentialsSpy = sinon.spy(oauth2Client, 'setCredentials');
         const refreshStub = sinon
-          .stub(oauth2Client, "refreshAccessToken")
+          .stub(oauth2Client, 'refreshAccessToken')
           .callsFake(() => {
             oauth2Client.credentials.access_token = DEFAULT_ACCESS_TOKEN;
           });
@@ -186,7 +186,7 @@ describe("GoogleAuthProvider", () => {
         sinon.assert.calledOnce(refreshStub);
       });
 
-      it("does nothing without a stored session", async () => {
+      it('does nothing without a stored session', async () => {
         await expect(authProvider.initialize()).to.eventually.be.fulfilled;
 
         await expect(
@@ -194,22 +194,22 @@ describe("GoogleAuthProvider", () => {
         ).to.eventually.deep.equal([]);
       });
 
-      describe("with a stored session", () => {
+      describe('with a stored session', () => {
         beforeEach(() => {
           storageStub.getSession.resolves(DEFAULT_REFRESH_SESSION);
         });
 
-        it("rejects when unable to refresh the OAuth token", async () => {
+        it('rejects when unable to refresh the OAuth token', async () => {
           // Don't set a new `access_token`.
-          sinon.stub(oauth2Client, "refreshAccessToken").resolves();
+          sinon.stub(oauth2Client, 'refreshAccessToken').resolves();
 
           await expect(authProvider.initialize()).to.eventually.be.rejectedWith(
             /refresh/,
           );
         });
 
-        it("saturates the oAuth2 credentials", async () => {
-          sinon.stub(oauth2Client, "refreshAccessToken").callsFake(() => {
+        it('saturates the oAuth2 credentials', async () => {
+          sinon.stub(oauth2Client, 'refreshAccessToken').callsFake(() => {
             oauth2Client.credentials.access_token = DEFAULT_ACCESS_TOKEN;
           });
 
@@ -221,8 +221,8 @@ describe("GoogleAuthProvider", () => {
           expect(session.accessToken).to.equal(DEFAULT_ACCESS_TOKEN);
         });
 
-        it("emits a session change", async () => {
-          sinon.stub(oauth2Client, "refreshAccessToken").callsFake(() => {
+        it('emits a session change', async () => {
+          sinon.stub(oauth2Client, 'refreshAccessToken').callsFake(() => {
             oauth2Client.credentials.access_token = DEFAULT_ACCESS_TOKEN;
           });
 
@@ -238,10 +238,10 @@ describe("GoogleAuthProvider", () => {
 
         const gaxiosErrors: { message: string; status: number }[] = [
           {
-            message: "invalid_grant",
+            message: 'invalid_grant',
             status: 400,
           },
-          { message: "unauthorized_client", status: 401 },
+          { message: 'unauthorized_client', status: 401 },
         ];
         for (const { message, status } of gaxiosErrors) {
           it(`clears the session and re-initializes if refreshAccessToken throws a ${status.toString()} GaxiosError`, async () => {
@@ -252,12 +252,12 @@ describe("GoogleAuthProvider", () => {
                 config: {},
                 data: undefined,
                 status,
-                statusText: "Unauthorized",
+                statusText: 'Unauthorized',
                 headers: {},
-                request: { responseURL: "" },
+                request: { responseURL: '' },
               },
             );
-            sinon.stub(oauth2Client, "refreshAccessToken").throws(gaxiosError);
+            sinon.stub(oauth2Client, 'refreshAccessToken').throws(gaxiosError);
             storageStub.getSession.onSecondCall().resolves(undefined);
 
             await expect(authProvider.initialize()).to.eventually.be.fulfilled;
@@ -272,8 +272,8 @@ describe("GoogleAuthProvider", () => {
           });
         }
 
-        it("sets the signed in context", async () => {
-          sinon.stub(oauth2Client, "refreshAccessToken").callsFake(() => {
+        it('sets the signed in context', async () => {
+          sinon.stub(oauth2Client, 'refreshAccessToken').callsFake(() => {
             oauth2Client.credentials.access_token = DEFAULT_ACCESS_TOKEN;
           });
           const signedInContext = signedInContextCalledWith();
@@ -283,20 +283,20 @@ describe("GoogleAuthProvider", () => {
           await expect(signedInContext).to.eventually.be.true;
         });
 
-        it("clears the session and re-initializes if refreshAccessToken throws a 401 GaxiosError", async () => {
+        it('clears the session and re-initializes if refreshAccessToken throws a 401 GaxiosError', async () => {
           const gaxiosError: GaxiosError = new GaxiosError(
-            "unauthorized_client",
+            'unauthorized_client',
             {},
             {
               config: {},
               data: undefined,
               status: 401,
-              statusText: "Unauthorized",
+              statusText: 'Unauthorized',
               headers: {},
-              request: { responseURL: "" },
+              request: { responseURL: '' },
             },
           );
-          sinon.stub(oauth2Client, "refreshAccessToken").throws(gaxiosError);
+          sinon.stub(oauth2Client, 'refreshAccessToken').throws(gaxiosError);
           storageStub.getSession.onSecondCall().resolves(undefined);
 
           await expect(authProvider.initialize()).to.eventually.be.fulfilled;
@@ -310,10 +310,10 @@ describe("GoogleAuthProvider", () => {
           );
         });
 
-        it("re-throws non handled errors when refreshing the access token", async () => {
+        it('re-throws non handled errors when refreshing the access token', async () => {
           sinon
-            .stub(oauth2Client, "refreshAccessToken")
-            .throws(new Error("🤮"));
+            .stub(oauth2Client, 'refreshAccessToken')
+            .throws(new Error('🤮'));
 
           await expect(authProvider.initialize()).to.eventually.be.rejectedWith(
             /🤮/,
@@ -323,7 +323,7 @@ describe("GoogleAuthProvider", () => {
     });
   });
 
-  describe("whileAuthorized", () => {
+  describe('whileAuthorized', () => {
     let toggles: sinon.SinonStubbedInstance<Toggleable>[];
 
     beforeEach(() => {
@@ -339,13 +339,13 @@ describe("GoogleAuthProvider", () => {
       ];
     });
 
-    it("throws when uninitialized", () => {
+    it('throws when uninitialized', () => {
       expect(() => authProvider.whileAuthorized(...toggles)).to.throw(
         /initialize/,
       );
     });
 
-    it("throws when disposed", async () => {
+    it('throws when disposed', async () => {
       await authProvider.initialize();
       authProvider.dispose();
 
@@ -354,8 +354,8 @@ describe("GoogleAuthProvider", () => {
       );
     });
 
-    it("initializes toggles to on when authorized", async () => {
-      sinon.stub(oauth2Client, "refreshAccessToken").callsFake(() => {
+    it('initializes toggles to on when authorized', async () => {
+      sinon.stub(oauth2Client, 'refreshAccessToken').callsFake(() => {
         oauth2Client.credentials.access_token = DEFAULT_ACCESS_TOKEN;
       });
       storageStub.getSession.resolves(DEFAULT_REFRESH_SESSION);
@@ -369,7 +369,7 @@ describe("GoogleAuthProvider", () => {
       }
     });
 
-    it("initializes toggles to off when not authorized", async () => {
+    it('initializes toggles to off when not authorized', async () => {
       await authProvider.initialize();
 
       authProvider.whileAuthorized(...toggles);
@@ -380,12 +380,12 @@ describe("GoogleAuthProvider", () => {
       }
     });
 
-    it("turns toggles on when session becomes authorized", async () => {
+    it('turns toggles on when session becomes authorized', async () => {
       await authProvider.initialize();
       authProvider.whileAuthorized(...toggles);
       loginStub.withArgs(SCOPES).resolves(DEFAULT_CREDENTIALS);
       fetchStub
-        .withArgs("https://www.googleapis.com/oauth2/v2/userinfo", {
+        .withArgs('https://www.googleapis.com/oauth2/v2/userinfo', {
           headers: {
             [AUTHORIZATION_HEADER.key]: `Bearer ${DEFAULT_ACCESS_TOKEN}`,
           },
@@ -411,13 +411,13 @@ describe("GoogleAuthProvider", () => {
       }
     });
 
-    it("turns toggles off when session is no longer authorized", async () => {
-      sinon.stub(oauth2Client, "refreshAccessToken").callsFake(() => {
+    it('turns toggles off when session is no longer authorized', async () => {
+      sinon.stub(oauth2Client, 'refreshAccessToken').callsFake(() => {
         oauth2Client.credentials.access_token = DEFAULT_ACCESS_TOKEN;
       });
       storageStub.getSession.resolves(DEFAULT_REFRESH_SESSION);
       await authProvider.initialize();
-      sinon.stub(oauth2Client, "revokeToken").resolves();
+      sinon.stub(oauth2Client, 'revokeToken').resolves();
       authProvider.whileAuthorized(...toggles);
       for (const t of toggles) {
         t.on.resetHistory();
@@ -433,25 +433,25 @@ describe("GoogleAuthProvider", () => {
     });
   });
 
-  describe("getSessions", () => {
+  describe('getSessions', () => {
     let refreshAccessTokenStub: sinon.SinonStubbedMember<
-      OAuth2Client["refreshAccessToken"]
+      OAuth2Client['refreshAccessToken']
     >;
     beforeEach(() => {
       refreshAccessTokenStub = sinon
-        .stub(oauth2Client, "refreshAccessToken")
+        .stub(oauth2Client, 'refreshAccessToken')
         .callsFake(() => {
           oauth2Client.credentials.access_token = DEFAULT_ACCESS_TOKEN;
         });
     });
 
-    it("throws when uninitialized", async () => {
+    it('throws when uninitialized', async () => {
       await expect(
         authProvider.getSessions(undefined, {}),
       ).to.eventually.be.rejectedWith(/initialize/);
     });
 
-    it("throws when disposed", async () => {
+    it('throws when disposed', async () => {
       await authProvider.initialize();
       authProvider.dispose();
 
@@ -460,18 +460,18 @@ describe("GoogleAuthProvider", () => {
       ).to.eventually.be.rejectedWith(/disposed/);
     });
 
-    describe("when no session is stored", () => {
+    describe('when no session is stored', () => {
       beforeEach(async () => {
         await authProvider.initialize();
       });
 
-      it("returns an empty array when scopes deviate from the supported set", async () => {
+      it('returns an empty array when scopes deviate from the supported set', async () => {
         await expect(
-          authProvider.getSessions(["foo", "bar"], {}),
+          authProvider.getSessions(['foo', 'bar'], {}),
         ).to.eventually.deep.equal([]);
       });
 
-      it("returns an empty array", async () => {
+      it('returns an empty array', async () => {
         storageStub.getSession.resolves(undefined);
 
         const sessions = authProvider.getSessions(undefined, {});
@@ -481,7 +481,7 @@ describe("GoogleAuthProvider", () => {
       });
     });
 
-    describe("when a session is stored", () => {
+    describe('when a session is stored', () => {
       beforeEach(async () => {
         storageStub.getSession.resolves(DEFAULT_REFRESH_SESSION);
         await authProvider.initialize();
@@ -489,12 +489,12 @@ describe("GoogleAuthProvider", () => {
 
       it("returns an empty array when the specified scopes aren't supported", async () => {
         await expect(
-          authProvider.getSessions(["foo", "bar"], {}),
+          authProvider.getSessions(['foo', 'bar'], {}),
         ).to.eventually.deep.equal([]);
       });
 
-      it("returns an empty array when the specified account does not match", async () => {
-        const otherAccount = { id: "kev@example.com", label: "Kevin Eger" };
+      it('returns an empty array when the specified account does not match', async () => {
+        const otherAccount = { id: 'kev@example.com', label: 'Kevin Eger' };
         await expect(
           authProvider.getSessions(SCOPES, {
             account: otherAccount,
@@ -502,19 +502,19 @@ describe("GoogleAuthProvider", () => {
         ).to.eventually.deep.equal([]);
       });
 
-      it("returns the session", async () => {
+      it('returns the session', async () => {
         const sessions = authProvider.getSessions(undefined, {});
 
         await expect(sessions).to.eventually.deep.equal([DEFAULT_AUTH_SESSION]);
       });
 
-      it("returns the session when the specified scopes match", async () => {
+      it('returns the session when the specified scopes match', async () => {
         const sessions = authProvider.getSessions(SCOPES, {});
 
         await expect(sessions).to.eventually.deep.equal([DEFAULT_AUTH_SESSION]);
       });
 
-      it("returns the session when the specified account matches", async () => {
+      it('returns the session when the specified account matches', async () => {
         const sessions = authProvider.getSessions(undefined, {
           account: DEFAULT_REFRESH_SESSION.account,
         });
@@ -526,7 +526,7 @@ describe("GoogleAuthProvider", () => {
         refreshAccessTokenStub.callsFake(() => {
           oauth2Client.credentials = {
             ...oauth2Client.credentials,
-            access_token: "new",
+            access_token: 'new',
           };
         });
         const fourMinutesMs = 4 * 60 * 1000;
@@ -535,7 +535,7 @@ describe("GoogleAuthProvider", () => {
         const sessions = authProvider.getSessions(undefined, {});
 
         await expect(sessions).to.eventually.deep.equal([
-          { ...DEFAULT_AUTH_SESSION, accessToken: "new" },
+          { ...DEFAULT_AUTH_SESSION, accessToken: 'new' },
         ]);
       });
 
@@ -543,7 +543,7 @@ describe("GoogleAuthProvider", () => {
         refreshAccessTokenStub.callsFake(() => {
           oauth2Client.credentials = {
             ...oauth2Client.credentials,
-            access_token: "new",
+            access_token: 'new',
           };
         });
         fakeClock.tick(HOUR_MS * 2);
@@ -551,26 +551,26 @@ describe("GoogleAuthProvider", () => {
         const sessions = authProvider.getSessions(undefined, {});
 
         await expect(sessions).to.eventually.deep.equal([
-          { ...DEFAULT_AUTH_SESSION, accessToken: "new" },
+          { ...DEFAULT_AUTH_SESSION, accessToken: 'new' },
         ]);
       });
     });
   });
 
-  describe("createSession", () => {
+  describe('createSession', () => {
     beforeEach(() => {
-      sinon.stub(oauth2Client, "refreshAccessToken").callsFake(() => {
+      sinon.stub(oauth2Client, 'refreshAccessToken').callsFake(() => {
         oauth2Client.credentials.access_token = DEFAULT_ACCESS_TOKEN;
       });
     });
 
-    it("throws when uninitialized", async () => {
+    it('throws when uninitialized', async () => {
       await expect(
         authProvider.createSession(SCOPES),
       ).to.eventually.be.rejectedWith(/initialize/);
     });
 
-    it("throws when disposed", async () => {
+    it('throws when disposed', async () => {
       await authProvider.initialize();
       authProvider.dispose();
 
@@ -579,17 +579,17 @@ describe("GoogleAuthProvider", () => {
       ).to.eventually.be.rejectedWith(/disposed/);
     });
 
-    it("rejects when the scopes are not supported", async () => {
+    it('rejects when the scopes are not supported', async () => {
       await authProvider.initialize();
 
       await expect(
-        authProvider.createSession(["foo", "bar"]),
+        authProvider.createSession(['foo', 'bar']),
       ).to.eventually.be.rejectedWith(/scopes/);
     });
 
-    it("rejects when getting token fails", async () => {
+    it('rejects when getting token fails', async () => {
       await authProvider.initialize();
-      loginStub.rejects(new Error("Failed to get token"));
+      loginStub.rejects(new Error('Failed to get token'));
 
       await expect(
         authProvider.createSession(SCOPES),
@@ -601,12 +601,12 @@ describe("GoogleAuthProvider", () => {
       );
     });
 
-    describe("with a successful login", () => {
+    describe('with a successful login', () => {
       beforeEach(async () => {
         await authProvider.initialize();
         loginStub.withArgs(SCOPES).resolves(DEFAULT_CREDENTIALS);
         fetchStub
-          .withArgs("https://www.googleapis.com/oauth2/v2/userinfo", {
+          .withArgs('https://www.googleapis.com/oauth2/v2/userinfo', {
             headers: {
               [AUTHORIZATION_HEADER.key]: `Bearer ${DEFAULT_ACCESS_TOKEN}`,
             },
@@ -621,7 +621,7 @@ describe("GoogleAuthProvider", () => {
           );
       });
 
-      it("creates a new session", async () => {
+      it('creates a new session', async () => {
         const signedInContext = signedInContextCalledWith();
         const session = await authProvider.createSession(SCOPES);
 
@@ -643,7 +643,7 @@ describe("GoogleAuthProvider", () => {
         await expect(signedInContext).to.eventually.be.true;
       });
 
-      it("replaces an existing session", async () => {
+      it('replaces an existing session', async () => {
         storageStub.getSession.resolves(DEFAULT_REFRESH_SESSION);
         const session = await authProvider.createSession(SCOPES);
 
@@ -662,32 +662,32 @@ describe("GoogleAuthProvider", () => {
     });
   });
 
-  describe("removeSession", () => {
+  describe('removeSession', () => {
     beforeEach(() => {
-      sinon.stub(oauth2Client, "refreshAccessToken").callsFake(() => {
+      sinon.stub(oauth2Client, 'refreshAccessToken').callsFake(() => {
         oauth2Client.credentials.access_token = DEFAULT_ACCESS_TOKEN;
       });
     });
 
-    it("throws when uninitialized", async () => {
+    it('throws when uninitialized', async () => {
       await expect(
-        authProvider.removeSession("foo"),
+        authProvider.removeSession('foo'),
       ).to.eventually.be.rejectedWith(/initialize/);
     });
 
-    it("throws when disposed", async () => {
+    it('throws when disposed', async () => {
       await authProvider.initialize();
       authProvider.dispose();
 
       await expect(
-        authProvider.removeSession("foo"),
+        authProvider.removeSession('foo'),
       ).to.eventually.be.rejectedWith(/disposed/);
     });
 
-    it("does nothing when there is no session", async () => {
+    it('does nothing when there is no session', async () => {
       await authProvider.initialize();
 
-      await authProvider.removeSession("foo");
+      await authProvider.removeSession('foo');
 
       sinon.assert.notCalled(storageStub.removeSession);
       sinon.assert.notCalled(onDidChangeSessionsStub);
@@ -698,27 +698,27 @@ describe("GoogleAuthProvider", () => {
       await authProvider.initialize();
       onDidChangeSessionsStub.resetHistory();
 
-      await authProvider.removeSession("foo");
+      await authProvider.removeSession('foo');
 
       sinon.assert.notCalled(storageStub.removeSession);
       sinon.assert.notCalled(onDidChangeSessionsStub);
     });
 
-    describe("when there is a session to remove", () => {
+    describe('when there is a session to remove', () => {
       beforeEach(async () => {
         storageStub.getSession.resolves(DEFAULT_REFRESH_SESSION);
         await authProvider.initialize();
       });
 
-      it("swallows errors from revoking credentials", async () => {
-        sinon.stub(oauth2Client, "revokeToken").rejects(new Error("Barf"));
+      it('swallows errors from revoking credentials', async () => {
+        sinon.stub(oauth2Client, 'revokeToken').rejects(new Error('Barf'));
 
         await expect(authProvider.removeSession(DEFAULT_REFRESH_SESSION.id)).to
           .eventually.be.fulfilled;
       });
 
-      it("removes the session", async () => {
-        sinon.stub(oauth2Client, "revokeToken").resolves();
+      it('removes the session', async () => {
+        sinon.stub(oauth2Client, 'revokeToken').resolves();
         const signedInContext = signedInContextCalledWith();
 
         await authProvider.removeSession(DEFAULT_REFRESH_SESSION.id);
@@ -729,8 +729,8 @@ describe("GoogleAuthProvider", () => {
         await expect(signedInContext).to.eventually.be.false;
       });
 
-      it("notifies of the removed session", async () => {
-        sinon.stub(oauth2Client, "revokeToken").resolves();
+      it('notifies of the removed session', async () => {
+        sinon.stub(oauth2Client, 'revokeToken').resolves();
         onDidChangeSessionsStub.resetHistory();
         const session = await authProvider.getSessions(undefined, {});
 

--- a/src/auth/code-manager.ts
+++ b/src/auth/code-manager.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode from "vscode";
+import vscode from 'vscode';
 
 const EXCHANGE_TIMEOUT_MS = 60_000;
 
@@ -31,7 +31,7 @@ export class CodeManager implements vscode.Disposable {
    * when the class instance is no longer needed to prevent resource leaks.
    */
   dispose(): void {
-    const error = new Error("Authentication provider has been disposed.");
+    const error = new Error('Authentication provider has been disposed.');
     for (const promiseHandlers of this.inFlightPromises.values()) {
       promiseHandlers.reject(error);
     }
@@ -85,7 +85,7 @@ export class CodeManager implements vscode.Disposable {
   resolveCode(nonce: string, code: string): void {
     const inFlight = this.inFlightPromises.get(nonce);
     if (!inFlight) {
-      throw new Error("Unexpected code exchange received");
+      throw new Error('Unexpected code exchange received');
     }
 
     inFlight.resolve(code);
@@ -102,7 +102,7 @@ function waitForCancellation(
   let listener: vscode.Disposable;
   const promise = new Promise<never>((_, reject) => {
     listener = token.onCancellationRequested(() => {
-      reject(new Error("Authentication was cancelled by the user"));
+      reject(new Error('Authentication was cancelled by the user'));
     });
   });
 
@@ -121,7 +121,7 @@ function waitForTimeout(ms: number): DisposablePromise<never> {
   let timeoutId: NodeJS.Timeout;
   const promise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
-      reject(new Error("Exchange timeout exceeded"));
+      reject(new Error('Exchange timeout exceeded'));
     }, ms);
   });
 

--- a/src/auth/code-manager.unit.test.ts
+++ b/src/auth/code-manager.unit.test.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import { SinonFakeTimers } from "sinon";
-import * as sinon from "sinon";
-import { CancellationTokenSource } from "vscode";
-import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
-import { CodeManager } from "./code-manager";
+import { expect } from 'chai';
+import { SinonFakeTimers } from 'sinon';
+import * as sinon from 'sinon';
+import { CancellationTokenSource } from 'vscode';
+import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
+import { CodeManager } from './code-manager';
 
-describe("CodeManager", () => {
+describe('CodeManager', () => {
   let vsCodeStub: VsCodeStub;
   let clock: SinonFakeTimers;
   let cancellationTokenSource: CancellationTokenSource;
@@ -19,7 +19,7 @@ describe("CodeManager", () => {
 
   beforeEach(() => {
     vsCodeStub = newVsCodeStub();
-    clock = sinon.useFakeTimers({ toFake: ["setTimeout"] });
+    clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
     cancellationTokenSource = new vsCodeStub.CancellationTokenSource();
     manager = new CodeManager();
   });
@@ -30,16 +30,16 @@ describe("CodeManager", () => {
     sinon.restore();
   });
 
-  it("rejects outstanding codes when disposed", async () => {
-    const code = manager.waitForCode("1", cancellationTokenSource.token);
+  it('rejects outstanding codes when disposed', async () => {
+    const code = manager.waitForCode('1', cancellationTokenSource.token);
 
     manager.dispose();
 
     await expect(code).to.be.rejectedWith(/disposed/);
   });
 
-  it("rejects when waiting for the same nonce", async () => {
-    const nonce = "1";
+  it('rejects when waiting for the same nonce', async () => {
+    const nonce = '1';
 
     void manager.waitForCode(nonce, cancellationTokenSource.token);
 
@@ -48,13 +48,13 @@ describe("CodeManager", () => {
     ).to.be.rejectedWith(/waiting/);
   });
 
-  it("throws when resolving an unknown nonce", async () => {
-    const nonce = "1";
-    const code = "42";
+  it('throws when resolving an unknown nonce', async () => {
+    const nonce = '1';
+    const code = '42';
     const gotCode = manager.waitForCode(nonce, cancellationTokenSource.token);
 
     expect(() => {
-      manager.resolveCode("unknown", code);
+      manager.resolveCode('unknown', code);
     }).to.throw(/Unexpected/);
 
     // Ensure no code is resolved and ultimately times out.
@@ -62,25 +62,25 @@ describe("CodeManager", () => {
     await expect(gotCode).to.be.rejectedWith(/timeout/);
   });
 
-  it("rejects when the timeout is exceeded", async () => {
-    const gotCode = manager.waitForCode("1", cancellationTokenSource.token);
+  it('rejects when the timeout is exceeded', async () => {
+    const gotCode = manager.waitForCode('1', cancellationTokenSource.token);
 
     clock.tick(60_001);
 
     await expect(gotCode).to.be.rejectedWith(/timeout/);
   });
 
-  it("rejects when the user cancels", async () => {
-    const gotCode = manager.waitForCode("1", cancellationTokenSource.token);
+  it('rejects when the user cancels', async () => {
+    const gotCode = manager.waitForCode('1', cancellationTokenSource.token);
 
     cancellationTokenSource.cancel();
 
     await expect(gotCode).to.be.rejectedWith(/cancelled/);
   });
 
-  it("resolves a code", async () => {
-    const code = "42";
-    const nonce = "123";
+  it('resolves a code', async () => {
+    const code = '42';
+    const nonce = '123';
 
     const gotCode = manager.waitForCode(nonce, cancellationTokenSource.token);
     manager.resolveCode(nonce, code);
@@ -88,10 +88,10 @@ describe("CodeManager", () => {
     await expect(gotCode).to.eventually.equal(code);
   });
 
-  it("resolves the code corresponding to the nonce", async () => {
+  it('resolves the code corresponding to the nonce', async () => {
     const redirects = [
-      { nonce: "1", code: "42" },
-      { nonce: "2", code: "99" },
+      { nonce: '1', code: '42' },
+      { nonce: '2', code: '99' },
     ];
 
     const gotFirstCode = manager.waitForCode(
@@ -110,11 +110,11 @@ describe("CodeManager", () => {
     await expect(gotSecondCode).to.eventually.equal(redirects[1].code);
   });
 
-  it("resolves a code while another request times out", async () => {
-    const code = "42";
-    const nonce = "2";
+  it('resolves a code while another request times out', async () => {
+    const code = '42';
+    const nonce = '2';
     const gotFirstCode = manager.waitForCode(
-      "1",
+      '1',
       cancellationTokenSource.token,
     );
     // Wait 30s after the first.

--- a/src/auth/flows/flows.ts
+++ b/src/auth/flows/flows.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import path from "path";
-import { CodeChallengeMethod, GenerateAuthUrlOpts } from "google-auth-library";
-import { OAuth2Client } from "google-auth-library";
-import vscode from "vscode";
-import { PackageInfo } from "../../config/package-info";
-import { buildExtensionUri } from "../../system/uri";
-import { LocalServerFlow } from "./loopback";
-import { ProxiedRedirectFlow } from "./proxied";
+import path from 'path';
+import { CodeChallengeMethod, GenerateAuthUrlOpts } from 'google-auth-library';
+import { OAuth2Client } from 'google-auth-library';
+import vscode from 'vscode';
+import { PackageInfo } from '../../config/package-info';
+import { buildExtensionUri } from '../../system/uri';
+import { LocalServerFlow } from './loopback';
+import { ProxiedRedirectFlow } from './proxied';
 
 /**
  * Options for triggering an OAuth2 flow.
@@ -45,9 +45,9 @@ export interface OAuth2Flow {
 }
 
 export const DEFAULT_AUTH_URL_OPTS: GenerateAuthUrlOpts = {
-  access_type: "offline",
-  response_type: "code",
-  prompt: "consent",
+  access_type: 'offline',
+  response_type: 'code',
+  prompt: 'consent',
   code_challenge_method: CodeChallengeMethod.S256,
 };
 
@@ -66,7 +66,7 @@ export function getOAuth2Flows(
     flows.push(
       new LocalServerFlow(
         vs,
-        path.join(__dirname, "auth/media"),
+        path.join(__dirname, 'auth/media'),
         oAuth2Client,
         extensionUri,
       ),

--- a/src/auth/flows/flows.unit.test.ts
+++ b/src/auth/flows/flows.unit.test.ts
@@ -4,21 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import { OAuth2Client } from "google-auth-library";
-import sinon from "sinon";
-import vscode from "vscode";
-import { PackageInfo } from "../../config/package-info";
-import { newVsCodeStub, VsCodeStub } from "../../test/helpers/vscode";
-import { getOAuth2Flows, OAuth2Flow } from "./flows";
+import { expect } from 'chai';
+import { OAuth2Client } from 'google-auth-library';
+import sinon from 'sinon';
+import vscode from 'vscode';
+import { PackageInfo } from '../../config/package-info';
+import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
+import { getOAuth2Flows, OAuth2Flow } from './flows';
 
 const PACKAGE_INFO: PackageInfo = {
-  publisher: "google",
-  name: "colab",
-  version: "0.1.0",
+  publisher: 'google',
+  name: 'colab',
+  version: '0.1.0',
 };
 
-describe("getOAuth2Flows", () => {
+describe('getOAuth2Flows', () => {
   let vs: VsCodeStub;
 
   beforeEach(() => {
@@ -38,18 +38,18 @@ describe("getOAuth2Flows", () => {
     );
   }
 
-  it("returns the local server and proxied redirect flows when running on desktop", () => {
+  it('returns the local server and proxied redirect flows when running on desktop', () => {
     const flows = getOAuth2FlowsFor(vs.UIKind.Desktop);
 
     expect(flows).to.have.lengthOf(2);
-    expect(flows[0].constructor.name).to.equal("LocalServerFlow");
-    expect(flows[1].constructor.name).to.equal("ProxiedRedirectFlow");
+    expect(flows[0].constructor.name).to.equal('LocalServerFlow');
+    expect(flows[1].constructor.name).to.equal('ProxiedRedirectFlow');
   });
 
-  it("returns the proxied redirect flow when running on web", () => {
+  it('returns the proxied redirect flow when running on web', () => {
     const flows = getOAuth2FlowsFor(vs.UIKind.Web);
 
     expect(flows).to.have.lengthOf(1);
-    expect(flows[0].constructor.name).to.equal("ProxiedRedirectFlow");
+    expect(flows[0].constructor.name).to.equal('ProxiedRedirectFlow');
   });
 });

--- a/src/auth/flows/loopback.ts
+++ b/src/auth/flows/loopback.ts
@@ -4,22 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import assert from "assert";
-import * as fs from "fs";
-import * as http from "http";
-import * as path from "path";
-import { OAuth2Client } from "google-auth-library";
-import vscode from "vscode";
-import { CONFIG } from "../../colab-config";
-import { log } from "../../common/logging";
-import { LoopbackHandler, LoopbackServer } from "../../common/loopback-server";
-import { CodeManager } from "../code-manager";
+import assert from 'assert';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as path from 'path';
+import { OAuth2Client } from 'google-auth-library';
+import vscode from 'vscode';
+import { CONFIG } from '../../colab-config';
+import { log } from '../../common/logging';
+import { LoopbackHandler, LoopbackServer } from '../../common/loopback-server';
+import { CodeManager } from '../code-manager';
 import {
   DEFAULT_AUTH_URL_OPTS,
   OAuth2Flow,
   OAuth2TriggerOptions,
   FlowResult,
-} from "./flows";
+} from './flows';
 
 /**
  * An OAuth2 flow that uses a local server to handle the redirect URI.
@@ -112,39 +112,39 @@ class Handler implements LoopbackHandler {
     assert(req.url);
     assert(req.headers.host);
     const url = new URL(req.url, `http://${req.headers.host}`);
-    if (req.method !== "GET") {
-      res.writeHead(405, { Allow: "GET" });
-      res.end("Method Not Allowed");
+    if (req.method !== 'GET') {
+      res.writeHead(405, { Allow: 'GET' });
+      res.end('Method Not Allowed');
       return;
     }
     switch (url.pathname) {
-      case "/": {
-        const state = url.searchParams.get("state");
+      case '/': {
+        const state = url.searchParams.get('state');
         if (!state) {
-          throw new Error("Missing state in redirect URL");
+          throw new Error('Missing state in redirect URL');
         }
         const parsedState = new URLSearchParams(state);
-        const nonce = parsedState.get("nonce");
-        const code = url.searchParams.get("code");
+        const nonce = parsedState.get('nonce');
+        const code = url.searchParams.get('code');
         if (!nonce || !code) {
-          throw new Error("Missing nonce or code in redirect URI");
+          throw new Error('Missing nonce or code in redirect URI');
         }
         this.codeProvider.resolveCode(nonce, code);
 
         void this.redirectSuccessfulAuth(res).catch((err: unknown) => {
-          log.error("Unable to redirect the successful auth request", err);
+          log.error('Unable to redirect the successful auth request', err);
         });
         break;
       }
-      case "/favicon.ico": {
+      case '/favicon.ico': {
         const assetPath = url.pathname.substring(1);
         sendFile(res, path.join(this.serveRoot, assetPath));
         break;
       }
       default: {
-        log.warn("Received unhandled request", req);
+        log.warn('Received unhandled request', req);
         res.writeHead(404);
-        res.end("Not Found");
+        res.end('Not Found');
         break;
       }
     }
@@ -173,9 +173,9 @@ function sendFile(res: http.ServerResponse, filepath: string): void {
     if (err) {
       log.error(`Unable to read file: ${filepath}`, err);
       res.writeHead(500);
-      res.end("Internal Server Error");
+      res.end('Internal Server Error');
     } else {
-      res.setHeader("content-length", body.length);
+      res.setHeader('content-length', body.length);
       res.writeHead(200);
       res.end(body);
     }

--- a/src/auth/flows/loopback.unit.test.ts
+++ b/src/auth/flows/loopback.unit.test.ts
@@ -4,31 +4,31 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import http from "http";
-import { AddressInfo } from "net";
-import { expect } from "chai";
-import { OAuth2Client } from "google-auth-library";
-import sinon from "sinon";
-import { CONFIG } from "../../colab-config";
-import { authUriMatch } from "../../test/helpers/authentication";
-import { TestCancellationTokenSource } from "../../test/helpers/cancellation";
-import { createHttpServerMock } from "../../test/helpers/http-server";
-import { matchUri } from "../../test/helpers/uri";
-import { newVsCodeStub, VsCodeStub } from "../../test/helpers/vscode";
-import { OAuth2TriggerOptions } from "./flows";
-import { LocalServerFlow } from "./loopback";
+import http from 'http';
+import { AddressInfo } from 'net';
+import { expect } from 'chai';
+import { OAuth2Client } from 'google-auth-library';
+import sinon from 'sinon';
+import { CONFIG } from '../../colab-config';
+import { authUriMatch } from '../../test/helpers/authentication';
+import { TestCancellationTokenSource } from '../../test/helpers/cancellation';
+import { createHttpServerMock } from '../../test/helpers/http-server';
+import { matchUri } from '../../test/helpers/uri';
+import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
+import { OAuth2TriggerOptions } from './flows';
+import { LocalServerFlow } from './loopback';
 
 const DEFAULT_ADDRESS: AddressInfo = {
-  address: "127.0.0.1",
-  family: "IPv4",
+  address: '127.0.0.1',
+  family: 'IPv4',
   port: 1234,
 };
 const DEFAULT_HOST = `${DEFAULT_ADDRESS.address}:${DEFAULT_ADDRESS.port.toString()}`;
-const NONCE = "nonce";
-const CODE = "42";
-const SCOPES = ["foo"];
+const NONCE = 'nonce';
+const CODE = '42';
+const SCOPES = ['foo'];
 
-describe("LocalServerFlow", () => {
+describe('LocalServerFlow', () => {
   let vs: VsCodeStub;
   let oauth2Client: OAuth2Client;
   let fakeServer: sinon.SinonStubbedInstance<http.Server>;
@@ -42,22 +42,22 @@ describe("LocalServerFlow", () => {
 
   beforeEach(() => {
     vs = newVsCodeStub();
-    oauth2Client = new OAuth2Client("testClientId", "testClientSecret");
+    oauth2Client = new OAuth2Client('testClientId', 'testClientSecret');
     fakeServer = createHttpServerMock(DEFAULT_ADDRESS);
-    createServerStub = sinon.stub(http, "createServer").returns(fakeServer);
+    createServerStub = sinon.stub(http, 'createServer').returns(fakeServer);
     cancellationTokenSource = new TestCancellationTokenSource();
     defaultTriggerOpts = {
       cancel: cancellationTokenSource.token,
       nonce: NONCE,
       scopes: SCOPES,
-      pkceChallenge: "1 + 1 = ?",
+      pkceChallenge: '1 + 1 = ?',
     };
     resStub = sinon.createStubInstance(http.ServerResponse);
     flow = new LocalServerFlow(
       vs.asVsCode(),
-      "out/test/media",
+      'out/test/media',
       oauth2Client,
-      "vscode://google.colab",
+      'vscode://google.colab',
     );
   });
 
@@ -68,14 +68,14 @@ describe("LocalServerFlow", () => {
 
   // Each call to `trigger` creates a new server. This test validates each of
   // them are disposed when the flow is.
-  it("disposes the supporting loopback server when disposed", () => {
+  it('disposes the supporting loopback server when disposed', () => {
     const fakeServer2 = createHttpServerMock({
       ...DEFAULT_ADDRESS,
       port: DEFAULT_ADDRESS.port + 1,
     });
     createServerStub.onSecondCall().returns(fakeServer2);
     void flow.trigger(defaultTriggerOpts);
-    void flow.trigger({ ...defaultTriggerOpts, nonce: "nonce2" });
+    void flow.trigger({ ...defaultTriggerOpts, nonce: 'nonce2' });
 
     flow.dispose();
 
@@ -83,65 +83,65 @@ describe("LocalServerFlow", () => {
     sinon.assert.calledOnce(fakeServer2.close);
   });
 
-  it("returns method not allowed for non-GET requests", async () => {
-    const clock = sinon.useFakeTimers({ toFake: ["setTimeout"] });
+  it('returns method not allowed for non-GET requests', async () => {
+    const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
     const trigger = flow.trigger(defaultTriggerOpts);
     const req = {
-      url: "/",
-      method: "POST",
+      url: '/',
+      method: 'POST',
       headers: { host: DEFAULT_HOST },
     } as http.IncomingMessage;
 
-    fakeServer.emit("request", req, resStub);
+    fakeServer.emit('request', req, resStub);
     clock.tick(60_001);
     await expect(trigger).to.eventually.be.rejectedWith(/timeout/);
 
-    sinon.assert.calledWith(resStub.writeHead, 405, { Allow: "GET" });
+    sinon.assert.calledWith(resStub.writeHead, 405, { Allow: 'GET' });
     sinon.assert.calledOnce(resStub.end);
     clock.restore();
   });
 
-  it("throws an error for malformed requests missing a URL", () => {
-    const req = { method: "GET" } as http.IncomingMessage;
-    fakeServer.emit("request", req, resStub);
+  it('throws an error for malformed requests missing a URL', () => {
+    const req = { method: 'GET' } as http.IncomingMessage;
+    fakeServer.emit('request', req, resStub);
     void flow.trigger(defaultTriggerOpts);
 
-    expect(() => fakeServer.emit("request", req, resStub)).to.throw(/url/);
+    expect(() => fakeServer.emit('request', req, resStub)).to.throw(/url/);
   });
 
-  it("throws an error for malformed requests missing a host header", () => {
-    const req = { method: "GET", url: "/" } as http.IncomingMessage;
-    fakeServer.emit("request", req, resStub);
+  it('throws an error for malformed requests missing a host header', () => {
+    const req = { method: 'GET', url: '/' } as http.IncomingMessage;
+    fakeServer.emit('request', req, resStub);
     void flow.trigger(defaultTriggerOpts);
 
-    expect(() => fakeServer.emit("request", req, resStub)).to.throw(/host/);
+    expect(() => fakeServer.emit('request', req, resStub)).to.throw(/host/);
   });
 
   const requestErrorTests = [
-    { label: "state", url: "/", expectedError: /state/ },
-    { label: "nonce", url: "/?state=", expectedError: /state/ },
-    { label: "code", url: `/?state=nonce%3D${NONCE}`, expectedError: /code/ },
+    { label: 'state', url: '/', expectedError: /state/ },
+    { label: 'nonce', url: '/?state=', expectedError: /state/ },
+    { label: 'code', url: `/?state=nonce%3D${NONCE}`, expectedError: /code/ },
   ];
   for (const t of requestErrorTests) {
     it(`throws an error when ${t.label} is missing`, () => {
       const req = {
-        method: "GET",
+        method: 'GET',
         url: t.url,
         headers: { host: DEFAULT_HOST },
       } as http.IncomingMessage;
-      fakeServer.emit("request", req, resStub);
+      fakeServer.emit('request', req, resStub);
       void flow.trigger(defaultTriggerOpts);
 
-      expect(() => fakeServer.emit("request", req, resStub)).to.throw(
+      expect(() => fakeServer.emit('request', req, resStub)).to.throw(
         t.expectedError,
       );
     });
   }
 
-  it("triggers and resolves the authentication flow", async () => {
+  it('triggers and resolves the authentication flow', async () => {
     const trigger = flow.trigger(defaultTriggerOpts);
     const req = {
-      method: "GET",
+      method: 'GET',
       url: `/?state=nonce%3D${NONCE}&code=${CODE}&scope=${SCOPES[0]}`,
       headers: { host: DEFAULT_HOST },
     } as http.IncomingMessage;
@@ -151,7 +151,7 @@ describe("LocalServerFlow", () => {
         return Promise.resolve(true);
       });
     });
-    const authSuccessUri = "vscode://google.colab/auth-success";
+    const authSuccessUri = 'vscode://google.colab/auth-success';
     const externalAuthSuccessUri = `${authSuccessUri}?windowId=1`;
     const state = encodeURIComponent(externalAuthSuccessUri);
     const colabAuthSuccessUrl = `${CONFIG.ColabApiDomain}/vscode/auth-success?state=${state}`;
@@ -167,7 +167,7 @@ describe("LocalServerFlow", () => {
     vs.env.asExternalUri
       .withArgs(matchUri(authSuccessUri))
       .resolves(vs.Uri.parse(externalAuthSuccessUri));
-    fakeServer.emit("request", req, resStub);
+    fakeServer.emit('request', req, resStub);
 
     const flowResult = await trigger;
 

--- a/src/auth/flows/proxied.ts
+++ b/src/auth/flows/proxied.ts
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OAuth2Client } from "google-auth-library";
-import vscode from "vscode";
-import { CONFIG } from "../../colab-config";
+import { OAuth2Client } from 'google-auth-library';
+import vscode from 'vscode';
+import { CONFIG } from '../../colab-config';
 import {
   MultiStepInput,
   InputFlowAction,
-} from "../../common/multi-step-quickpick";
-import { CodeManager } from "../code-manager";
+} from '../../common/multi-step-quickpick';
+import { CodeManager } from '../code-manager';
 import {
   DEFAULT_AUTH_URL_OPTS,
   OAuth2Flow,
   OAuth2TriggerOptions,
   FlowResult,
-} from "./flows";
+} from './flows';
 
 const PROXIED_REDIRECT_URI = `${CONFIG.ColabApiDomain}/vscode/redirect`;
 
@@ -75,14 +75,14 @@ export class ProxiedRedirectFlow implements OAuth2Flow, vscode.Disposable {
           buttons: undefined,
           ignoreFocusOut: true,
           password: true,
-          prompt: "Enter your authorization code",
-          title: "Sign in to Google",
+          prompt: 'Enter your authorization code',
+          title: 'Sign in to Google',
           validate: (value: string) => {
             return value.length === 0
-              ? "Authorization code cannot be empty"
+              ? 'Authorization code cannot be empty'
               : undefined;
           },
-          value: "",
+          value: '',
         });
         this.codeManager.resolveCode(nonce, pastedCode);
         return undefined;

--- a/src/auth/flows/proxied.unit.test.ts
+++ b/src/auth/flows/proxied.unit.test.ts
@@ -4,29 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import { OAuth2Client } from "google-auth-library";
-import * as sinon from "sinon";
-import { InputBox } from "vscode";
-import { CONFIG } from "../../colab-config";
-import { ExtensionUriHandler } from "../../system/uri";
-import { TestCancellationTokenSource } from "../../test/helpers/cancellation";
+import { expect } from 'chai';
+import { OAuth2Client } from 'google-auth-library';
+import * as sinon from 'sinon';
+import { InputBox } from 'vscode';
+import { CONFIG } from '../../colab-config';
+import { ExtensionUriHandler } from '../../system/uri';
+import { TestCancellationTokenSource } from '../../test/helpers/cancellation';
 import {
   buildInputBoxStub,
   InputBoxStub,
-} from "../../test/helpers/quick-input";
-import { matchUri, TestUri } from "../../test/helpers/uri";
-import { newVsCodeStub, VsCodeStub } from "../../test/helpers/vscode";
-import { FlowResult, OAuth2TriggerOptions } from "./flows";
-import { ProxiedRedirectFlow } from "./proxied";
+} from '../../test/helpers/quick-input';
+import { matchUri, TestUri } from '../../test/helpers/uri';
+import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
+import { FlowResult, OAuth2TriggerOptions } from './flows';
+import { ProxiedRedirectFlow } from './proxied';
 
-const NONCE = "nonce";
-const CODE = "42";
+const NONCE = 'nonce';
+const CODE = '42';
 const EXTERNAL_CALLBACK_URI = `vscode://google.colab?nonce=${NONCE}&windowId=1`;
 const REDIRECT_URI = `${CONFIG.ColabApiDomain}/vscode/redirect`;
-const SCOPES = ["foo"];
+const SCOPES = ['foo'];
 
-describe("ProxiedRedirectFlow", () => {
+describe('ProxiedRedirectFlow', () => {
   let vs: VsCodeStub;
   let oauth2Client: OAuth2Client;
   let uriHandler: ExtensionUriHandler;
@@ -43,19 +43,19 @@ describe("ProxiedRedirectFlow", () => {
     vs.window.createInputBox.returns(
       inputBoxStub as Partial<InputBox> as InputBox,
     );
-    oauth2Client = new OAuth2Client("testClientId", "testClientSecret");
+    oauth2Client = new OAuth2Client('testClientId', 'testClientSecret');
     uriHandler = new ExtensionUriHandler(vs.asVsCode());
     cancellationTokenSource = new TestCancellationTokenSource();
     defaultTriggerOpts = {
       cancel: cancellationTokenSource.token,
       nonce: NONCE,
       scopes: SCOPES,
-      pkceChallenge: "1 + 1 = ?",
+      pkceChallenge: '1 + 1 = ?',
     };
     flow = new ProxiedRedirectFlow(
       vs.asVsCode(),
       oauth2Client,
-      "vscode://google.colab",
+      'vscode://google.colab',
     );
     vs.env.asExternalUri
       .withArgs(matchUri(/vscode:\/\/google\.colab\?nonce=nonce/))
@@ -67,22 +67,22 @@ describe("ProxiedRedirectFlow", () => {
     sinon.restore();
   });
 
-  it("ignores requests missing a nonce", () => {
+  it('ignores requests missing a nonce', () => {
     void flow.trigger(defaultTriggerOpts);
-    const uri = TestUri.parse("vscode://google.colab");
+    const uri = TestUri.parse('vscode://google.colab');
 
     expect(() => uriHandler.handleUri(uri)).not.to.throw();
   });
 
-  it("ignores requests missing a code", () => {
+  it('ignores requests missing a code', () => {
     void flow.trigger(defaultTriggerOpts);
     const uri = TestUri.parse(`${EXTERNAL_CALLBACK_URI}&code=`);
 
     expect(() => uriHandler.handleUri(uri)).not.to.throw();
   });
 
-  it("throws an error when the code exchange times out", async () => {
-    const clock = sinon.useFakeTimers({ toFake: ["setTimeout"] });
+  it('throws an error when the code exchange times out', async () => {
+    const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
 
     const trigger = flow.trigger(defaultTriggerOpts);
     clock.tick(60_001);
@@ -91,22 +91,22 @@ describe("ProxiedRedirectFlow", () => {
     clock.restore();
   });
 
-  it("validates the input authentication code", async () => {
+  it('validates the input authentication code', async () => {
     void flow.trigger(defaultTriggerOpts);
 
     await inputBoxStub.nextShow();
-    inputBoxStub.value = "";
+    inputBoxStub.value = '';
     inputBoxStub.onDidChangeValue.yield(inputBoxStub.value);
     expect(inputBoxStub.validationMessage).equal(
-      "Authorization code cannot be empty",
+      'Authorization code cannot be empty',
     );
 
-    inputBoxStub.value = "s".repeat(10);
+    inputBoxStub.value = 's'.repeat(10);
     inputBoxStub.onDidChangeValue.yield(inputBoxStub.value);
     expect(inputBoxStub.validationMessage).equal(undefined);
   });
 
-  it("cancels auth when the user dismisses the input box", async () => {
+  it('cancels auth when the user dismisses the input box', async () => {
     const trigger = flow.trigger(defaultTriggerOpts);
 
     await inputBoxStub.nextShow();
@@ -115,7 +115,7 @@ describe("ProxiedRedirectFlow", () => {
     await expect(trigger).to.eventually.be.rejectedWith(/cancelled/);
   });
 
-  it("triggers and resolves the authentication flow", async () => {
+  it('triggers and resolves the authentication flow', async () => {
     const trigger = flow.trigger(defaultTriggerOpts);
 
     await inputBoxStub.nextShow();

--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -7,10 +7,10 @@
 import {
   Credentials as OAuth2Credentials,
   OAuth2Client,
-} from "google-auth-library";
-import { v4 as uuid } from "uuid";
-import vscode from "vscode";
-import { OAuth2TriggerOptions, FlowResult, OAuth2Flow } from "./flows/flows";
+} from 'google-auth-library';
+import { v4 as uuid } from 'uuid';
+import vscode from 'vscode';
+import { OAuth2TriggerOptions, FlowResult, OAuth2Flow } from './flows/flows';
 
 /**
  * A complete set of credentials produced from completing OAuth2 authentication.
@@ -37,7 +37,7 @@ export async function login(
   scopes: string[],
 ): Promise<Credentials> {
   if (flows.length === 0) {
-    throw new Error("No authentication flows available.");
+    throw new Error('No authentication flows available.');
   }
 
   for (const flow of flows) {
@@ -48,7 +48,7 @@ export async function login(
       return await vs.window.withProgress<Credentials>(
         {
           location: vs.ProgressLocation.Notification,
-          title: "Signing in to Google...",
+          title: 'Signing in to Google...',
           cancellable: true,
         },
         async (_, cancel: vscode.CancellationToken) => {
@@ -71,7 +71,7 @@ export async function login(
         },
       );
     } catch (err) {
-      const innerMsg = err instanceof Error ? err.message : "unknown error";
+      const innerMsg = err instanceof Error ? err.message : 'unknown error';
       const msg = `Sign-in attempt failed: ${innerMsg}.`;
       // Notify this attempt failed, but try other methods 🤞.
       vs.window.showErrorMessage(msg);
@@ -80,16 +80,16 @@ export async function login(
 
   const msg =
     flows.length > 1
-      ? "All authentication methods failed."
-      : "Authentication failed.";
+      ? 'All authentication methods failed.'
+      : 'Authentication failed.';
   throw new Error(msg);
 }
 
 async function promptIfFallback(vs: typeof vscode): Promise<boolean> {
-  const yes = "Yes";
-  const no = "No";
+  const yes = 'Yes';
+  const no = 'No';
   const result = await vs.window.showErrorMessage(
-    "Failed to authenticate with Google. Would you like to try a different authentication method?",
+    'Failed to authenticate with Google. Would you like to try a different authentication method?',
     yes,
     no,
   );
@@ -109,18 +109,18 @@ async function exchangeCodeForCredentials(
   if (tokenResponse.res?.status !== 200) {
     const details = tokenResponse.res
       ? tokenResponse.res.statusText
-      : "unknown error";
+      : 'unknown error';
     throw new Error(`Failed to get token: ${details}.`);
   }
   if (!isDefinedCredentials(tokenResponse.tokens)) {
-    throw new Error("Missing credential information.");
+    throw new Error('Missing credential information.');
   }
   return tokenResponse.tokens;
 }
 
 type RequiredCredentials = Pick<
   OAuth2Credentials,
-  "refresh_token" | "access_token" | "expiry_date" | "scope"
+  'refresh_token' | 'access_token' | 'expiry_date' | 'scope'
 >;
 
 function isDefinedCredentials(

--- a/src/auth/login.unit.test.ts
+++ b/src/auth/login.unit.test.ts
@@ -4,26 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import { gaxios, OAuth2Client } from "google-auth-library";
-import { GetTokenResponse } from "google-auth-library/build/src/auth/oauth2client";
-import sinon from "sinon";
-import vscode from "vscode";
-import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
-import { OAuth2Flow } from "./flows/flows";
-import { login } from "./login";
-import { RefreshableAuthenticationSession } from "./storage";
+import { expect } from 'chai';
+import { gaxios, OAuth2Client } from 'google-auth-library';
+import { GetTokenResponse } from 'google-auth-library/build/src/auth/oauth2client';
+import sinon from 'sinon';
+import vscode from 'vscode';
+import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
+import { OAuth2Flow } from './flows/flows';
+import { login } from './login';
+import { RefreshableAuthenticationSession } from './storage';
 
-const CODE = "123";
-const REDIRECT = "http://example.com/redirect";
-const SCOPES = ["scope1", "scope2"];
-const ACCESS_TOKEN = "42";
+const CODE = '123';
+const REDIRECT = 'http://example.com/redirect';
+const SCOPES = ['scope1', 'scope2'];
+const ACCESS_TOKEN = '42';
 const REFRESH_SESSION: RefreshableAuthenticationSession = {
-  id: "1",
-  refreshToken: "1//23",
+  id: '1',
+  refreshToken: '1//23',
   account: {
-    label: "Foo Bar",
-    id: "foo@example.com",
+    label: 'Foo Bar',
+    id: 'foo@example.com',
   },
   scopes: SCOPES,
 };
@@ -34,8 +34,8 @@ const CREDENTIALS = {
   refresh_token: REFRESH_SESSION.refreshToken,
   access_token: ACCESS_TOKEN,
   expiry_date: NOW + HOUR_MS,
-  id_token: "eh",
-  scope: SCOPES.join(" "),
+  id_token: 'eh',
+  scope: SCOPES.join(' '),
 };
 const GET_TOKEN_RESPONSE: GetTokenResponse = {
   res: { status: 200 } as gaxios.GaxiosResponse,
@@ -48,14 +48,14 @@ function buildStubFlow(): sinon.SinonStubbedInstance<OAuth2Flow> {
   };
 }
 
-describe("login", () => {
+describe('login', () => {
   let vs: VsCodeStub;
   let oauth2Client: OAuth2Client;
   const flowCancellationSources: vscode.CancellationTokenSource[] = [];
 
   beforeEach(() => {
     vs = newVsCodeStub();
-    oauth2Client = new OAuth2Client("testClientId", "testClientSecret");
+    oauth2Client = new OAuth2Client('testClientId', 'testClientSecret');
 
     vs.window.withProgress
       .withArgs(
@@ -81,25 +81,25 @@ describe("login", () => {
     sinon.restore();
   });
 
-  it("throws an error if no flows are available", async () => {
+  it('throws an error if no flows are available', async () => {
     await expect(
       login(vs.asVsCode(), [], oauth2Client, SCOPES),
-    ).to.be.rejectedWith("No authentication flows available.");
+    ).to.be.rejectedWith('No authentication flows available.');
   });
 
-  describe("with a flow", () => {
+  describe('with a flow', () => {
     let flow: sinon.SinonStubbedInstance<OAuth2Flow>;
     beforeEach(() => {
       flow = buildStubFlow();
     });
 
-    it("signals cancellation to the flow when the user chooses to cancel", async () => {
+    it('signals cancellation to the flow when the user chooses to cancel', async () => {
       let cancelCalled = false;
       flow.trigger.callsFake(async (options) => {
         return new Promise<never>((_, reject) => {
           options.cancel.onCancellationRequested(() => {
             cancelCalled = true;
-            reject(new Error("Cancellation signaled to flow"));
+            reject(new Error('Cancellation signaled to flow'));
           });
           flowCancellationSources[0].cancel();
         });
@@ -107,16 +107,16 @@ describe("login", () => {
 
       await expect(
         login(vs.asVsCode(), [flow], oauth2Client, SCOPES),
-      ).to.be.rejectedWith("Authentication failed.");
+      ).to.be.rejectedWith('Authentication failed.');
       expect(cancelCalled).to.be.true;
     });
 
-    it("throws an error if the flow fails", async () => {
-      flow.trigger.rejects(new Error("Flow failed"));
+    it('throws an error if the flow fails', async () => {
+      flow.trigger.rejects(new Error('Flow failed'));
 
       await expect(
         login(vs.asVsCode(), [flow], oauth2Client, SCOPES),
-      ).to.be.rejectedWith("Authentication failed.");
+      ).to.be.rejectedWith('Authentication failed.');
 
       sinon.assert.calledOnceWithMatch(
         vs.window.showErrorMessage,
@@ -124,19 +124,19 @@ describe("login", () => {
       );
     });
 
-    it("throws an error if a token cannot be obtained", async () => {
+    it('throws an error if a token cannot be obtained', async () => {
       flow.trigger.resolves({
         code: CODE,
         redirectUri: REDIRECT,
       });
-      sinon.stub(oauth2Client, "getToken").resolves({
+      sinon.stub(oauth2Client, 'getToken').resolves({
         res: { status: 500 },
         tokens: {},
       } as GetTokenResponse);
 
       await expect(
         login(vs.asVsCode(), [flow], oauth2Client, SCOPES),
-      ).to.be.rejectedWith("Authentication failed");
+      ).to.be.rejectedWith('Authentication failed');
 
       sinon.assert.calledOnceWithMatch(
         vs.window.showErrorMessage,
@@ -144,19 +144,19 @@ describe("login", () => {
       );
     });
 
-    it("throws an error if the token is missing credential information", async () => {
+    it('throws an error if the token is missing credential information', async () => {
       flow.trigger.resolves({
         code: CODE,
         redirectUri: REDIRECT,
       });
-      sinon.stub(oauth2Client, "getToken").resolves({
+      sinon.stub(oauth2Client, 'getToken').resolves({
         res: { status: 200 },
         tokens: {},
       } as GetTokenResponse);
 
       await expect(
         login(vs.asVsCode(), [flow], oauth2Client, SCOPES),
-      ).to.be.rejectedWith("Authentication failed");
+      ).to.be.rejectedWith('Authentication failed');
 
       sinon.assert.calledOnceWithMatch(
         vs.window.showErrorMessage,
@@ -164,13 +164,13 @@ describe("login", () => {
       );
     });
 
-    it("returns credentials from a successful login flow", async () => {
+    it('returns credentials from a successful login flow', async () => {
       flow.trigger.resolves({
         code: CODE,
         redirectUri: REDIRECT,
       });
       sinon
-        .stub(oauth2Client, "getToken")
+        .stub(oauth2Client, 'getToken')
         .withArgs({
           code: CODE,
           codeVerifier: sinon.match.string,
@@ -184,7 +184,7 @@ describe("login", () => {
     });
   });
 
-  describe("with multiple flows", () => {
+  describe('with multiple flows', () => {
     let flow1: sinon.SinonStubbedInstance<OAuth2Flow>;
     let flow2: sinon.SinonStubbedInstance<OAuth2Flow>;
 
@@ -192,7 +192,7 @@ describe("login", () => {
       // Type assertion needed due to overloading on showErrorMessage.
       (vs.window.showErrorMessage as sinon.SinonStub)
         .withArgs(sinon.match(/try a different/))
-        .resolves("Yes");
+        .resolves('Yes');
     }
 
     beforeEach(() => {
@@ -200,9 +200,9 @@ describe("login", () => {
       flow2 = buildStubFlow();
     });
 
-    it("throws an error if multiple flows fail", async () => {
-      flow1.trigger.rejects(new Error("Barf"));
-      flow2.trigger.rejects(new Error("Yack"));
+    it('throws an error if multiple flows fail', async () => {
+      flow1.trigger.rejects(new Error('Barf'));
+      flow2.trigger.rejects(new Error('Yack'));
       stubTryAnotherFlow();
 
       await expect(
@@ -220,15 +220,15 @@ describe("login", () => {
       );
     });
 
-    it("successfully completes a flow after failing a first attempt", async () => {
-      flow1.trigger.rejects(new Error("Burp"));
+    it('successfully completes a flow after failing a first attempt', async () => {
+      flow1.trigger.rejects(new Error('Burp'));
       stubTryAnotherFlow();
       flow2.trigger.resolves({
         code: CODE,
         redirectUri: REDIRECT,
       });
       sinon
-        .stub(oauth2Client, "getToken")
+        .stub(oauth2Client, 'getToken')
         .withArgs({
           code: CODE,
           codeVerifier: sinon.match.string,

--- a/src/auth/storage.ts
+++ b/src/auth/storage.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode from "vscode";
-import { z } from "zod";
-import { PROVIDER_ID } from "../config/constants";
+import vscode from 'vscode';
+import { z } from 'zod';
+import { PROVIDER_ID } from '../config/constants';
 
 const SESSIONS_KEY = `${PROVIDER_ID}.sessions`;
 

--- a/src/auth/storage.unit.test.ts
+++ b/src/auth/storage.unit.test.ts
@@ -4,24 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import sinon, { SinonStubbedInstance } from "sinon";
-import { SecretStorage } from "vscode";
-import { PROVIDER_ID } from "../config/constants";
-import { SecretStorageFake } from "../test/helpers/secret-storage";
-import { AuthStorage, RefreshableAuthenticationSession } from "./storage";
+import { expect } from 'chai';
+import sinon, { SinonStubbedInstance } from 'sinon';
+import { SecretStorage } from 'vscode';
+import { PROVIDER_ID } from '../config/constants';
+import { SecretStorageFake } from '../test/helpers/secret-storage';
+import { AuthStorage, RefreshableAuthenticationSession } from './storage';
 
 const SESSIONS_KEY = `${PROVIDER_ID}.sessions`;
 const DEFAULT_SESSION: RefreshableAuthenticationSession = {
-  id: "1",
-  refreshToken: "//42",
-  account: { id: "foo", label: "bar" },
-  scopes: ["baz"],
+  id: '1',
+  refreshToken: '//42',
+  account: { id: 'foo', label: 'bar' },
+  scopes: ['baz'],
 };
 
-describe("ServerStorage", () => {
+describe('ServerStorage', () => {
   let secretsStub: SinonStubbedInstance<
-    Pick<SecretStorage, "get" | "store" | "delete">
+    Pick<SecretStorage, 'get' | 'store' | 'delete'>
   >;
   let authStorage: AuthStorage;
 
@@ -36,14 +36,14 @@ describe("ServerStorage", () => {
     sinon.restore();
   });
 
-  describe("getSessions", () => {
-    it("returns no sessions when none are stored", async () => {
+  describe('getSessions', () => {
+    it('returns no sessions when none are stored', async () => {
       await expect(authStorage.getSession()).to.eventually.equal(undefined);
 
       sinon.assert.calledOnceWithExactly(secretsStub.get, SESSIONS_KEY);
     });
 
-    it("returns a single session when one is stored", async () => {
+    it('returns a single session when one is stored', async () => {
       await authStorage.storeSession(DEFAULT_SESSION);
 
       await expect(authStorage.getSession()).to.eventually.deep.equal(
@@ -53,7 +53,7 @@ describe("ServerStorage", () => {
       sinon.assert.calledOnceWithExactly(secretsStub.get, SESSIONS_KEY);
     });
 
-    it("throws an error when the stored sessions do not conform to the expected schema", async () => {
+    it('throws an error when the stored sessions do not conform to the expected schema', async () => {
       secretsStub.store(
         SESSIONS_KEY,
         JSON.stringify([
@@ -67,8 +67,8 @@ describe("ServerStorage", () => {
     });
   });
 
-  describe("storeSession", () => {
-    it("stores the provided session", async () => {
+  describe('storeSession', () => {
+    it('stores the provided session', async () => {
       await authStorage.storeSession(DEFAULT_SESSION);
 
       await expect(authStorage.getSession()).to.eventually.deep.equal(
@@ -81,8 +81,8 @@ describe("ServerStorage", () => {
       );
     });
 
-    it("overrides the existing stored session", async () => {
-      const newSession = { ...DEFAULT_SESSION, id: "2" };
+    it('overrides the existing stored session', async () => {
+      const newSession = { ...DEFAULT_SESSION, id: '2' };
       await authStorage.storeSession(DEFAULT_SESSION);
 
       await authStorage.storeSession(newSession);
@@ -104,8 +104,8 @@ describe("ServerStorage", () => {
     });
   });
 
-  describe("removeSession", () => {
-    it("returns undefined when no sessions exist", async () => {
+  describe('removeSession', () => {
+    it('returns undefined when no sessions exist', async () => {
       await expect(
         authStorage.removeSession(DEFAULT_SESSION.id),
       ).to.eventually.equal(undefined);
@@ -113,17 +113,17 @@ describe("ServerStorage", () => {
       sinon.assert.notCalled(secretsStub.delete);
     });
 
-    it("returns undefined when the session does not exist", async () => {
+    it('returns undefined when the session does not exist', async () => {
       await authStorage.storeSession(DEFAULT_SESSION);
 
       await expect(
-        authStorage.removeSession("does not exist"),
+        authStorage.removeSession('does not exist'),
       ).to.eventually.equal(undefined);
 
       sinon.assert.notCalled(secretsStub.delete);
     });
 
-    it("returns the session when it is the only one and is removed", async () => {
+    it('returns the session when it is the only one and is removed', async () => {
       await authStorage.storeSession(DEFAULT_SESSION);
 
       await expect(

--- a/src/colab/api.ts
+++ b/src/colab/api.ts
@@ -23,7 +23,7 @@
  * will get smaller and more sensible.
  */
 
-import { z } from "zod";
+import { z } from 'zod';
 
 export enum SubscriptionState {
   UNSUBSCRIBED = 1,
@@ -46,10 +46,10 @@ enum ColabSubscriptionTier {
 }
 
 enum ColabGapiSubscriptionTier {
-  UNSPECIFIED = "SUBSCRIPTION_TIER_UNSPECIFIED",
-  NONE = "SUBSCRIPTION_TIER_NONE",
-  PRO = "SUBSCRIPTION_TIER_PRO",
-  PRO_PLUS = "SUBSCRIPTION_TIER_PRO_PLUS",
+  UNSPECIFIED = 'SUBSCRIPTION_TIER_UNSPECIFIED',
+  NONE = 'SUBSCRIPTION_TIER_NONE',
+  PRO = 'SUBSCRIPTION_TIER_PRO',
+  PRO_PLUS = 'SUBSCRIPTION_TIER_PRO_PLUS',
 }
 
 export enum Outcome {
@@ -62,15 +62,15 @@ export enum Outcome {
 }
 
 export enum Variant {
-  DEFAULT = "DEFAULT",
-  GPU = "GPU",
-  TPU = "TPU",
+  DEFAULT = 'DEFAULT',
+  GPU = 'GPU',
+  TPU = 'TPU',
 }
 
 enum ColabGapiVariant {
-  UNSPECIFIED = "VARIANT_UNSPECIFIED",
-  GPU = "VARIANT_GPU",
-  TPU = "VARIANT_TPU",
+  UNSPECIFIED = 'VARIANT_UNSPECIFIED',
+  GPU = 'VARIANT_GPU',
+  TPU = 'VARIANT_TPU',
 }
 
 export enum Shape {
@@ -193,7 +193,7 @@ export const CcuInfoSchema = z.object({
             return Number.isSafeInteger(num);
           },
           {
-            error: "Value too large to be a safe integer for JavaScript",
+            error: 'Value too large to be a safe integer for JavaScript',
           },
         )
         .transform((val) => Number(val)),
@@ -263,7 +263,7 @@ export const PostAssignmentResponseSchema = z.object({
   // On GET, this is a string (enum) but on POST this is a number.
   // Normalize it to the string-based enum.
   variant: z.preprocess((val) => {
-    if (typeof val === "number") {
+    if (typeof val === 'number') {
       switch (val) {
         case 0:
           return Variant.DEFAULT;
@@ -384,10 +384,10 @@ export type Session = z.infer<typeof SessionSchema>;
 export function variantToMachineType(variant: Variant): string {
   switch (variant) {
     case Variant.DEFAULT:
-      return "CPU";
+      return 'CPU';
     case Variant.GPU:
-      return "GPU";
+      return 'GPU';
     case Variant.TPU:
-      return "TPU";
+      return 'TPU';
   }
 }

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { randomUUID } from "crypto";
-import { expect } from "chai";
-import fetch, { Response } from "node-fetch";
-import { SinonStub, SinonMatcher } from "sinon";
-import * as sinon from "sinon";
-import { ColabAssignedServer } from "../jupyter/servers";
-import { TestUri } from "../test/helpers/uri";
-import { uuidToWebSafeBase64 } from "../utils/uuid";
+import { randomUUID } from 'crypto';
+import { expect } from 'chai';
+import fetch, { Response } from 'node-fetch';
+import { SinonStub, SinonMatcher } from 'sinon';
+import * as sinon from 'sinon';
+import { ColabAssignedServer } from '../jupyter/servers';
+import { TestUri } from '../test/helpers/uri';
+import { uuidToWebSafeBase64 } from '../utils/uuid';
 import {
   CcuInfo,
   Assignment,
@@ -24,13 +24,13 @@ import {
   Outcome,
   ListedAssignments,
   RuntimeProxyInfo,
-} from "./api";
+} from './api';
 import {
   ColabClient,
   DenylistedError,
   InsufficientQuotaError,
   TooManyAssignmentsError,
-} from "./client";
+} from './client';
 import {
   ACCEPT_JSON_HEADER,
   AUTHORIZATION_HEADER,
@@ -38,24 +38,24 @@ import {
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
   COLAB_TUNNEL_HEADER,
   COLAB_XSRF_TOKEN_HEADER,
-} from "./headers";
+} from './headers';
 
-const COLAB_HOST = "colab.example.com";
-const GOOGLE_APIS_HOST = "colab.example.googleapis.com";
-const BEARER_TOKEN = "access-token";
+const COLAB_HOST = 'colab.example.com';
+const GOOGLE_APIS_HOST = 'colab.example.googleapis.com';
+const BEARER_TOKEN = 'access-token';
 const NOTEBOOK_HASH = randomUUID();
 const DEFAULT_ASSIGNMENT_RESPONSE = {
-  accelerator: "A100",
-  endpoint: "mock-server",
+  accelerator: 'A100',
+  endpoint: 'mock-server',
   fit: 30,
   sub: SubscriptionState.UNSUBSCRIBED,
   subTier: SubscriptionTier.NONE,
   variant: Variant.GPU,
   machineShape: Shape.STANDARD,
   runtimeProxyInfo: {
-    token: "mock-token",
+    token: 'mock-token',
     tokenExpiresInSeconds: 42,
-    url: "https://mock-url.com",
+    url: 'https://mock-url.com',
   },
 };
 const DEFAULT_LIST_ASSIGNMENTS_RESPONSE: ListedAssignments = {
@@ -76,13 +76,13 @@ const DEFAULT_ASSIGNMENT: Assignment = {
   subscriptionTier: subTier,
 };
 
-describe("ColabClient", () => {
+describe('ColabClient', () => {
   let fetchStub: sinon.SinonStubbedMember<typeof fetch>;
   let sessionStub: SinonStub<[], Promise<string>>;
   let client: ColabClient;
 
   beforeEach(() => {
-    fetchStub = sinon.stub(fetch, "default");
+    fetchStub = sinon.stub(fetch, 'default');
     sessionStub = sinon.stub<[], Promise<string>>().resolves(BEARER_TOKEN);
     client = new ColabClient(
       new URL(`https://${COLAB_HOST}`),
@@ -95,18 +95,18 @@ describe("ColabClient", () => {
     sinon.restore();
   });
 
-  it("successfully gets the subscription tier", async () => {
+  it('successfully gets the subscription tier', async () => {
     const mockResponse = {
-      subscriptionTier: "SUBSCRIPTION_TIER_NONE",
+      subscriptionTier: 'SUBSCRIPTION_TIER_NONE',
       paidComputeUnitsBalance: 0,
-      eligibleAccelerators: [{ variant: "VARIANT_GPU", models: ["T4"] }],
+      eligibleAccelerators: [{ variant: 'VARIANT_GPU', models: ['T4'] }],
     };
     fetchStub
       .withArgs(
         urlMatcher({
-          method: "GET",
+          method: 'GET',
           host: GOOGLE_APIS_HOST,
-          path: "/v1/user-info",
+          path: '/v1/user-info',
           withAuthUser: false,
         }),
       )
@@ -121,26 +121,26 @@ describe("ColabClient", () => {
     sinon.assert.calledOnce(fetchStub);
   });
 
-  it("successfully gets CCU info", async () => {
+  it('successfully gets CCU info', async () => {
     const mockResponse = {
       currentBalance: 1,
       consumptionRateHourly: 2,
       assignmentsCount: 3,
-      eligibleGpus: ["T4"],
-      ineligibleGpus: ["A100", "L4"],
-      eligibleTpus: ["V6E1", "V28"],
-      ineligibleTpus: ["V5E1"],
+      eligibleGpus: ['T4'],
+      ineligibleGpus: ['A100', 'L4'],
+      eligibleTpus: ['V6E1', 'V28'],
+      ineligibleTpus: ['V5E1'],
       freeCcuQuotaInfo: {
-        remainingTokens: "4",
+        remainingTokens: '4',
         nextRefillTimestampSec: 5,
       },
     };
     fetchStub
       .withArgs(
         urlMatcher({
-          method: "GET",
+          method: 'GET',
           host: COLAB_HOST,
-          path: "/tun/m/ccu-info",
+          path: '/tun/m/ccu-info',
         }),
       )
       .resolves(
@@ -161,8 +161,8 @@ describe("ColabClient", () => {
     sinon.assert.calledOnce(fetchStub);
   });
 
-  describe("assignment", () => {
-    const ASSIGN_PATH = "/tun/m/assign";
+  describe('assignment', () => {
+    const ASSIGN_PATH = '/tun/m/assign';
     let wireNbh: string;
     let queryParams: Record<string, string | RegExp>;
 
@@ -173,11 +173,11 @@ describe("ColabClient", () => {
       };
     });
 
-    it("resolves an existing assignment", async () => {
+    it('resolves an existing assignment', async () => {
       fetchStub
         .withArgs(
           urlMatcher({
-            method: "GET",
+            method: 'GET',
             host: COLAB_HOST,
             path: ASSIGN_PATH,
             queryParams,
@@ -190,7 +190,7 @@ describe("ColabClient", () => {
         );
 
       await expect(
-        client.assign(NOTEBOOK_HASH, Variant.GPU, "A100"),
+        client.assign(NOTEBOOK_HASH, Variant.GPU, 'A100'),
       ).to.eventually.deep.equal({
         assignment: DEFAULT_ASSIGNMENT,
         isNew: false,
@@ -199,19 +199,19 @@ describe("ColabClient", () => {
       sinon.assert.calledOnce(fetchStub);
     });
 
-    describe("without an existing assignment", () => {
+    describe('without an existing assignment', () => {
       beforeEach(() => {
         const mockGetResponse = {
-          acc: "NONE",
+          acc: 'NONE',
           nbh: wireNbh,
           p: false,
-          token: "mock-xsrf-token",
+          token: 'mock-xsrf-token',
           variant: Variant.DEFAULT,
         };
         fetchStub
           .withArgs(
             urlMatcher({
-              method: "GET",
+              method: 'GET',
               host: COLAB_HOST,
               path: ASSIGN_PATH,
               queryParams,
@@ -226,11 +226,11 @@ describe("ColabClient", () => {
 
       const assignmentTests: [Variant, string?][] = [
         [Variant.DEFAULT, undefined],
-        [Variant.GPU, "T4"],
-        [Variant.TPU, "V28"],
+        [Variant.GPU, 'T4'],
+        [Variant.TPU, 'V28'],
       ];
       for (const [variant, accelerator] of assignmentTests) {
-        const assignment = `${variant}${accelerator ? ` (${accelerator})` : ""}`;
+        const assignment = `${variant}${accelerator ? ` (${accelerator})` : ''}`;
 
         it(`creates a new ${assignment}`, async () => {
           const postQueryParams: Record<string, string | RegExp> = {
@@ -245,17 +245,17 @@ describe("ColabClient", () => {
           const assignmentResponse = {
             ...DEFAULT_ASSIGNMENT_RESPONSE,
             variant,
-            accelerator: accelerator ?? "NONE",
+            accelerator: accelerator ?? 'NONE',
           };
           fetchStub
             .withArgs(
               urlMatcher({
-                method: "POST",
+                method: 'POST',
                 host: COLAB_HOST,
                 path: ASSIGN_PATH,
                 queryParams: postQueryParams,
                 otherHeaders: {
-                  [COLAB_XSRF_TOKEN_HEADER.key]: "mock-xsrf-token",
+                  [COLAB_XSRF_TOKEN_HEADER.key]: 'mock-xsrf-token',
                 },
               }),
             )
@@ -268,7 +268,7 @@ describe("ColabClient", () => {
           const expectedAssignment: Assignment = {
             ...DEFAULT_ASSIGNMENT,
             variant,
-            accelerator: accelerator ?? "NONE",
+            accelerator: accelerator ?? 'NONE',
           };
           await expect(
             client.assign(NOTEBOOK_HASH, variant, accelerator),
@@ -281,16 +281,16 @@ describe("ColabClient", () => {
         });
       }
 
-      it("rejects when assignments exceed limit", async () => {
+      it('rejects when assignments exceed limit', async () => {
         fetchStub
           .withArgs(
             urlMatcher({
-              method: "POST",
+              method: 'POST',
               host: COLAB_HOST,
               path: ASSIGN_PATH,
               queryParams,
               otherHeaders: {
-                "X-Goog-Colab-Token": "mock-xsrf-token",
+                'X-Goog-Colab-Token': 'mock-xsrf-token',
               },
             }),
           )
@@ -303,11 +303,11 @@ describe("ColabClient", () => {
 
       for (const quotaTest of [
         {
-          reason: "request variant unavailable",
+          reason: 'request variant unavailable',
           outcome: Outcome.QUOTA_DENIED_REQUESTED_VARIANTS,
         },
         {
-          reason: "usage time exceeded",
+          reason: 'usage time exceeded',
           outcome: Outcome.QUOTA_EXCEEDED_USAGE_TIME,
         },
       ]) {
@@ -315,12 +315,12 @@ describe("ColabClient", () => {
           fetchStub
             .withArgs(
               urlMatcher({
-                method: "POST",
+                method: 'POST',
                 host: COLAB_HOST,
                 path: ASSIGN_PATH,
                 queryParams,
                 otherHeaders: {
-                  "X-Goog-Colab-Token": "mock-xsrf-token",
+                  'X-Goog-Colab-Token': 'mock-xsrf-token',
                 },
               }),
             )
@@ -346,16 +346,16 @@ describe("ColabClient", () => {
         });
       }
 
-      it("rejects when user is banned", async () => {
+      it('rejects when user is banned', async () => {
         fetchStub
           .withArgs(
             urlMatcher({
-              method: "POST",
+              method: 'POST',
               host: COLAB_HOST,
               path: ASSIGN_PATH,
               queryParams,
               otherHeaders: {
-                "X-Goog-Colab-Token": "mock-xsrf-token",
+                'X-Goog-Colab-Token': 'mock-xsrf-token',
               },
             }),
           )
@@ -379,13 +379,13 @@ describe("ColabClient", () => {
     });
   });
 
-  it("successfully lists assignments", async () => {
+  it('successfully lists assignments', async () => {
     fetchStub
       .withArgs(
         urlMatcher({
-          method: "GET",
+          method: 'GET',
           host: COLAB_HOST,
-          path: "/tun/m/assignments",
+          path: '/tun/m/assignments',
         }),
       )
       .resolves(
@@ -404,19 +404,19 @@ describe("ColabClient", () => {
     sinon.assert.calledOnce(fetchStub);
   });
 
-  it("successfully unassigns the specified assignment", async () => {
-    const endpoint = "mock-server";
+  it('successfully unassigns the specified assignment', async () => {
+    const endpoint = 'mock-server';
     const path = `/tun/m/unassign/${endpoint}`;
-    const token = "mock-xsrf-token";
+    const token = 'mock-xsrf-token';
     fetchStub
-      .withArgs(urlMatcher({ method: "GET", host: COLAB_HOST, path: path }))
+      .withArgs(urlMatcher({ method: 'GET', host: COLAB_HOST, path: path }))
       .resolves(
         new Response(withXSSI(JSON.stringify({ token })), { status: 200 }),
       );
     fetchStub
       .withArgs(
         urlMatcher({
-          method: "POST",
+          method: 'POST',
           host: COLAB_HOST,
           path,
           otherHeaders: {
@@ -431,44 +431,44 @@ describe("ColabClient", () => {
     sinon.assert.calledTwice(fetchStub);
   });
 
-  describe("with an assigned server", () => {
+  describe('with an assigned server', () => {
     const assignedServerUrl = new URL(
-      "https://8080-m-s-foo.bar.prod.colab.dev",
+      'https://8080-m-s-foo.bar.prod.colab.dev',
     );
     let assignedServer: ColabAssignedServer;
 
     beforeEach(() => {
       assignedServer = {
         id: randomUUID(),
-        label: "foo",
+        label: 'foo',
         variant: Variant.DEFAULT,
         accelerator: undefined,
-        endpoint: "m-s-foo",
+        endpoint: 'm-s-foo',
         connectionInformation: {
           baseUrl: TestUri.parse(assignedServerUrl.toString()),
-          token: "123",
+          token: '123',
           tokenExpiry: new Date(Date.now() + 1000 * 60 * 60),
         },
         dateAssigned: new Date(),
       };
     });
 
-    it("successfully refreshes the connection", async () => {
+    it('successfully refreshes the connection', async () => {
       const newConnectionInfo: RuntimeProxyInfo = {
-        token: "new",
+        token: 'new',
         tokenExpiresInSeconds: 3600,
         url: assignedServerUrl.toString(),
       };
-      const path = "/tun/m/runtime-proxy-token";
+      const path = '/tun/m/runtime-proxy-token';
       fetchStub
         .withArgs(
           urlMatcher({
-            method: "GET",
+            method: 'GET',
             host: COLAB_HOST,
             path: path,
             queryParams: {
               endpoint: assignedServer.endpoint,
-              port: "8080",
+              port: '8080',
             },
           }),
         )
@@ -483,15 +483,15 @@ describe("ColabClient", () => {
       ).to.eventually.deep.equal(newConnectionInfo);
     });
 
-    it("successfully lists kernels", async () => {
+    it('successfully lists kernels', async () => {
       const lastActivity = new Date().toISOString();
 
       fetchStub
         .withArgs(
           urlMatcher({
-            method: "GET",
+            method: 'GET',
             host: assignedServerUrl.host,
-            path: "/api/kernels",
+            path: '/api/kernels',
             otherHeaders: {
               [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
                 assignedServer.connectionInformation.token,
@@ -504,10 +504,10 @@ describe("ColabClient", () => {
             withXSSI(
               JSON.stringify([
                 {
-                  id: "mock-id",
-                  name: "mock-name",
+                  id: 'mock-id',
+                  name: 'mock-name',
                   last_activity: lastActivity,
-                  execution_state: "idle",
+                  execution_state: 'idle',
                   connections: 1,
                 },
               ]),
@@ -518,10 +518,10 @@ describe("ColabClient", () => {
           ),
         );
       const kernel: Kernel = {
-        id: "mock-id",
-        name: "mock-name",
+        id: 'mock-id',
+        name: 'mock-name',
         lastActivity,
-        executionState: "idle",
+        executionState: 'idle',
         connections: 1,
       };
 
@@ -532,42 +532,42 @@ describe("ColabClient", () => {
       sinon.assert.calledOnce(fetchStub);
     });
 
-    describe("listSessions", () => {
+    describe('listSessions', () => {
       const last_activity = new Date().toISOString();
       const mockResponseSession = {
-        id: "mock-session-id",
+        id: 'mock-session-id',
         kernel: {
-          id: "mock-kernel-id",
-          name: "mock-kernel-name",
+          id: 'mock-kernel-id',
+          name: 'mock-kernel-name',
           last_activity,
-          execution_state: "idle",
+          execution_state: 'idle',
           connections: 1,
         },
-        name: "mock-session-name",
-        path: "/mock-path",
-        type: "notebook",
+        name: 'mock-session-name',
+        path: '/mock-path',
+        type: 'notebook',
       };
       const expectedSession: Session = {
-        id: "mock-session-id",
+        id: 'mock-session-id',
         kernel: {
-          id: "mock-kernel-id",
-          name: "mock-kernel-name",
+          id: 'mock-kernel-id',
+          name: 'mock-kernel-name',
           lastActivity: last_activity,
-          executionState: "idle",
+          executionState: 'idle',
           connections: 1,
         },
-        name: "mock-session-name",
-        path: "/mock-path",
-        type: "notebook",
+        name: 'mock-session-name',
+        path: '/mock-path',
+        type: 'notebook',
       };
 
-      it("successfully lists sessions by server", async () => {
+      it('successfully lists sessions by server', async () => {
         fetchStub
           .withArgs(
             urlMatcher({
-              method: "GET",
+              method: 'GET',
               host: assignedServerUrl.host,
-              path: "/api/sessions",
+              path: '/api/sessions',
               otherHeaders: {
                 [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
                   assignedServer.connectionInformation.token,
@@ -588,11 +588,11 @@ describe("ColabClient", () => {
         sinon.assert.calledOnce(fetchStub);
       });
 
-      it("successfully lists sessions by assignment endpoint", async () => {
+      it('successfully lists sessions by assignment endpoint', async () => {
         fetchStub
           .withArgs(
             urlMatcher({
-              method: "GET",
+              method: 'GET',
               host: COLAB_HOST,
               path: `/tun/m/${assignedServer.endpoint}/api/sessions`,
               otherHeaders: {
@@ -615,12 +615,12 @@ describe("ColabClient", () => {
       });
     });
 
-    it("successfully deletes a session", async () => {
-      const sessionId = "mock-session-id";
+    it('successfully deletes a session', async () => {
+      const sessionId = 'mock-session-id';
       fetchStub
         .withArgs(
           urlMatcher({
-            method: "DELETE",
+            method: 'DELETE',
             host: assignedServerUrl.host,
             path: `/api/sessions/${sessionId}`,
             otherHeaders: {
@@ -639,13 +639,13 @@ describe("ColabClient", () => {
     });
   });
 
-  it("successfully issues keep-alive pings", async () => {
+  it('successfully issues keep-alive pings', async () => {
     fetchStub
       .withArgs(
         urlMatcher({
-          method: "GET",
+          method: 'GET',
           host: COLAB_HOST,
-          path: "/tun/m/foo/keep-alive/",
+          path: '/tun/m/foo/keep-alive/',
           otherHeaders: {
             [COLAB_TUNNEL_HEADER.key]: COLAB_TUNNEL_HEADER.value,
           },
@@ -653,27 +653,27 @@ describe("ColabClient", () => {
       )
       .resolves(new Response(undefined, { status: 200 }));
 
-    await expect(client.sendKeepAlive("foo")).to.eventually.be.fulfilled;
+    await expect(client.sendKeepAlive('foo')).to.eventually.be.fulfilled;
 
     sinon.assert.calledOnce(fetchStub);
   });
 
-  it("supports non-XSSI responses", async () => {
+  it('supports non-XSSI responses', async () => {
     const mockResponse = {
       currentBalance: 1,
       consumptionRateHourly: 2,
       assignmentsCount: 3,
-      eligibleGpus: ["T4"],
-      ineligibleGpus: ["A100", "L4"],
-      eligibleTpus: ["V6E1", "V28"],
-      ineligibleTpus: ["V5E1"],
+      eligibleGpus: ['T4'],
+      ineligibleGpus: ['A100', 'L4'],
+      eligibleTpus: ['V6E1', 'V28'],
+      ineligibleTpus: ['V5E1'],
     };
     fetchStub
       .withArgs(
         urlMatcher({
-          method: "GET",
+          method: 'GET',
           host: COLAB_HOST,
-          path: "/tun/m/ccu-info",
+          path: '/tun/m/ccu-info',
         }),
       )
       .resolves(new Response(JSON.stringify(mockResponse), { status: 200 }));
@@ -683,19 +683,19 @@ describe("ColabClient", () => {
     sinon.assert.calledOnce(fetchStub);
   });
 
-  it("rejects when error responses are returned", async () => {
+  it('rejects when error responses are returned', async () => {
     fetchStub
       .withArgs(
         urlMatcher({
-          method: "GET",
+          method: 'GET',
           host: COLAB_HOST,
-          path: "/tun/m/ccu-info",
+          path: '/tun/m/ccu-info',
         }),
       )
       .resolves(
-        new Response("Error", {
+        new Response('Error', {
           status: 500,
-          statusText: "Foo error",
+          statusText: 'Foo error',
         }),
       );
 
@@ -704,34 +704,34 @@ describe("ColabClient", () => {
     );
   });
 
-  it("rejects invalid JSON responses", async () => {
+  it('rejects invalid JSON responses', async () => {
     fetchStub
       .withArgs(
         urlMatcher({
-          method: "GET",
+          method: 'GET',
           host: COLAB_HOST,
-          path: "/tun/m/ccu-info",
+          path: '/tun/m/ccu-info',
         }),
       )
-      .resolves(new Response(withXSSI("not JSON eh?"), { status: 200 }));
+      .resolves(new Response(withXSSI('not JSON eh?'), { status: 200 }));
 
     await expect(client.getCcuInfo()).to.eventually.be.rejectedWith(
       /not JSON.+eh\?/,
     );
   });
 
-  it("rejects response schema mismatches", async () => {
+  it('rejects response schema mismatches', async () => {
     const mockResponse: Partial<CcuInfo> = {
       currentBalance: 1,
       consumptionRateHourly: 2,
-      eligibleGpus: ["T4"],
+      eligibleGpus: ['T4'],
     };
     fetchStub
       .withArgs(
         urlMatcher({
-          method: "GET",
+          method: 'GET',
           host: COLAB_HOST,
-          path: "/tun/m/ccu-info",
+          path: '/tun/m/ccu-info',
         }),
       )
       .resolves(
@@ -743,13 +743,13 @@ describe("ColabClient", () => {
     );
   });
 
-  it("initializes fetch with abort signal", async () => {
+  it('initializes fetch with abort signal', async () => {
     const abort = new AbortController();
     fetchStub
       .withArgs(sinon.match({ signal: abort.signal }))
       .resolves(new Response(undefined, { status: 200 }));
 
-    await expect(client.sendKeepAlive("foo", abort.signal)).to.eventually.be
+    await expect(client.sendKeepAlive('foo', abort.signal)).to.eventually.be
       .fulfilled;
 
     sinon.assert.calledOnce(fetchStub);
@@ -761,7 +761,7 @@ function withXSSI(response: string): string {
 }
 
 export interface URLMatchOptions {
-  method: "GET" | "POST" | "DELETE";
+  method: 'GET' | 'POST' | 'DELETE';
   host: string;
   path: string | RegExp;
   queryParams?: Record<string, string | RegExp>;
@@ -778,10 +778,10 @@ export interface URLMatchOptions {
  * headers.
  */
 export function urlMatcher(expected: URLMatchOptions): SinonMatcher {
-  let reason = "";
+  let reason = '';
   return sinon.match((request: Request) => {
     const reasons: string[] = [];
-    reason = "";
+    reason = '';
 
     // Check method
     const actualMethod = request.method.toUpperCase();
@@ -817,10 +817,10 @@ export function urlMatcher(expected: URLMatchOptions): SinonMatcher {
     // Check query params
     const params = url.searchParams;
     if (expected.withAuthUser !== false) {
-      const actualAuthuser = params.get("authuser");
-      if (actualAuthuser !== "0") {
+      const actualAuthuser = params.get('authuser');
+      if (actualAuthuser !== '0') {
         reasons.push(
-          `authuser param is "${actualAuthuser ?? ""}", expected "0"`,
+          `authuser param is "${actualAuthuser ?? ''}", expected "0"`,
         );
       }
     }
@@ -851,19 +851,19 @@ export function urlMatcher(expected: URLMatchOptions): SinonMatcher {
     const expectedAuth = `Bearer ${BEARER_TOKEN}`;
     if (actualAuth !== expectedAuth) {
       reasons.push(
-        `Authorization header is "${actualAuth ?? ""}", expected "${expectedAuth}"`,
+        `Authorization header is "${actualAuth ?? ''}", expected "${expectedAuth}"`,
       );
     }
     const actualAccept = headers.get(ACCEPT_JSON_HEADER.key);
     if (actualAccept !== ACCEPT_JSON_HEADER.value) {
       reasons.push(
-        `Accept header is "${actualAccept ?? ""}", expected "${ACCEPT_JSON_HEADER.value}"`,
+        `Accept header is "${actualAccept ?? ''}", expected "${ACCEPT_JSON_HEADER.value}"`,
       );
     }
     const actualClientAgent = headers.get(COLAB_CLIENT_AGENT_HEADER.key);
     if (actualClientAgent !== COLAB_CLIENT_AGENT_HEADER.value) {
       reasons.push(
-        `Client-Agent header is "${actualClientAgent ?? ""}", expected "${COLAB_CLIENT_AGENT_HEADER.value}"`,
+        `Client-Agent header is "${actualClientAgent ?? ''}", expected "${COLAB_CLIENT_AGENT_HEADER.value}"`,
       );
     }
     if (expected.otherHeaders) {
@@ -871,17 +871,17 @@ export function urlMatcher(expected: URLMatchOptions): SinonMatcher {
         const actualVal = headers.get(key);
         if (actualVal !== expectedVal) {
           reasons.push(
-            `header "${key}" = "${actualVal ?? ""}", expected "${expectedVal}"`,
+            `header "${key}" = "${actualVal ?? ''}", expected "${expectedVal}"`,
           );
         }
       }
     }
 
     if (reasons.length > 0) {
-      reason = reasons.join("; ");
+      reason = reasons.join('; ');
       return false;
     }
 
     return true;
-  }, reason || "URL did not match expected pattern");
+  }, reason || 'URL did not match expected pattern');
 }

--- a/src/colab/commands/constants.ts
+++ b/src/colab/commands/constants.ts
@@ -20,54 +20,54 @@ export interface RegisteredCommand extends Command {
 
 /** Command to open the toolbar command selection. */
 export const COLAB_TOOLBAR: RegisteredCommand = {
-  id: "colab.toolbarCommand",
-  label: "Colab",
+  id: 'colab.toolbarCommand',
+  label: 'Colab',
 };
 
 /** Command to sign out. */
 export const SIGN_OUT: RegisteredCommand = {
-  id: "colab.signOut",
-  label: "Sign Out",
+  id: 'colab.signOut',
+  label: 'Sign Out',
 };
 
 /** Command to trigger the sign-in flow, to view existing Colab servers. */
 export const SIGN_IN_VIEW_EXISTING: Command = {
-  label: "$(sign-in)  View Existing Servers",
-  description: "Click to sign-in...",
+  label: '$(sign-in)  View Existing Servers',
+  description: 'Click to sign-in...',
 };
 
 /** Command to auto-connect a Colab server. */
 export const AUTO_CONNECT: Command = {
-  label: "$(symbol-event)  Auto Connect",
-  description: "1-click connect! Most recently created server, or a new one.",
+  label: '$(symbol-event)  Auto Connect',
+  description: '1-click connect! Most recently created server, or a new one.',
 };
 
 /** Command to create a new Colab server. */
 export const NEW_SERVER: Command = {
-  label: "$(add)  New Colab Server",
-  description: "CPU, GPU or TPU.",
+  label: '$(add)  New Colab Server',
+  description: 'CPU, GPU or TPU.',
 };
 
 /** Command to open Colab in the browser. */
 export const OPEN_COLAB_WEB: Command = {
-  label: "$(link-external)  Open Colab Web",
-  description: "Open Colab web.",
+  label: '$(link-external)  Open Colab Web',
+  description: 'Open Colab web.',
 };
 
 /** Command to remove a server. */
 export const REMOVE_SERVER: RegisteredCommand = {
-  id: "colab.removeServer",
-  label: "Remove Server",
+  id: 'colab.removeServer',
+  label: 'Remove Server',
 };
 
 /** Command to rename a server alias. */
 export const RENAME_SERVER_ALIAS: RegisteredCommand = {
-  id: "colab.renameServerAlias",
-  label: "Rename Server Alias",
+  id: 'colab.renameServerAlias',
+  label: 'Rename Server Alias',
 };
 
 /** Command to open the Colab signup page, to upgrade to pro. */
 export const UPGRADE_TO_PRO: Command = {
-  label: "$(accounts-view-bar-icon)  Upgrade to Pro",
-  description: "More machines, more quota, more Colab!",
+  label: '$(accounts-view-bar-icon)  Upgrade to Pro',
+  description: 'More machines, more quota, more Colab!',
 };

--- a/src/colab/commands/external.ts
+++ b/src/colab/commands/external.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode from "vscode";
+import vscode from 'vscode';
 
 /** Opens Colab in the browser. */
 export function openColabWeb(vs: typeof vscode) {
-  vs.env.openExternal(vs.Uri.parse("https://colab.research.google.com"));
+  vs.env.openExternal(vs.Uri.parse('https://colab.research.google.com'));
 }
 
 /** Opens the Colab signup page in the browser. */
 export function openColabSignup(vs: typeof vscode) {
-  vs.env.openExternal(vs.Uri.parse("https://colab.research.google.com/signup"));
+  vs.env.openExternal(vs.Uri.parse('https://colab.research.google.com/signup'));
 }

--- a/src/colab/commands/notebook.ts
+++ b/src/colab/commands/notebook.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode, { QuickPickItem } from "vscode";
-import { InputFlowAction } from "../../common/multi-step-quickpick";
-import { AssignmentManager } from "../../jupyter/assignments";
-import { OPEN_COLAB_WEB, REMOVE_SERVER, UPGRADE_TO_PRO } from "./constants";
-import { openColabSignup, openColabWeb } from "./external";
+import vscode, { QuickPickItem } from 'vscode';
+import { InputFlowAction } from '../../common/multi-step-quickpick';
+import { AssignmentManager } from '../../jupyter/assignments';
+import { OPEN_COLAB_WEB, REMOVE_SERVER, UPGRADE_TO_PRO } from './constants';
+import { openColabSignup, openColabWeb } from './external';
 
 /**
  * Prompt the user to select a Colab command to run.
@@ -22,7 +22,7 @@ export async function notebookToolbar(
 ): Promise<void> {
   const commands = await getAvailableCommands(vs, assignments);
   const command = await vs.window.showQuickPick<NotebookCommand>(commands, {
-    title: "Colab",
+    title: 'Colab',
   });
   if (!command) {
     return;
@@ -79,7 +79,7 @@ async function getAvailableCommands(
     },
   ];
   const separator: NotebookCommand = {
-    label: "",
+    label: '',
     kind: vs.QuickPickItemKind.Separator,
     invoke: () => {
       // Not selectable.

--- a/src/colab/commands/notebook.unit.test.ts
+++ b/src/colab/commands/notebook.unit.test.ts
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import sinon, { SinonStubbedInstance } from "sinon";
-import { QuickPickItem, Uri } from "vscode";
-import { InputFlowAction } from "../../common/multi-step-quickpick";
-import { AssignmentManager } from "../../jupyter/assignments";
-import { newVsCodeStub, VsCodeStub } from "../../test/helpers/vscode";
-import { OPEN_COLAB_WEB, UPGRADE_TO_PRO, REMOVE_SERVER } from "./constants";
-import { notebookToolbar } from "./notebook";
+import { expect } from 'chai';
+import sinon, { SinonStubbedInstance } from 'sinon';
+import { QuickPickItem, Uri } from 'vscode';
+import { InputFlowAction } from '../../common/multi-step-quickpick';
+import { AssignmentManager } from '../../jupyter/assignments';
+import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
+import { OPEN_COLAB_WEB, UPGRADE_TO_PRO, REMOVE_SERVER } from './constants';
+import { notebookToolbar } from './notebook';
 
-describe("notebookToolbar", () => {
+describe('notebookToolbar', () => {
   let vsCodeStub: VsCodeStub;
   let assignmentManager: SinonStubbedInstance<AssignmentManager>;
 
@@ -26,14 +26,14 @@ describe("notebookToolbar", () => {
     sinon.restore();
   });
 
-  it("does nothing when no command is selected", async () => {
+  it('does nothing when no command is selected', async () => {
     vsCodeStub.window.showQuickPick.resolves(undefined);
 
     await expect(notebookToolbar(vsCodeStub.asVsCode(), assignmentManager)).to
       .eventually.be.fulfilled;
   });
 
-  it("re-invokes the notebook toolbar when a command flows back", async () => {
+  it('re-invokes the notebook toolbar when a command flows back', async () => {
     assignmentManager.hasAssignedServer.resolves(true);
     vsCodeStub.commands.executeCommand
       .withArgs(REMOVE_SERVER.id)
@@ -51,7 +51,7 @@ describe("notebookToolbar", () => {
     sinon.assert.calledTwice(vsCodeStub.window.showQuickPick);
   });
 
-  it("excludes server specific commands when there are non assigned", async () => {
+  it('excludes server specific commands when there are non assigned', async () => {
     vsCodeStub.window.showQuickPick
       .onFirstCall()
       // Arbitrarily select the first command.
@@ -66,7 +66,7 @@ describe("notebookToolbar", () => {
     );
   });
 
-  it("includes all commands when there is a server assigned", async () => {
+  it('includes all commands when there is a server assigned', async () => {
     assignmentManager.hasAssignedServer.resolves(true);
     vsCodeStub.window.showQuickPick
       .onFirstCall()
@@ -80,14 +80,14 @@ describe("notebookToolbar", () => {
       vsCodeStub.window.showQuickPick,
       commandsLabeled([
         REMOVE_SERVER.label,
-        /* separator */ "",
+        /* separator */ '',
         OPEN_COLAB_WEB.label,
         UPGRADE_TO_PRO.label,
       ]),
     );
   });
 
-  it("opens Colab in web", async () => {
+  it('opens Colab in web', async () => {
     vsCodeStub.window.showQuickPick.callsFake(
       findCommand(OPEN_COLAB_WEB.label),
     );
@@ -99,12 +99,12 @@ describe("notebookToolbar", () => {
       vsCodeStub.env.openExternal,
       sinon.match(
         (u: Uri) =>
-          u.authority === "colab.research.google.com" && u.path === "/",
+          u.authority === 'colab.research.google.com' && u.path === '/',
       ),
     );
   });
 
-  it("opens the Colab signup page", async () => {
+  it('opens the Colab signup page', async () => {
     vsCodeStub.window.showQuickPick.callsFake(
       findCommand(UPGRADE_TO_PRO.label),
     );
@@ -116,12 +116,12 @@ describe("notebookToolbar", () => {
       vsCodeStub.env.openExternal,
       sinon.match(
         (u: Uri) =>
-          u.authority === "colab.research.google.com" && u.path === "/signup",
+          u.authority === 'colab.research.google.com' && u.path === '/signup',
       ),
     );
   });
 
-  it("removes a server", async () => {
+  it('removes a server', async () => {
     assignmentManager.hasAssignedServer.resolves(true);
     vsCodeStub.window.showQuickPick.callsFake(findCommand(REMOVE_SERVER.label));
 
@@ -146,5 +146,5 @@ function findCommand(label: string) {
 }
 
 function commandsLabeled(labels: string[]) {
-  return sinon.match(labels.map((label) => sinon.match.has("label", label)));
+  return sinon.match(labels.map((label) => sinon.match.has('label', label)));
 }

--- a/src/colab/commands/server.ts
+++ b/src/colab/commands/server.ts
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode, { QuickPickItem } from "vscode";
-import { MultiStepInput } from "../../common/multi-step-quickpick";
-import { AssignmentManager } from "../../jupyter/assignments";
-import { ColabAssignedServer, UnownedServer } from "../../jupyter/servers";
-import { ServerStorage } from "../../jupyter/storage";
-import { PROMPT_SERVER_ALIAS, validateServerAlias } from "../server-picker";
-import { REMOVE_SERVER, RENAME_SERVER_ALIAS } from "./constants";
+import vscode, { QuickPickItem } from 'vscode';
+import { MultiStepInput } from '../../common/multi-step-quickpick';
+import { AssignmentManager } from '../../jupyter/assignments';
+import { ColabAssignedServer, UnownedServer } from '../../jupyter/servers';
+import { ServerStorage } from '../../jupyter/storage';
+import { PROMPT_SERVER_ALIAS, validateServerAlias } from '../server-picker';
+import { REMOVE_SERVER, RENAME_SERVER_ALIAS } from './constants';
 
 /**
  * Prompt the user to select and rename the local alias used to identify an
@@ -32,7 +32,7 @@ export async function renameServerAlias(
   await MultiStepInput.run(vs, async (input) => {
     const selectedServer = (
       await input.showQuickPick({
-        title: "Select a Server",
+        title: 'Select a Server',
         buttons: withBackButton ? [vs.QuickInputButtons.Back] : undefined,
         items: servers.map((s) => ({ label: s.label, value: s })),
         step: 1,
@@ -68,7 +68,7 @@ export async function removeServer(
   assignmentManager: AssignmentManager,
   withBackButton?: boolean,
 ) {
-  const allServers = await assignmentManager.getServers("all");
+  const allServers = await assignmentManager.getServers('all');
   const vsCodeServers = allServers.assigned;
   const nonVsCodeServers = allServers.unowned;
   if (vsCodeServers.length === 0 && nonVsCodeServers.length === 0) {
@@ -82,7 +82,7 @@ export async function removeServer(
       value: s,
     }));
     if (vsCodeServers.length > 0 && nonVsCodeServers.length > 0) {
-      items.push({ label: "", kind: -1 });
+      items.push({ label: '', kind: -1 });
     }
     items.push(
       ...nonVsCodeServers.map((s) => ({
@@ -115,8 +115,8 @@ export async function removeServer(
 }
 
 enum ServerCategory {
-  VS_CODE = "VS Code Server",
-  COLAB_WEB = "Colab Web Server",
+  VS_CODE = 'VS Code Server',
+  COLAB_WEB = 'Colab Web Server',
 }
 
 interface RemoveServerItem extends QuickPickItem {

--- a/src/colab/commands/server.unit.test.ts
+++ b/src/colab/commands/server.unit.test.ts
@@ -4,24 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { randomUUID } from "crypto";
-import { expect } from "chai";
-import sinon, { SinonStubbedInstance } from "sinon";
-import { InputBox, QuickPick, QuickPickItem } from "vscode";
-import { AssignmentManager } from "../../jupyter/assignments";
-import { ColabAssignedServer } from "../../jupyter/servers";
-import { ServerStorage } from "../../jupyter/storage";
+import { randomUUID } from 'crypto';
+import { expect } from 'chai';
+import sinon, { SinonStubbedInstance } from 'sinon';
+import { InputBox, QuickPick, QuickPickItem } from 'vscode';
+import { AssignmentManager } from '../../jupyter/assignments';
+import { ColabAssignedServer } from '../../jupyter/servers';
+import { ServerStorage } from '../../jupyter/storage';
 import {
   buildQuickPickStub,
   QuickPickStub,
   InputBoxStub,
   buildInputBoxStub,
-} from "../../test/helpers/quick-input";
-import { newVsCodeStub, VsCodeStub } from "../../test/helpers/vscode";
-import { Variant } from "../api";
-import { removeServer, renameServerAlias } from "./server";
+} from '../../test/helpers/quick-input';
+import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
+import { Variant } from '../api';
+import { removeServer, renameServerAlias } from './server';
 
-describe("Server Commands", () => {
+describe('Server Commands', () => {
   let vsCodeStub: VsCodeStub;
   let defaultServer: ColabAssignedServer;
   let inputBoxStub: InputBoxStub & {
@@ -45,15 +45,15 @@ describe("Server Commands", () => {
     );
     defaultServer = {
       id: randomUUID(),
-      label: "foo",
+      label: 'foo',
       variant: Variant.DEFAULT,
       accelerator: undefined,
-      endpoint: "m-s-foo",
+      endpoint: 'm-s-foo',
       connectionInformation: {
-        baseUrl: vsCodeStub.Uri.parse("https://example.com"),
-        token: "123",
+        baseUrl: vsCodeStub.Uri.parse('https://example.com'),
+        token: '123',
         tokenExpiry: new Date(Date.now() + 1000 * 60 * 60),
-        headers: { foo: "bar" },
+        headers: { foo: 'bar' },
       },
       dateAssigned: new Date(),
     };
@@ -63,14 +63,14 @@ describe("Server Commands", () => {
     sinon.restore();
   });
 
-  describe("renameServerAlias", () => {
+  describe('renameServerAlias', () => {
     let serverStorageStub: SinonStubbedInstance<ServerStorage>;
 
     beforeEach(() => {
       serverStorageStub = sinon.createStubInstance(ServerStorage);
     });
 
-    it("does not open the Quick Pick when no servers are assigned", async () => {
+    it('does not open the Quick Pick when no servers are assigned', async () => {
       serverStorageStub.list.resolves([]);
 
       await renameServerAlias(vsCodeStub.asVsCode(), serverStorageStub);
@@ -78,9 +78,9 @@ describe("Server Commands", () => {
       sinon.assert.notCalled(vsCodeStub.window.createQuickPick);
     });
 
-    describe("when servers are assigned", () => {
-      it("lists assigned servers for selection", async () => {
-        const additionalServer = { ...defaultServer, label: "bar" };
+    describe('when servers are assigned', () => {
+      it('lists assigned servers for selection', async () => {
+        const additionalServer = { ...defaultServer, label: 'bar' };
         serverStorageStub.list.resolves([defaultServer, additionalServer]);
 
         void renameServerAlias(vsCodeStub.asVsCode(), serverStorageStub);
@@ -93,8 +93,8 @@ describe("Server Commands", () => {
         ]);
       });
 
-      describe("renaming the selected server", () => {
-        it("validates the input alias", async () => {
+      describe('renaming the selected server', () => {
+        it('validates the input alias', async () => {
           serverStorageStub.list.resolves([defaultServer]);
           void renameServerAlias(vsCodeStub.asVsCode(), serverStorageStub);
           await quickPickStub.nextShow();
@@ -103,18 +103,18 @@ describe("Server Commands", () => {
           ]);
 
           await inputBoxStub.nextShow();
-          inputBoxStub.value = "s".repeat(11);
+          inputBoxStub.value = 's'.repeat(11);
           inputBoxStub.onDidChangeValue.yield(inputBoxStub.value);
           expect(inputBoxStub.validationMessage).equal(
-            "Name must be less than 10 characters.",
+            'Name must be less than 10 characters.',
           );
 
-          inputBoxStub.value = "s".repeat(10);
+          inputBoxStub.value = 's'.repeat(10);
           inputBoxStub.onDidChangeValue.yield(inputBoxStub.value);
-          expect(inputBoxStub.validationMessage).equal("");
+          expect(inputBoxStub.validationMessage).equal('');
         });
 
-        it("updates the server alias", async () => {
+        it('updates the server alias', async () => {
           serverStorageStub.list.resolves([defaultServer]);
           const rename = renameServerAlias(
             vsCodeStub.asVsCode(),
@@ -127,17 +127,17 @@ describe("Server Commands", () => {
           ]);
 
           await inputBoxStub.nextShow();
-          inputBoxStub.value = "new_alias";
+          inputBoxStub.value = 'new_alias';
           inputBoxStub.onDidChangeValue.yield(inputBoxStub.value);
           inputBoxStub.onDidAccept.yield();
 
           await expect(rename).to.eventually.be.fulfilled;
           sinon.assert.calledOnceWithExactly(serverStorageStub.store, [
-            { ...defaultServer, label: "new_alias" },
+            { ...defaultServer, label: 'new_alias' },
           ]);
         });
 
-        it("does not update the server alias when it is unchanged", async () => {
+        it('does not update the server alias when it is unchanged', async () => {
           serverStorageStub.list.resolves([defaultServer]);
           const rename = renameServerAlias(
             vsCodeStub.asVsCode(),
@@ -161,15 +161,15 @@ describe("Server Commands", () => {
     });
   });
 
-  describe("removeServer", () => {
+  describe('removeServer', () => {
     let assignmentManagerStub: SinonStubbedInstance<AssignmentManager>;
 
     beforeEach(() => {
       assignmentManagerStub = sinon.createStubInstance(AssignmentManager);
     });
 
-    it("does not open the Quick Pick when no servers are assigned", async () => {
-      assignmentManagerStub.getServers.withArgs("all").resolves({
+    it('does not open the Quick Pick when no servers are assigned', async () => {
+      assignmentManagerStub.getServers.withArgs('all').resolves({
         assigned: [],
         unowned: [],
       });
@@ -179,15 +179,15 @@ describe("Server Commands", () => {
       sinon.assert.notCalled(vsCodeStub.window.createQuickPick);
     });
 
-    describe("when servers are assigned", () => {
-      it("lists mixed servers with a separator", async () => {
-        const additionalVsCodeServer = { ...defaultServer, label: "bar" };
+    describe('when servers are assigned', () => {
+      it('lists mixed servers with a separator', async () => {
+        const additionalVsCodeServer = { ...defaultServer, label: 'bar' };
         const nonVsCodeServer = {
-          label: "test.ipynb",
-          endpoint: "test-endpoint",
+          label: 'test.ipynb',
+          endpoint: 'test-endpoint',
           variant: Variant.DEFAULT,
         };
-        assignmentManagerStub.getServers.withArgs("all").resolves({
+        assignmentManagerStub.getServers.withArgs('all').resolves({
           assigned: [defaultServer, additionalVsCodeServer],
           unowned: [nonVsCodeServer],
         });
@@ -199,25 +199,25 @@ describe("Server Commands", () => {
           {
             label: defaultServer.label,
             value: defaultServer,
-            description: "VS Code Server",
+            description: 'VS Code Server',
           },
           {
             label: additionalVsCodeServer.label,
             value: additionalVsCodeServer,
-            description: "VS Code Server",
+            description: 'VS Code Server',
           },
-          { label: "", kind: -1 },
+          { label: '', kind: -1 },
           {
             label: nonVsCodeServer.label,
             value: nonVsCodeServer,
-            description: "Colab Web Server",
+            description: 'Colab Web Server',
           },
         ]);
       });
 
-      it("lists VS Code servers without separator", async () => {
-        const additionalVsCodeServer = { ...defaultServer, label: "bar" };
-        assignmentManagerStub.getServers.withArgs("all").resolves({
+      it('lists VS Code servers without separator', async () => {
+        const additionalVsCodeServer = { ...defaultServer, label: 'bar' };
+        assignmentManagerStub.getServers.withArgs('all').resolves({
           assigned: [defaultServer, additionalVsCodeServer],
           unowned: [],
         });
@@ -229,23 +229,23 @@ describe("Server Commands", () => {
           {
             label: defaultServer.label,
             value: defaultServer,
-            description: "VS Code Server",
+            description: 'VS Code Server',
           },
           {
             label: additionalVsCodeServer.label,
             value: additionalVsCodeServer,
-            description: "VS Code Server",
+            description: 'VS Code Server',
           },
         ]);
       });
 
-      it("lists Colab web servers without separator", async () => {
+      it('lists Colab web servers without separator', async () => {
         const nonVsCodeServer = {
-          label: "test.ipynb",
-          endpoint: "test-endpoint",
+          label: 'test.ipynb',
+          endpoint: 'test-endpoint',
           variant: Variant.DEFAULT,
         };
-        assignmentManagerStub.getServers.withArgs("all").resolves({
+        assignmentManagerStub.getServers.withArgs('all').resolves({
           assigned: [],
           unowned: [nonVsCodeServer],
         });
@@ -257,16 +257,16 @@ describe("Server Commands", () => {
           {
             label: nonVsCodeServer.label,
             value: nonVsCodeServer,
-            description: "Colab Web Server",
+            description: 'Colab Web Server',
           },
         ]);
       });
 
-      describe("when a server is removed", () => {
+      describe('when a server is removed', () => {
         let remove: Promise<void>;
 
         beforeEach(async () => {
-          assignmentManagerStub.getServers.withArgs("all").resolves({
+          assignmentManagerStub.getServers.withArgs('all').resolves({
             assigned: [defaultServer],
             unowned: [],
           });
@@ -277,7 +277,7 @@ describe("Server Commands", () => {
           ]);
         });
 
-        it("unassigns the selected server", async () => {
+        it('unassigns the selected server', async () => {
           await expect(remove).to.eventually.be.fulfilled;
 
           assignmentManagerStub.unassignServer.calledOnceWithExactly(
@@ -285,7 +285,7 @@ describe("Server Commands", () => {
           );
         });
 
-        it("notifies the user while server unassignment is in progress", async () => {
+        it('notifies the user while server unassignment is in progress', async () => {
           await expect(remove).to.eventually.be.fulfilled;
 
           sinon.assert.calledWithMatch(

--- a/src/colab/connection-refresher.ts
+++ b/src/colab/connection-refresher.ts
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { UUID } from "crypto";
-import { Disposable } from "vscode";
-import { log } from "../common/logging";
-import { AsyncToggle } from "../common/toggleable";
+import { UUID } from 'crypto';
+import { Disposable } from 'vscode';
+import { log } from '../common/logging';
+import { AsyncToggle } from '../common/toggleable';
 import {
   AssignmentChangeEvent,
   AssignmentManager,
-} from "../jupyter/assignments";
-import { ColabAssignedServer } from "../jupyter/servers";
-import { NotFoundError } from "./client";
+} from '../jupyter/assignments';
+import { ColabAssignedServer } from '../jupyter/servers';
+import { NotFoundError } from './client';
 
 /* The buffer we give to refresh the token, before it actually expires. */
 const REFRESH_BUFFER_MS = 5 * 60 * 1000; // 5 minutes.
@@ -123,7 +123,7 @@ export class ConnectionRefresher implements Disposable {
     assignments: AssignmentManager,
     cancel?: AbortSignal,
   ): Promise<ConnectionRefresher> {
-    const servers = await assignments.getServers("extension", cancel);
+    const servers = await assignments.getServers('extension', cancel);
     const toRefresh = servers.filter(shouldRefresh);
     const refreshing: Promise<ColabAssignedServer>[] = [];
     for (const s of toRefresh) {
@@ -132,10 +132,10 @@ export class ConnectionRefresher implements Disposable {
     await Promise.all(refreshing);
 
     if (cancel?.aborted) {
-      throw new Error("Connection refresher initialization aborted");
+      throw new Error('Connection refresher initialization aborted');
     }
 
-    const refreshedServers = await assignments.getServers("extension", cancel);
+    const refreshedServers = await assignments.getServers('extension', cancel);
     return new ConnectionRefresher(assignments, refreshedServers);
   }
 
@@ -173,7 +173,7 @@ export class ConnectionRefresher implements Disposable {
       const r = this.refreshes.get(s.id);
       // This would be a programming error.
       if (!r) {
-        log.error("Connection watcher received change for an untracked server");
+        log.error('Connection watcher received change for an untracked server');
         return;
       }
       // If the change wasn't to the token expiry, ignore it.

--- a/src/colab/connection-refresher.unit.test.ts
+++ b/src/colab/connection-refresher.unit.test.ts
@@ -4,41 +4,41 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { randomUUID } from "crypto";
-import { expect } from "chai";
-import sinon, { SinonFakeTimers, SinonStubbedInstance } from "sinon";
+import { randomUUID } from 'crypto';
+import { expect } from 'chai';
+import sinon, { SinonFakeTimers, SinonStubbedInstance } from 'sinon';
 import {
   AssignmentChangeEvent,
   AssignmentManager,
-} from "../jupyter/assignments";
-import { ColabAssignedServer } from "../jupyter/servers";
-import { ControllableAsyncToggle } from "../test/helpers/async";
-import { TestEventEmitter } from "../test/helpers/events";
-import { TestUri } from "../test/helpers/uri";
-import { Variant } from "./api";
-import { NotFoundError } from "./client";
+} from '../jupyter/assignments';
+import { ColabAssignedServer } from '../jupyter/servers';
+import { ControllableAsyncToggle } from '../test/helpers/async';
+import { TestEventEmitter } from '../test/helpers/events';
+import { TestUri } from '../test/helpers/uri';
+import { Variant } from './api';
+import { NotFoundError } from './client';
 import {
   ConnectionRefreshController,
   ConnectionRefresher,
-} from "./connection-refresher";
+} from './connection-refresher';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
-} from "./headers";
+} from './headers';
 
 const REFRESH_MS = 1000 * 60 * 60;
 const DEFAULT_SERVER: ColabAssignedServer = {
   id: randomUUID(),
-  label: "Colab GPU A100",
+  label: 'Colab GPU A100',
   variant: Variant.GPU,
-  accelerator: "A100",
-  endpoint: "m-s-foo",
+  accelerator: 'A100',
+  endpoint: 'm-s-foo',
   connectionInformation: {
-    baseUrl: TestUri.parse("https://example.com"),
-    token: "123",
+    baseUrl: TestUri.parse('https://example.com'),
+    token: '123',
     tokenExpiry: new Date(Date.now() + REFRESH_MS),
     headers: {
-      [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: "123",
+      [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: '123',
       [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
     },
   },
@@ -59,14 +59,14 @@ function expiresInMs(s: ColabAssignedServer) {
   );
 }
 
-describe("ConnectionRefreshController", () => {
+describe('ConnectionRefreshController', () => {
   let clock: SinonFakeTimers;
   let assignmentStub: SinonStubbedInstance<AssignmentManager>;
   let controller: ConnectionRefreshController;
   let controllerSpy: ControllableAsyncToggle;
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers({ toFake: ["setTimeout"] });
+    clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
     assignmentStub = sinon.createStubInstance(AssignmentManager);
     controller = new ConnectionRefreshController(assignmentStub);
     controllerSpy = new ControllableAsyncToggle(controller);
@@ -77,22 +77,22 @@ describe("ConnectionRefreshController", () => {
     clock.restore();
   });
 
-  describe("turned on", () => {
+  describe('turned on', () => {
     beforeEach(async () => {
       // Type assertion needed due to overloading on getServers
       (assignmentStub.getServers as sinon.SinonStub)
-        .withArgs("extension")
+        .withArgs('extension')
         .resolves([DEFAULT_SERVER]);
       controller.on();
       await controllerSpy.turnOn.call(0).waitForCompletion();
     });
 
-    it("refreshes connections ", async () => {
+    it('refreshes connections ', async () => {
       await clock.tickAsync(REFRESH_MS + 1);
       sinon.assert.calledOnce(assignmentStub.refreshConnection);
     });
 
-    it("stops refreshing connections when turned off", async () => {
+    it('stops refreshing connections when turned off', async () => {
       await clock.tickAsync(REFRESH_MS + 1);
       sinon.assert.calledOnce(assignmentStub.refreshConnection);
       assignmentStub.refreshConnection.resetHistory();
@@ -106,7 +106,7 @@ describe("ConnectionRefreshController", () => {
   });
 });
 
-describe("ConnectionRefresher", () => {
+describe('ConnectionRefresher', () => {
   let assignmentStub: SinonStubbedInstance<AssignmentManager>;
   let assignmentsChangeEmitter: TestEventEmitter<AssignmentChangeEvent>;
 
@@ -114,7 +114,7 @@ describe("ConnectionRefresher", () => {
     assignmentStub = sinon.createStubInstance(AssignmentManager);
     assignmentsChangeEmitter = new TestEventEmitter<AssignmentChangeEvent>();
     // Needed to work around the property being readonly.
-    Object.defineProperty(assignmentStub, "onDidAssignmentsChange", {
+    Object.defineProperty(assignmentStub, 'onDidAssignmentsChange', {
       value: sinon.stub(),
     });
     assignmentStub.onDidAssignmentsChange.callsFake(
@@ -122,12 +122,12 @@ describe("ConnectionRefresher", () => {
     );
   });
 
-  describe("lifecycle", () => {
-    describe("initialize", () => {
-      it("creates a new connection refresher when there are no servers", async () => {
+  describe('lifecycle', () => {
+    describe('initialize', () => {
+      it('creates a new connection refresher when there are no servers', async () => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([]);
 
         const initialization = ConnectionRefresher.initialize(assignmentStub);
@@ -136,10 +136,10 @@ describe("ConnectionRefresher", () => {
         (await initialization).dispose();
       });
 
-      it("creates a new connection refresher with a single server not needing refreshing", async () => {
+      it('creates a new connection refresher with a single server not needing refreshing', async () => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([DEFAULT_SERVER]);
 
         const initialization = ConnectionRefresher.initialize(assignmentStub);
@@ -148,10 +148,10 @@ describe("ConnectionRefresher", () => {
         (await initialization).dispose();
       });
 
-      it("creates a new connection refresher with a multiple servers not needing refreshing", async () => {
+      it('creates a new connection refresher with a multiple servers not needing refreshing', async () => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([DEFAULT_SERVER, { ...DEFAULT_SERVER, id: randomUUID() }]);
 
         const initialization = ConnectionRefresher.initialize(assignmentStub);
@@ -160,10 +160,10 @@ describe("ConnectionRefresher", () => {
         (await initialization).dispose();
       });
 
-      it("refreshes a single server before creating a new connection refresher", async () => {
+      it('refreshes a single server before creating a new connection refresher', async () => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([DEFAULT_SERVER_TOKEN_EXPIRED]);
 
         const initialization = ConnectionRefresher.initialize(assignmentStub);
@@ -176,12 +176,12 @@ describe("ConnectionRefresher", () => {
         (await initialization).dispose();
       });
 
-      it("refreshes multiple servers before creating a new connection refresher", async () => {
+      it('refreshes multiple servers before creating a new connection refresher', async () => {
         const server1 = DEFAULT_SERVER_TOKEN_EXPIRED;
         const server2 = { ...server1, id: randomUUID() };
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([server1, server2]);
 
         const initialization = ConnectionRefresher.initialize(assignmentStub);
@@ -193,14 +193,14 @@ describe("ConnectionRefresher", () => {
         (await initialization).dispose();
       });
 
-      it("refreshes only servers needing it before creating a new connection refresher", async () => {
+      it('refreshes only servers needing it before creating a new connection refresher', async () => {
         const server2 = {
           ...DEFAULT_SERVER_TOKEN_EXPIRED,
           id: randomUUID(),
         };
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([DEFAULT_SERVER, server2]);
 
         const initialization = ConnectionRefresher.initialize(assignmentStub);
@@ -213,7 +213,7 @@ describe("ConnectionRefresher", () => {
         (await initialization).dispose();
       });
 
-      it("aborts initialization when signalled", async () => {
+      it('aborts initialization when signalled', async () => {
         let getAbortSignal: AbortSignal | undefined;
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub).callsFake(
@@ -237,30 +237,30 @@ describe("ConnectionRefresher", () => {
 
         expect(
           getAbortSignal?.aborted,
-          "Call to get assigned servers should be aborted",
+          'Call to get assigned servers should be aborted',
         ).to.be.true;
         expect(
           refreshAbortSignal?.aborted,
-          "Call to refresh servers should be aborted",
+          'Call to refresh servers should be aborted',
         ).to.be.true;
       });
     });
 
-    describe("dispose", () => {
+    describe('dispose', () => {
       let clock: SinonFakeTimers;
 
       beforeEach(() => {
-        clock = sinon.useFakeTimers({ toFake: ["setTimeout"] });
+        clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
       });
 
       afterEach(() => {
         clock.restore();
       });
 
-      it("clears scheduled refreshes", async () => {
+      it('clears scheduled refreshes', async () => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([DEFAULT_SERVER]);
         const refresher = await ConnectionRefresher.initialize(assignmentStub);
 
@@ -271,16 +271,16 @@ describe("ConnectionRefresher", () => {
       });
     });
 
-    describe("refresh with a server", () => {
+    describe('refresh with a server', () => {
       let server = DEFAULT_SERVER;
       let clock: SinonFakeTimers;
       let refresher: ConnectionRefresher;
 
       beforeEach(async () => {
-        clock = sinon.useFakeTimers({ toFake: ["setTimeout"] });
+        clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([server]);
         refresher = await ConnectionRefresher.initialize(assignmentStub);
         assignmentStub.refreshConnection.callsFake(() => {
@@ -305,12 +305,12 @@ describe("ConnectionRefresher", () => {
         clock.restore();
       });
 
-      it("refreshes a connection before its expiry", async () => {
+      it('refreshes a connection before its expiry', async () => {
         await clock.tickAsync(expiresInMs(server) - 1);
         sinon.assert.calledOnce(assignmentStub.refreshConnection);
       });
 
-      it("schedules a refresh after refreshing", async () => {
+      it('schedules a refresh after refreshing', async () => {
         await clock.tickAsync(expiresInMs(server) - 1);
         sinon.assert.calledOnce(assignmentStub.refreshConnection);
 
@@ -318,7 +318,7 @@ describe("ConnectionRefresher", () => {
         sinon.assert.calledTwice(assignmentStub.refreshConnection);
       });
 
-      it("stops refreshing if the server to refresh is gone", async () => {
+      it('stops refreshing if the server to refresh is gone', async () => {
         assignmentStub.refreshConnection
           .onFirstCall()
           .rejects(new NotFoundError());
@@ -329,15 +329,15 @@ describe("ConnectionRefresher", () => {
         sinon.assert.notCalled(assignmentStub.refreshConnection);
       });
 
-      it("schedules a retry on failure if within buffer", async () => {
-        assignmentStub.refreshConnection.onFirstCall().rejects("💩");
+      it('schedules a retry on failure if within buffer', async () => {
+        assignmentStub.refreshConnection.onFirstCall().rejects('💩');
         await clock.tickAsync(expiresInMs(server) - 60 * 1000);
 
         sinon.assert.calledTwice(assignmentStub.refreshConnection);
       });
 
-      it("schedules a normal refresh after a successful retry", async () => {
-        assignmentStub.refreshConnection.onFirstCall().rejects("💩");
+      it('schedules a normal refresh after a successful retry', async () => {
+        assignmentStub.refreshConnection.onFirstCall().rejects('💩');
         await clock.tickAsync(expiresInMs(server) - 60 * 1000);
 
         sinon.assert.calledTwice(assignmentStub.refreshConnection);
@@ -345,15 +345,15 @@ describe("ConnectionRefresher", () => {
         sinon.assert.calledThrice(assignmentStub.refreshConnection);
       });
 
-      it("gives up retrying if outside buffer", async () => {
-        assignmentStub.refreshConnection.onFirstCall().rejects("💩");
+      it('gives up retrying if outside buffer', async () => {
+        assignmentStub.refreshConnection.onFirstCall().rejects('💩');
         await clock.tickAsync(expiresInMs(server) - 1);
 
         sinon.assert.calledTwice(assignmentStub.refreshConnection);
       });
 
-      describe("as assignments change", () => {
-        it("schedules new servers for refreshes", async () => {
+      describe('as assignments change', () => {
+        it('schedules new servers for refreshes', async () => {
           const server2 = { ...server, id: randomUUID() };
           assignmentsChangeEmitter.fire({
             added: [server2],
@@ -373,10 +373,10 @@ describe("ConnectionRefresher", () => {
           );
         });
 
-        it("no-ops when irrelevant changes are made", async () => {
+        it('no-ops when irrelevant changes are made', async () => {
           assignmentsChangeEmitter.fire({
             added: [],
-            changed: [{ ...server, label: "foo" }],
+            changed: [{ ...server, label: 'foo' }],
             removed: [],
           });
 
@@ -387,7 +387,7 @@ describe("ConnectionRefresher", () => {
         // This test is the exact same as "schedules a refresh after refreshing"
         // above, but is included to reinforce the fact that refreshes are
         // scheduled as a result of the assigned server updating.
-        it("updates the scheduled refresh when the expiry changes", async () => {
+        it('updates the scheduled refresh when the expiry changes', async () => {
           await clock.tickAsync(expiresInMs(server) - 1);
           sinon.assert.calledOnce(assignmentStub.refreshConnection);
 
@@ -395,7 +395,7 @@ describe("ConnectionRefresher", () => {
           sinon.assert.calledTwice(assignmentStub.refreshConnection);
         });
 
-        it("stops scheduling refreshes for removed servers", async () => {
+        it('stops scheduling refreshes for removed servers', async () => {
           assignmentsChangeEmitter.fire({
             added: [],
             changed: [],
@@ -406,7 +406,7 @@ describe("ConnectionRefresher", () => {
           sinon.assert.notCalled(assignmentStub.refreshConnection);
         });
 
-        it("ignores changes after being disposed", async () => {
+        it('ignores changes after being disposed', async () => {
           refresher.dispose();
 
           await clock.tickAsync(expiresInMs(server) - 1);

--- a/src/colab/consumption/notifier.ts
+++ b/src/colab/consumption/notifier.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode from "vscode";
-import { CcuInfo, SubscriptionTier } from "../api";
-import { ColabClient } from "../client";
-import { openColabSignup } from "../commands/external";
+import vscode from 'vscode';
+import { CcuInfo, SubscriptionTier } from '../api';
+import { ColabClient } from '../client';
+import { openColabSignup } from '../commands/external';
 
 const WARN_WHEN_LESS_THAN_MINUTES = 30;
 const DEFAULT_SNOOZE_MINUTES = 10;
@@ -93,7 +93,7 @@ export class ConsumptionNotifier implements vscode.Disposable {
       if (this.snoozeError) {
         return undefined;
       }
-      message = "Colab Compute Units (CCU) depleted!";
+      message = 'Colab Compute Units (CCU) depleted!';
       notify = this.vs.window.showErrorMessage;
     } else {
       // Close to running out.
@@ -157,7 +157,7 @@ function calculateRoughMinutesLeft(ccuInfo: CcuInfo): number {
 }
 
 enum SignupAction {
-  SIGNUP_FOR_COLAB = "Sign Up for Colab",
-  UPGRADE_TO_PRO_PLUS = "Upgrade to Pro+",
-  PURCHASE_MORE_CCU = "Purchase More CCUs",
+  SIGNUP_FOR_COLAB = 'Sign Up for Colab',
+  UPGRADE_TO_PRO_PLUS = 'Upgrade to Pro+',
+  PURCHASE_MORE_CCU = 'Purchase More CCUs',
 }

--- a/src/colab/consumption/notifier.unit.test.ts
+++ b/src/colab/consumption/notifier.unit.test.ts
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { assert, expect } from "chai";
-import sinon, { SinonFakeTimers, SinonStubbedInstance } from "sinon";
-import { TestEventEmitter } from "../../test/helpers/events";
-import { newVsCodeStub, VsCodeStub } from "../../test/helpers/vscode";
-import { CcuInfo, SubscriptionTier } from "../api";
-import { ColabClient } from "../client";
-import { ConsumptionNotifier } from "./notifier";
+import { assert, expect } from 'chai';
+import sinon, { SinonFakeTimers, SinonStubbedInstance } from 'sinon';
+import { TestEventEmitter } from '../../test/helpers/events';
+import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
+import { CcuInfo, SubscriptionTier } from '../api';
+import { ColabClient } from '../client';
+import { ConsumptionNotifier } from './notifier';
 
-const NOTIFICATION_SEVERITIES = ["warn", "error"] as const;
+const NOTIFICATION_SEVERITIES = ['warn', 'error'] as const;
 type NotificationSeverity = (typeof NOTIFICATION_SEVERITIES)[number];
 
 // Since notifications are dispatched asynchronously and are non-blocking, when
@@ -37,7 +37,7 @@ class TestConsumptionNotifier extends ConsumptionNotifier {
    */
   async nextConsumptionCalculation(): Promise<void> {
     const orig = this.notifyCcuConsumption;
-    const stub = sinon.stub(this, "notifyCcuConsumption");
+    const stub = sinon.stub(this, 'notifyCcuConsumption');
     const res = new Promise<void>((resolve) => {
       stub.callsFake(async (...args) => {
         try {
@@ -53,7 +53,7 @@ class TestConsumptionNotifier extends ConsumptionNotifier {
   }
 }
 
-describe("ConsumptionNotifier", () => {
+describe('ConsumptionNotifier', () => {
   let vs: VsCodeStub;
   let colabClient: SinonStubbedInstance<ColabClient>;
   let ccuEmitter: TestEventEmitter<CcuInfo>;
@@ -93,7 +93,7 @@ describe("ConsumptionNotifier", () => {
       // Type assertion needed due to overloading.
       (
         vs.window[
-          severity === "warn" ? "showWarningMessage" : "showErrorMessage"
+          severity === 'warn' ? 'showWarningMessage' : 'showErrorMessage'
         ] as sinon.SinonStub
       ).callsFake(
         async (
@@ -117,7 +117,7 @@ describe("ConsumptionNotifier", () => {
     });
   }
 
-  it("disposes the CCU listener on dispose", () => {
+  it('disposes the CCU listener on dispose', () => {
     consumptionNotifier.dispose();
 
     expect(ccuEmitter.hasListeners()).to.be.false;
@@ -140,7 +140,7 @@ describe("ConsumptionNotifier", () => {
     let hourlyConsumptionRate: number;
     let paidBalance: number;
     let freeTokens: number;
-    if ("hourlyRate" in c) {
+    if ('hourlyRate' in c) {
       hourlyConsumptionRate = c.hourlyRate;
       paidBalance = c.paidHourlyCcuBalance;
       freeTokens = c.freeTokens;
@@ -169,37 +169,37 @@ describe("ConsumptionNotifier", () => {
     consumption: Consumption;
   }[] = [
     {
-      label: "free with sufficient free minutes",
+      label: 'free with sufficient free minutes',
       tier: SubscriptionTier.NONE,
       consumption: { paidMinutes: 0, freeMinutes: 31 },
     },
     {
-      label: "pay-as-you-go with sufficient paid minutes",
+      label: 'pay-as-you-go with sufficient paid minutes',
       tier: SubscriptionTier.NONE,
       consumption: { paidMinutes: 31, freeMinutes: 0 },
     },
     {
-      label: "pay-as-you-go with sufficient combined paid and free minutes",
+      label: 'pay-as-you-go with sufficient combined paid and free minutes',
       tier: SubscriptionTier.NONE,
       consumption: { paidMinutes: 15, freeMinutes: 16 },
     },
     {
-      label: "subscribed with sufficient paid minutes",
+      label: 'subscribed with sufficient paid minutes',
       tier: SubscriptionTier.PRO,
       consumption: { paidMinutes: 31, freeMinutes: 0 },
     },
     {
-      label: "subscribed with sufficient free minutes",
+      label: 'subscribed with sufficient free minutes',
       tier: SubscriptionTier.PRO,
       consumption: { paidMinutes: 0, freeMinutes: 31 },
     },
     {
-      label: "subscribed with sufficient combined paid and free minutes",
+      label: 'subscribed with sufficient combined paid and free minutes',
       tier: SubscriptionTier.PRO,
       consumption: { paidMinutes: 15, freeMinutes: 16 },
     },
     {
-      label: "sufficient headroom and no active assignments",
+      label: 'sufficient headroom and no active assignments',
       consumption: {
         hourlyRate: 0,
         paidHourlyCcuBalance: 42,
@@ -207,11 +207,11 @@ describe("ConsumptionNotifier", () => {
       },
     },
     {
-      label: "insufficient headroom but no active assignments",
+      label: 'insufficient headroom but no active assignments',
       consumption: { hourlyRate: 0, paidHourlyCcuBalance: 0, freeTokens: 1 },
     },
     {
-      label: "depleted but no active assignments",
+      label: 'depleted but no active assignments',
       consumption: { hourlyRate: 0, paidHourlyCcuBalance: 0, freeTokens: 0 },
     },
   ];
@@ -235,119 +235,119 @@ describe("ConsumptionNotifier", () => {
     consumption: ConsumptionByMinutes;
     should: {
       severity: NotificationSeverity;
-      action: "Sign Up" | "Upgrade" | "Purchase More";
+      action: 'Sign Up' | 'Upgrade' | 'Purchase More';
     };
   }[] = [
     {
-      label: "unsubscribed with no free minutes",
+      label: 'unsubscribed with no free minutes',
       tier: SubscriptionTier.NONE,
       consumption: { paidMinutes: 0, freeMinutes: 0 },
       should: {
-        severity: "error",
-        action: "Sign Up",
+        severity: 'error',
+        action: 'Sign Up',
       },
     },
     {
-      label: "unsubscribed with minimal free minutes",
+      label: 'unsubscribed with minimal free minutes',
       tier: SubscriptionTier.NONE,
       consumption: { paidMinutes: 0, freeMinutes: 1 },
       should: {
-        severity: "warn",
-        action: "Sign Up",
+        severity: 'warn',
+        action: 'Sign Up',
       },
     },
     {
-      label: "pay-as-you-go with minimal paid minutes and no free minutes",
+      label: 'pay-as-you-go with minimal paid minutes and no free minutes',
       tier: SubscriptionTier.NONE,
       consumption: { paidMinutes: 1, freeMinutes: 0 },
       should: {
-        severity: "warn",
-        action: "Purchase More",
+        severity: 'warn',
+        action: 'Purchase More',
       },
     },
     {
-      label: "pay-as-you-go with minimal combined paid and free minutes",
+      label: 'pay-as-you-go with minimal combined paid and free minutes',
       tier: SubscriptionTier.NONE,
       consumption: { paidMinutes: 1, freeMinutes: 1 },
       should: {
-        severity: "warn",
-        action: "Purchase More",
+        severity: 'warn',
+        action: 'Purchase More',
       },
     },
     {
-      label: "pro with no paid or free minutes",
+      label: 'pro with no paid or free minutes',
       tier: SubscriptionTier.PRO,
       consumption: { paidMinutes: 0, freeMinutes: 0 },
       should: {
-        severity: "error",
-        action: "Upgrade",
+        severity: 'error',
+        action: 'Upgrade',
       },
     },
     {
-      label: "pro with no paid and minimal free minutes",
+      label: 'pro with no paid and minimal free minutes',
       tier: SubscriptionTier.PRO,
       consumption: { paidMinutes: 0, freeMinutes: 1 },
       should: {
-        severity: "warn",
-        action: "Upgrade",
+        severity: 'warn',
+        action: 'Upgrade',
       },
     },
     {
       // Seems like a weird case, but consider a free user who consumes all
       // their quota but then signs up for Pro.
-      label: "pro with minimal paid and no free minutes",
+      label: 'pro with minimal paid and no free minutes',
       tier: SubscriptionTier.PRO,
       consumption: { paidMinutes: 1, freeMinutes: 0 },
       should: {
-        severity: "warn",
-        action: "Upgrade",
+        severity: 'warn',
+        action: 'Upgrade',
       },
     },
     {
-      label: "pro with minimal combined paid and free minutes",
+      label: 'pro with minimal combined paid and free minutes',
       tier: SubscriptionTier.PRO,
       consumption: { paidMinutes: 1, freeMinutes: 1 },
       should: {
-        severity: "warn",
-        action: "Upgrade",
+        severity: 'warn',
+        action: 'Upgrade',
       },
     },
     {
-      label: "pro+ with no paid or free minutes",
+      label: 'pro+ with no paid or free minutes',
       tier: SubscriptionTier.PRO_PLUS,
       consumption: { paidMinutes: 0, freeMinutes: 0 },
       should: {
-        severity: "error",
-        action: "Purchase More",
+        severity: 'error',
+        action: 'Purchase More',
       },
     },
     {
-      label: "pro+ with no paid and minimal free minutes",
+      label: 'pro+ with no paid and minimal free minutes',
       tier: SubscriptionTier.PRO_PLUS,
       consumption: { paidMinutes: 0, freeMinutes: 1 },
       should: {
-        severity: "warn",
-        action: "Purchase More",
+        severity: 'warn',
+        action: 'Purchase More',
       },
     },
     {
       // Seems like a weird case, but consider a free user who consumes all
       // their quota but then signs up for Pro+.
-      label: "pro+ with minimal paid and no free minutes",
+      label: 'pro+ with minimal paid and no free minutes',
       tier: SubscriptionTier.PRO_PLUS,
       consumption: { paidMinutes: 1, freeMinutes: 0 },
       should: {
-        severity: "warn",
-        action: "Purchase More",
+        severity: 'warn',
+        action: 'Purchase More',
       },
     },
     {
-      label: "pro+ with minimal combined paid and free minutes",
+      label: 'pro+ with minimal combined paid and free minutes',
       tier: SubscriptionTier.PRO_PLUS,
       consumption: { paidMinutes: 1, freeMinutes: 1 },
       should: {
-        severity: "warn",
-        action: "Purchase More",
+        severity: 'warn',
+        action: 'Purchase More',
       },
     },
   ];
@@ -365,7 +365,7 @@ describe("ConsumptionNotifier", () => {
         t.consumption.paidMinutes + t.consumption.freeMinutes
       ).toString();
       const expectedMessage =
-        t.should.severity === "error"
+        t.should.severity === 'error'
           ? /depleted/
           : new RegExp(`${minutesLeft} minutes left`);
       expect(notification.message).to.match(expectedMessage);
@@ -373,7 +373,7 @@ describe("ConsumptionNotifier", () => {
       const action = notification.actions[0];
       expect(action).to.match(new RegExp(t.should.action));
       const notificationStub =
-        t.should.severity === "error"
+        t.should.severity === 'error'
           ? vs.window.showErrorMessage
           : vs.window.showWarningMessage;
       sinon.assert.calledOnce(notificationStub);
@@ -384,7 +384,7 @@ describe("ConsumptionNotifier", () => {
     it(`should open signup page when action is clicked for ${severity}`, async () => {
       const ccuInfo = createCcuInfo({
         paidMinutes: 0,
-        freeMinutes: severity === "warn" ? 1 : 0,
+        freeMinutes: severity === 'warn' ? 1 : 0,
       });
       const notification = nextNotification(severity);
       ccuEmitter.fire(ccuInfo);
@@ -396,19 +396,19 @@ describe("ConsumptionNotifier", () => {
         });
       });
 
-      shownNotification.click("Sign Up for Colab");
+      shownNotification.click('Sign Up for Colab');
 
       await expect(openExternal).to.eventually.equal(
-        "https://colab.research.google.com/signup",
+        'https://colab.research.google.com/signup',
       );
     });
   }
 
-  describe("snooze", () => {
+  describe('snooze', () => {
     let fakeClock: SinonFakeTimers;
 
     beforeEach(() => {
-      fakeClock = sinon.useFakeTimers({ toFake: ["setTimeout"] });
+      fakeClock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
     });
 
     afterEach(() => {
@@ -419,7 +419,7 @@ describe("ConsumptionNotifier", () => {
       it(`should not ${severity} while in "snooze" period`, async () => {
         const ccuInfo = createCcuInfo({
           paidMinutes: 0,
-          freeMinutes: severity === "warn" ? 1 : 0,
+          freeMinutes: severity === 'warn' ? 1 : 0,
         });
         const firstNotification = nextNotification(severity);
         ccuEmitter.fire(ccuInfo);

--- a/src/colab/consumption/poller.ts
+++ b/src/colab/consumption/poller.ts
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode, { Disposable } from "vscode";
+import vscode, { Disposable } from 'vscode';
 import {
   OverrunPolicy,
   SequentialTaskRunner,
   StartMode,
-} from "../../common/task-runner";
-import { Toggleable } from "../../common/toggleable";
-import { CcuInfo } from "../api";
-import { ColabClient } from "../client";
+} from '../../common/task-runner';
+import { Toggleable } from '../../common/toggleable';
+import { CcuInfo } from '../api';
+import { ColabClient } from '../client';
 
 const POLL_INTERVAL_MS = 1000 * 60 * 5; // 5 minutes.
 const TASK_TIMEOUT_MS = 1000 * 10; // 10 seconds.
@@ -87,7 +87,7 @@ export class ConsumptionPoller implements Toggleable, Disposable {
 
   private assertNotDisposed(): void {
     if (this.isDisposed) {
-      throw new Error("ConsumptionPoller is disposed");
+      throw new Error('ConsumptionPoller is disposed');
     }
   }
 }

--- a/src/colab/consumption/poller.unit.test.ts
+++ b/src/colab/consumption/poller.unit.test.ts
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import * as sinon from "sinon";
+import { expect } from 'chai';
+import * as sinon from 'sinon';
 import {
   SinonFakeTimers,
   SinonStubbedInstance,
   createStubInstance,
-} from "sinon";
-import { newVsCodeStub, VsCodeStub } from "../../test/helpers/vscode";
-import { CcuInfo } from "../api";
-import { ColabClient } from "../client";
-import { ConsumptionPoller } from "./poller";
+} from 'sinon';
+import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
+import { CcuInfo } from '../api';
+import { ColabClient } from '../client';
+import { ConsumptionPoller } from './poller';
 
 const POLL_INTERVAL_MS = 1000 * 60 * 5; // 5 minutes.
 const TASK_TIMEOUT_MS = 1000 * 10; // 10 seconds.
@@ -22,17 +22,17 @@ const DEFAULT_CCU_INFO: CcuInfo = {
   currentBalance: 1,
   consumptionRateHourly: 2,
   assignmentsCount: 3,
-  eligibleGpus: ["T4"],
-  ineligibleGpus: ["A100", "L4"],
-  eligibleTpus: ["V6E1", "V28"],
-  ineligibleTpus: ["V5E1"],
+  eligibleGpus: ['T4'],
+  ineligibleGpus: ['A100', 'L4'],
+  eligibleTpus: ['V6E1', 'V28'],
+  ineligibleTpus: ['V5E1'],
   freeCcuQuotaInfo: {
     remainingTokens: 4,
     nextRefillTimestampSec: 5,
   },
 };
 
-describe("ConsumptionPoller", () => {
+describe('ConsumptionPoller', () => {
   let fakeClock: SinonFakeTimers;
   let vsCodeStub: VsCodeStub;
   let clientStub: SinonStubbedInstance<ColabClient>;
@@ -40,7 +40,7 @@ describe("ConsumptionPoller", () => {
 
   beforeEach(() => {
     fakeClock = sinon.useFakeTimers({
-      toFake: ["setInterval", "clearInterval", "setTimeout"],
+      toFake: ['setInterval', 'clearInterval', 'setTimeout'],
     });
     vsCodeStub = newVsCodeStub();
     clientStub = createStubInstance(ColabClient);
@@ -52,7 +52,7 @@ describe("ConsumptionPoller", () => {
     sinon.restore();
   });
 
-  describe("lifecycle", () => {
+  describe('lifecycle', () => {
     beforeEach(() => {
       clientStub.getCcuInfo.resolves(DEFAULT_CCU_INFO);
     });
@@ -61,7 +61,7 @@ describe("ConsumptionPoller", () => {
       poller.dispose();
     });
 
-    it("disposes the runner", async () => {
+    it('disposes the runner', async () => {
       clientStub.getCcuInfo.resetHistory();
 
       poller.dispose();
@@ -70,7 +70,7 @@ describe("ConsumptionPoller", () => {
       sinon.assert.notCalled(clientStub.getCcuInfo);
     });
 
-    it("throws when used after being disposed", () => {
+    it('throws when used after being disposed', () => {
       poller.dispose();
 
       expect(() => {
@@ -81,7 +81,7 @@ describe("ConsumptionPoller", () => {
       }).to.throw(/disposed/);
     });
 
-    it("aborts slow calls to get CCU info", async () => {
+    it('aborts slow calls to get CCU info', async () => {
       clientStub.getCcuInfo.resetHistory();
       clientStub.getCcuInfo.onFirstCall().callsFake(
         // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -96,7 +96,7 @@ describe("ConsumptionPoller", () => {
     });
   });
 
-  describe("toggled on", () => {
+  describe('toggled on', () => {
     beforeEach(async () => {
       clientStub.getCcuInfo.resolves(DEFAULT_CCU_INFO);
       poller.on();
@@ -106,7 +106,7 @@ describe("ConsumptionPoller", () => {
       clientStub.getCcuInfo.resetHistory();
     });
 
-    describe("when the CCU info does not change", () => {
+    describe('when the CCU info does not change', () => {
       let onDidChangeCcuInfo: sinon.SinonStub<[CcuInfo]>;
 
       beforeEach(() => {
@@ -114,7 +114,7 @@ describe("ConsumptionPoller", () => {
         poller.onDidChangeCcuInfo(onDidChangeCcuInfo);
       });
 
-      it("does not emit an event", async () => {
+      it('does not emit an event', async () => {
         await fakeClock.tickAsync(POLL_INTERVAL_MS);
 
         sinon.assert.calledOnce(clientStub.getCcuInfo);
@@ -122,7 +122,7 @@ describe("ConsumptionPoller", () => {
       });
     });
 
-    describe("when the CCU info changes", () => {
+    describe('when the CCU info changes', () => {
       const newCcuInfo: CcuInfo = {
         ...DEFAULT_CCU_INFO,
         eligibleGpus: [],
@@ -136,7 +136,7 @@ describe("ConsumptionPoller", () => {
         clientStub.getCcuInfo.resolves(newCcuInfo);
       });
 
-      it("emits an event", async () => {
+      it('emits an event', async () => {
         await fakeClock.tickAsync(POLL_INTERVAL_MS);
 
         sinon.assert.calledOnce(clientStub.getCcuInfo);
@@ -145,7 +145,7 @@ describe("ConsumptionPoller", () => {
     });
   });
 
-  it("can be toggled on and off", async () => {
+  it('can be toggled on and off', async () => {
     const onDidChangeCcuInfo: sinon.SinonStub<[CcuInfo]> = sinon.stub();
     poller.onDidChangeCcuInfo(onDidChangeCcuInfo);
 

--- a/src/colab/headers.ts
+++ b/src/colab/headers.ts
@@ -28,16 +28,16 @@ export interface StaticHeader extends Header {
  * The HTTP header for JSON content type.
  */
 export const CONTENT_TYPE_JSON_HEADER: StaticHeader = {
-  key: "Content-Type",
-  value: "application/json",
+  key: 'Content-Type',
+  value: 'application/json',
 };
 
 /**
  * The HTTP header for accepting JSON.
  */
 export const ACCEPT_JSON_HEADER: StaticHeader = {
-  key: "Accept",
-  value: "application/json",
+  key: 'Accept',
+  value: 'application/json',
 };
 
 /**
@@ -45,35 +45,35 @@ export const ACCEPT_JSON_HEADER: StaticHeader = {
  * VS Code.
  */
 export const COLAB_CLIENT_AGENT_HEADER: StaticHeader = {
-  key: "X-Colab-Client-Agent",
-  value: "vscode",
+  key: 'X-Colab-Client-Agent',
+  value: 'vscode',
 };
 
 /**
  * The HTTP header for requests that are resolved through the Colab tunnel.
  */
 export const COLAB_TUNNEL_HEADER: StaticHeader = {
-  key: "X-Colab-Tunnel",
-  value: "Google",
+  key: 'X-Colab-Tunnel',
+  value: 'Google',
 };
 
 /**
  * The HTTP header for the authorization token.
  */
 export const AUTHORIZATION_HEADER: Header = {
-  key: "Authorization",
+  key: 'Authorization',
 };
 
 /**
  * The HTTP header for the Colab runtime proxy token.
  */
 export const COLAB_RUNTIME_PROXY_TOKEN_HEADER: Header = {
-  key: "X-Colab-Runtime-Proxy-Token",
+  key: 'X-Colab-Runtime-Proxy-Token',
 };
 
 /**
  * The HTTP header for the Colab XSRF token.
  */
 export const COLAB_XSRF_TOKEN_HEADER: Header = {
-  key: "X-Goog-Colab-Token",
+  key: 'X-Goog-Colab-Token',
 };

--- a/src/colab/keep-alive.ts
+++ b/src/colab/keep-alive.ts
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { UUID } from "crypto";
-import { Disposable } from "vscode";
-import vscode from "vscode";
-import { log } from "../common/logging";
-import { traceMethod } from "../common/logging/decorators";
-import { OverrunPolicy, SequentialTaskRunner } from "../common/task-runner";
-import { Toggleable } from "../common/toggleable";
-import { AssignmentManager } from "../jupyter/assignments";
-import { ColabAssignedServer } from "../jupyter/servers";
-import { Kernel } from "./api";
-import { ColabClient } from "./client";
+import { UUID } from 'crypto';
+import { Disposable } from 'vscode';
+import vscode from 'vscode';
+import { log } from '../common/logging';
+import { traceMethod } from '../common/logging/decorators';
+import { OverrunPolicy, SequentialTaskRunner } from '../common/task-runner';
+import { Toggleable } from '../common/toggleable';
+import { AssignmentManager } from '../jupyter/assignments';
+import { ColabAssignedServer } from '../jupyter/servers';
+import { Kernel } from './api';
+import { ColabClient } from './client';
 
 interface Config {
   /**
@@ -45,10 +45,10 @@ const DEFAULT_CONFIG: Config = {
 };
 
 const ACTIVE_KERNEL_STATES = new Set([
-  "starting",
-  "busy",
-  "restarting",
-  "autorestarting",
+  'starting',
+  'busy',
+  'restarting',
+  'autorestarting',
 ]);
 
 /**
@@ -108,7 +108,7 @@ export class ServerKeepAliveController implements Toggleable, Disposable {
 
   private async keepServersAlive(signal: AbortSignal): Promise<void> {
     const assignments = await this.assignmentManager.getServers(
-      "extension",
+      'extension',
       signal,
     );
     const keepAliveSignals = assignments.map(async (a) => {
@@ -232,7 +232,7 @@ export class ServerKeepAliveController implements Toggleable, Disposable {
 
   private assertNotDisposed(): void {
     if (this.isDisposed) {
-      throw new Error("ServerKeepAliveController is disposed");
+      throw new Error('ServerKeepAliveController is disposed');
     }
   }
 }

--- a/src/colab/keep-alive.unit.test.ts
+++ b/src/colab/keep-alive.unit.test.ts
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { randomUUID } from "crypto";
-import { expect } from "chai";
-import sinon, { SinonFakeTimers, SinonStubbedInstance } from "sinon";
-import { AssignmentManager } from "../jupyter/assignments";
-import { ColabAssignedServer } from "../jupyter/servers";
-import { TestCancellationTokenSource } from "../test/helpers/cancellation";
-import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
-import { Kernel, Variant } from "./api";
-import { ColabClient } from "./client";
+import { randomUUID } from 'crypto';
+import { expect } from 'chai';
+import sinon, { SinonFakeTimers, SinonStubbedInstance } from 'sinon';
+import { AssignmentManager } from '../jupyter/assignments';
+import { ColabAssignedServer } from '../jupyter/servers';
+import { TestCancellationTokenSource } from '../test/helpers/cancellation';
+import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
+import { Kernel, Variant } from './api';
+import { ColabClient } from './client';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
-} from "./headers";
-import { ServerKeepAliveController } from "./keep-alive";
+} from './headers';
+import { ServerKeepAliveController } from './keep-alive';
 
 const NOW = new Date();
 const ONE_SECOND_MS = 1000;
@@ -27,8 +27,8 @@ const ABORTING_KEEP_ALIVE = async (
   signal?: AbortSignal,
 ): Promise<void> =>
   new Promise((_, reject) => {
-    signal?.addEventListener("abort", () => {
-      reject(new Error("Aborted"));
+    signal?.addEventListener('abort', () => {
+      reject(new Error('Aborted'));
     });
   });
 
@@ -40,14 +40,14 @@ const CONFIG = {
 };
 
 const DEFAULT_KERNEL: Kernel = {
-  id: "456",
-  name: "Kermit the Kernel",
+  id: '456',
+  name: 'Kermit the Kernel',
   lastActivity: new Date(NOW.getTime() - ONE_MINUTE_MS).toString(),
-  executionState: "idle",
+  executionState: 'idle',
   connections: 1,
 };
 
-describe("ServerKeepAliveController", () => {
+describe('ServerKeepAliveController', () => {
   let clock: SinonFakeTimers;
   let vsCodeStub: VsCodeStub;
   let colabClientStub: SinonStubbedInstance<ColabClient>;
@@ -61,7 +61,7 @@ describe("ServerKeepAliveController", () => {
 
   beforeEach(() => {
     clock = sinon.useFakeTimers({
-      toFake: ["setInterval", "clearInterval", "setTimeout"],
+      toFake: ['setInterval', 'clearInterval', 'setTimeout'],
     });
     clock.setSystemTime(NOW);
     vsCodeStub = newVsCodeStub();
@@ -69,16 +69,16 @@ describe("ServerKeepAliveController", () => {
     assignmentStub = sinon.createStubInstance(AssignmentManager);
     defaultServer = {
       id: randomUUID(),
-      label: "Colab GPU A100",
+      label: 'Colab GPU A100',
       variant: Variant.GPU,
-      accelerator: "A100",
-      endpoint: "m-s-foo",
+      accelerator: 'A100',
+      endpoint: 'm-s-foo',
       connectionInformation: {
-        baseUrl: vsCodeStub.Uri.parse("https://example.com"),
-        token: "123",
+        baseUrl: vsCodeStub.Uri.parse('https://example.com'),
+        token: '123',
         tokenExpiry: new Date(Date.now() + 1000 * 60 * 60),
         headers: {
-          [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: "123",
+          [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: '123',
           [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
         },
       },
@@ -98,15 +98,15 @@ describe("ServerKeepAliveController", () => {
     keepAlive.dispose();
   });
 
-  describe("lifecycle", () => {
-    it("disposes the runner", async () => {
+  describe('lifecycle', () => {
+    it('disposes the runner', async () => {
       keepAlive.dispose();
 
       await tickPast(CONFIG.keepAliveIntervalMs);
       sinon.assert.notCalled(colabClientStub.sendKeepAlive);
     });
 
-    it("throws when disposed", () => {
+    it('throws when disposed', () => {
       keepAlive.dispose();
 
       expect(() => {
@@ -117,17 +117,17 @@ describe("ServerKeepAliveController", () => {
       }).to.throw(/disposed/);
     });
 
-    it("throws if used after being disposed", () => {
+    it('throws if used after being disposed', () => {
       keepAlive.dispose();
 
       expect(keepAlive.on).to.throw();
       expect(keepAlive.off).to.throw();
     });
 
-    it("skips when a keep-alive is already in flight", async () => {
+    it('skips when a keep-alive is already in flight', async () => {
       // Type assertion needed due to overloading on getServers
       (assignmentStub.getServers as sinon.SinonStub)
-        .withArgs("extension")
+        .withArgs('extension')
         .resolves([defaultServer]);
       colabClientStub.listKernels
         .withArgs(defaultServer)
@@ -152,10 +152,10 @@ describe("ServerKeepAliveController", () => {
       sinon.assert.calledOnce(colabClientStub.sendKeepAlive);
     });
 
-    it("can be toggled on and off", async () => {
+    it('can be toggled on and off', async () => {
       // Type assertion needed due to overloading on getServers
       (assignmentStub.getServers as sinon.SinonStub)
-        .withArgs("extension")
+        .withArgs('extension')
         .resolves([defaultServer]);
       colabClientStub.listKernels
         .withArgs(defaultServer)
@@ -178,15 +178,15 @@ describe("ServerKeepAliveController", () => {
     });
   });
 
-  describe("toggled on", () => {
+  describe('toggled on', () => {
     beforeEach(() => {
       keepAlive.on();
     });
 
-    it("aborts slow keep-alive attempts", async () => {
+    it('aborts slow keep-alive attempts', async () => {
       // Type assertion needed due to overloading on getServers
       (assignmentStub.getServers as sinon.SinonStub)
-        .withArgs("extension")
+        .withArgs('extension')
         .resolves([defaultServer]);
       colabClientStub.listKernels
         .withArgs(defaultServer)
@@ -204,11 +204,11 @@ describe("ServerKeepAliveController", () => {
         .true;
     });
 
-    describe("with no assigned servers", () => {
-      it("does nothing", async () => {
+    describe('with no assigned servers', () => {
+      it('does nothing', async () => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([]);
 
         await tickPast(CONFIG.keepAliveIntervalMs);
@@ -223,11 +223,11 @@ describe("ServerKeepAliveController", () => {
       beforeEach(() => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([defaultServer]);
       });
 
-      it("sends a keep-alive request for a server with recent activity", async () => {
+      it('sends a keep-alive request for a server with recent activity', async () => {
         colabClientStub.listKernels
           .withArgs(defaultServer)
           .resolves([DEFAULT_KERNEL]);
@@ -242,9 +242,9 @@ describe("ServerKeepAliveController", () => {
       });
 
       for (const state of [
-        "starting",
-        "restarting",
-        "autorestarting",
+        'starting',
+        'restarting',
+        'autorestarting',
       ] as const) {
         it(`sends a keep-alive request for a server with a "${state}" kernel`, async () => {
           const busyKernel: Kernel = {
@@ -290,7 +290,7 @@ describe("ServerKeepAliveController", () => {
       beforeEach(() => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([defaultServer]);
         colabClientStub.listKernels
           .withArgs(defaultServer)
@@ -311,13 +311,13 @@ describe("ServerKeepAliveController", () => {
           );
       });
 
-      it("prompts the user to keep it running", async () => {
+      it('prompts the user to keep it running', async () => {
         await tickPast(CONFIG.keepAliveIntervalMs);
 
         sinon.assert.calledOnce(vsCodeStub.window.withProgress);
       });
 
-      it("counts down the time to extend", async () => {
+      it('counts down the time to extend', async () => {
         const increment =
           100 / (CONFIG.idleExtensionPromptTimeMs / ONE_SECOND_MS);
         await tickPast(CONFIG.keepAliveIntervalMs);
@@ -341,17 +341,17 @@ describe("ServerKeepAliveController", () => {
         });
       });
 
-      describe("which the user does not extend", () => {
+      describe('which the user does not extend', () => {
         beforeEach(async () => {
           await tickPast(CONFIG.keepAliveIntervalMs);
           await tickPast(CONFIG.idleExtensionPromptTimeMs);
         });
 
-        it("does not send keep-alive requests", () => {
+        it('does not send keep-alive requests', () => {
           sinon.assert.notCalled(colabClientStub.sendKeepAlive);
         });
 
-        it("does not prompt for extension again", async () => {
+        it('does not prompt for extension again', async () => {
           sinon.assert.calledOnce(vsCodeStub.window.withProgress);
           vsCodeStub.window.withProgress.resetHistory();
 
@@ -362,7 +362,7 @@ describe("ServerKeepAliveController", () => {
           sinon.assert.notCalled(colabClientStub.sendKeepAlive);
         });
 
-        it("starts sending keep-alive requests when used again", async () => {
+        it('starts sending keep-alive requests when used again', async () => {
           sinon.assert.notCalled(colabClientStub.sendKeepAlive);
           const activeKernel: Kernel = {
             ...idleKernel,
@@ -378,7 +378,7 @@ describe("ServerKeepAliveController", () => {
         });
       });
 
-      describe("which the user extends", () => {
+      describe('which the user extends', () => {
         beforeEach(async () => {
           await tickPast(CONFIG.keepAliveIntervalMs);
           sinon.assert.calledOnce(reportStub);
@@ -387,12 +387,12 @@ describe("ServerKeepAliveController", () => {
           await clock.runToLastAsync();
         });
 
-        it("sends a keep-alive request", () => {
+        it('sends a keep-alive request', () => {
           // Once before the extension prompt, and once after.
           sinon.assert.calledTwice(colabClientStub.sendKeepAlive);
         });
 
-        describe("and then uses", () => {
+        describe('and then uses', () => {
           beforeEach(async () => {
             const activeKernel: Kernel = {
               ...idleKernel,
@@ -404,13 +404,13 @@ describe("ServerKeepAliveController", () => {
             await tickPast(CONFIG.keepAliveIntervalMs);
           });
 
-          it("sends a keep-alive request", () => {
+          it('sends a keep-alive request', () => {
             // Once before the extension prompt, once after and again after
             // using the kernel.
             sinon.assert.calledThrice(colabClientStub.sendKeepAlive);
           });
 
-          it("does not prompt to keep it running", () => {
+          it('does not prompt to keep it running', () => {
             // Only the first prompt.
             sinon.assert.calledOnce(vsCodeStub.window.withProgress);
           });
@@ -421,7 +421,7 @@ describe("ServerKeepAliveController", () => {
     describe('with a mix of "active" and "idle" servers', () => {
       function createServerWithKernel(
         n: number,
-        activity: "idle" | "active",
+        activity: 'idle' | 'active',
       ): { server: ColabAssignedServer; kernel: Kernel } {
         const server = {
           ...defaultServer,
@@ -433,14 +433,14 @@ describe("ServerKeepAliveController", () => {
 
       function createKernel(
         assignment: ColabAssignedServer,
-        activity: "idle" | "active",
+        activity: 'idle' | 'active',
       ): Kernel {
         return {
           ...DEFAULT_KERNEL,
           id: assignment.id,
           lastActivity: new Date(
             NOW.getTime() +
-              (activity === "active" ? 1 : -1) * CONFIG.inactivityThresholdMs -
+              (activity === 'active' ? 1 : -1) * CONFIG.inactivityThresholdMs -
               1,
           ).toString(),
         };
@@ -452,17 +452,17 @@ describe("ServerKeepAliveController", () => {
       let idle2: { server: ColabAssignedServer; kernel: Kernel };
 
       beforeEach(() => {
-        active1 = createServerWithKernel(1, "active");
-        active2 = createServerWithKernel(2, "active");
-        idle1 = createServerWithKernel(3, "idle");
-        idle2 = createServerWithKernel(4, "idle");
+        active1 = createServerWithKernel(1, 'active');
+        active2 = createServerWithKernel(2, 'active');
+        idle1 = createServerWithKernel(3, 'idle');
+        idle2 = createServerWithKernel(4, 'idle');
         const servers = [active1, active2, idle1, idle2];
         for (const { server, kernel } of servers) {
           colabClientStub.listKernels.withArgs(server).resolves([kernel]);
         }
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves(servers.map((s) => s.server));
       });
 
@@ -523,7 +523,7 @@ describe("ServerKeepAliveController", () => {
 
       // This is important to validate that keep-alive requests continue to
       // get sent to all servers, even if one is failing.
-      it("swallows keep-alive failures", async () => {
+      it('swallows keep-alive failures', async () => {
         colabClientStub.sendKeepAlive
           .withArgs(active1.server.endpoint)
           .rejects();
@@ -542,18 +542,18 @@ describe("ServerKeepAliveController", () => {
       });
     });
 
-    describe("with a server that has multiple kernels", () => {
-      it("respects the most recent kernel activity", async () => {
+    describe('with a server that has multiple kernels', () => {
+      it('respects the most recent kernel activity', async () => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([defaultServer]);
         const kernels: Kernel[] = [
           DEFAULT_KERNEL,
           // An "idle" kernel.
           {
             ...DEFAULT_KERNEL,
-            id: "789",
+            id: '789',
             lastActivity: new Date(42).toString(),
           },
         ];
@@ -568,20 +568,20 @@ describe("ServerKeepAliveController", () => {
         );
       });
 
-      it("does not send a keep-alive request if all kernels are idle", async () => {
+      it('does not send a keep-alive request if all kernels are idle', async () => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
-          .withArgs("extension")
+          .withArgs('extension')
           .resolves([defaultServer]);
         const kernels: Kernel[] = [
           {
             ...DEFAULT_KERNEL,
-            id: "789",
+            id: '789',
             lastActivity: new Date(42).toString(),
           },
           {
             ...DEFAULT_KERNEL,
-            id: "987",
+            id: '987',
             lastActivity: new Date(43).toString(),
           },
         ];

--- a/src/colab/server-picker.ts
+++ b/src/colab/server-picker.ts
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode, { QuickPickItem } from "vscode";
-import { InputStep, MultiStepInput } from "../common/multi-step-quickpick";
-import { AssignmentManager } from "../jupyter/assignments";
-import { ColabServerDescriptor } from "../jupyter/servers";
-import { Variant, variantToMachineType } from "./api";
+import vscode, { QuickPickItem } from 'vscode';
+import { InputStep, MultiStepInput } from '../common/multi-step-quickpick';
+import { AssignmentManager } from '../jupyter/assignments';
+import { ColabServerDescriptor } from '../jupyter/servers';
+import { Variant, variantToMachineType } from './api';
 
 /** Provides an explanation to the user on updating the server alias. */
 export const PROMPT_SERVER_ALIAS =
-  "Provide a local convenience alias to the server.";
+  'Provide a local convenience alias to the server.';
 
 /** Validates the server alias. */
 export const validateServerAlias = (value: string) =>
-  value.length > 10 ? "Name must be less than 10 characters." : "";
+  value.length > 10 ? 'Name must be less than 10 characters.' : '';
 
 /**
  * Supports prompting the user to pick a Colab server to be created.
@@ -41,7 +41,7 @@ export class ServerPicker {
     for (const server of availableServers) {
       const accelerators =
         variantToAccelerators.get(server.variant) ?? new Set();
-      accelerators.add(server.accelerator ?? "NONE");
+      accelerators.add(server.accelerator ?? 'NONE');
       variantToAccelerators.set(server.variant, accelerators);
     }
     if (variantToAccelerators.size === 0) {
@@ -80,7 +80,7 @@ export class ServerPicker {
       });
     }
     const pick = await input.showQuickPick({
-      title: "Select a variant",
+      title: 'Select a variant',
       step: 1,
       totalSteps: 2,
       items,
@@ -93,7 +93,7 @@ export class ServerPicker {
     }
     // Skip prompting for an accelerator for the default variant (CPU).
     if (state.variant === Variant.DEFAULT) {
-      state.accelerator = "NONE";
+      state.accelerator = 'NONE';
       return (input: MultiStepInput) => this.promptForAlias(input, state);
     }
     return (input: MultiStepInput) =>
@@ -102,7 +102,7 @@ export class ServerPicker {
 
   private async promptForAccelerator(
     input: MultiStepInput,
-    state: PartialServerWith<"variant">,
+    state: PartialServerWith<'variant'>,
     acceleratorsByVariant: Map<Variant, Set<string>>,
   ): Promise<InputStep | undefined> {
     const accelerators = acceleratorsByVariant.get(state.variant) ?? new Set();
@@ -114,7 +114,7 @@ export class ServerPicker {
       });
     }
     const pick = await input.showQuickPick({
-      title: "Select an accelerator",
+      title: 'Select an accelerator',
       step: 2,
       // Since we have to pick an accelerator, we've added a step.
       totalSteps: 3,
@@ -132,18 +132,18 @@ export class ServerPicker {
 
   private async promptForAlias(
     input: MultiStepInput,
-    state: PartialServerWith<"variant">,
+    state: PartialServerWith<'variant'>,
   ): Promise<InputStep | undefined> {
     const placeholder = await this.assignments.getDefaultLabel(
       state.variant,
       state.accelerator,
     );
-    const step = state.accelerator && state.accelerator !== "NONE" ? 3 : 2;
+    const step = state.accelerator && state.accelerator !== 'NONE' ? 3 : 2;
     const alias = await input.showInputBox({
-      title: "Alias your server",
+      title: 'Alias your server',
       step,
       totalSteps: step,
-      value: state.alias ?? "",
+      value: state.alias ?? '',
       prompt: PROMPT_SERVER_ALIAS,
       validate: validateServerAlias,
       placeholder,
@@ -168,13 +168,13 @@ type PartialServerWith<K extends keyof Server> = Partial<Server> &
 
 function isVariantDefined(
   state: Partial<Server>,
-): state is PartialServerWith<"variant"> {
+): state is PartialServerWith<'variant'> {
   return state.variant !== undefined;
 }
 
 function isAcceleratorDefined(
   state: Partial<Server>,
-): state is PartialServerWith<"accelerator"> {
+): state is PartialServerWith<'accelerator'> {
   return state.accelerator !== undefined;
 }
 

--- a/src/colab/server-picker.unit.test.ts
+++ b/src/colab/server-picker.unit.test.ts
@@ -4,39 +4,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import * as sinon from "sinon";
-import { InputBox, QuickPick, QuickPickItem } from "vscode";
-import { AssignmentManager } from "../jupyter/assignments";
-import { DEFAULT_CPU_SERVER } from "../jupyter/servers";
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { InputBox, QuickPick, QuickPickItem } from 'vscode';
+import { AssignmentManager } from '../jupyter/assignments';
+import { DEFAULT_CPU_SERVER } from '../jupyter/servers';
 import {
   buildInputBoxStub,
   buildQuickPickStub,
-} from "../test/helpers/quick-input";
-import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
-import { Variant } from "./api";
-import { ServerPicker } from "./server-picker";
+} from '../test/helpers/quick-input';
+import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
+import { Variant } from './api';
+import { ServerPicker } from './server-picker';
 
 const AVAILABLE_SERVERS = [
   DEFAULT_CPU_SERVER,
   {
-    label: "Colab GPU T4",
+    label: 'Colab GPU T4',
     variant: Variant.GPU,
-    accelerator: "T4",
+    accelerator: 'T4',
   },
   {
-    label: "Colab GPU A100",
+    label: 'Colab GPU A100',
     variant: Variant.GPU,
-    accelerator: "A100",
+    accelerator: 'A100',
   },
   {
-    label: "Colab TPU V6E1",
+    label: 'Colab TPU V6E1',
     variant: Variant.TPU,
-    accelerator: "V6E1",
+    accelerator: 'V6E1',
   },
 ];
 
-describe("ServerPicker", () => {
+describe('ServerPicker', () => {
   let vsCodeStub: VsCodeStub;
   let assignmentStub: sinon.SinonStubbedInstance<AssignmentManager>;
   let serverPicker: ServerPicker;
@@ -48,7 +48,7 @@ describe("ServerPicker", () => {
 
     // Type assertion needed due to overloading on getServers
     (assignmentStub.getServers as sinon.SinonStub)
-      .withArgs("extension")
+      .withArgs('extension')
       .resolves([]);
   });
 
@@ -56,7 +56,7 @@ describe("ServerPicker", () => {
     sinon.restore();
   });
 
-  describe("prompt", () => {
+  describe('prompt', () => {
     function stubQuickPickForCall(n: number) {
       const stub = buildQuickPickStub();
       vsCodeStub.window.createQuickPick
@@ -75,11 +75,11 @@ describe("ServerPicker", () => {
       return stub;
     }
 
-    it("returns undefined when there are no available servers", async () => {
+    it('returns undefined when there are no available servers', async () => {
       await expect(serverPicker.prompt([])).to.eventually.equal(undefined);
     });
 
-    it("returns undefined when selecting a variant is cancelled", async () => {
+    it('returns undefined when selecting a variant is cancelled', async () => {
       const variantQuickPickStub = stubQuickPickForCall(0);
 
       const variantPickerShown = variantQuickPickStub.nextShow();
@@ -90,7 +90,7 @@ describe("ServerPicker", () => {
       await expect(prompt).to.eventually.equal(undefined);
     });
 
-    it("returns undefined when selecting an accelerator is cancelled", async () => {
+    it('returns undefined when selecting an accelerator is cancelled', async () => {
       const variantQuickPickStub = stubQuickPickForCall(0);
       const acceleratorQuickPickStub = stubQuickPickForCall(1);
 
@@ -99,7 +99,7 @@ describe("ServerPicker", () => {
       await variantPickerShown;
       const acceleratorPickerShown = acceleratorQuickPickStub.nextShow();
       variantQuickPickStub.onDidChangeSelection.yield([
-        { value: Variant.GPU, label: "GPU" },
+        { value: Variant.GPU, label: 'GPU' },
       ]);
       await acceleratorPickerShown;
       acceleratorQuickPickStub.onDidHide.yield();
@@ -107,7 +107,7 @@ describe("ServerPicker", () => {
       await expect(prompt).to.eventually.be.undefined;
     });
 
-    it("returns undefined when selecting an alias is cancelled", async () => {
+    it('returns undefined when selecting an alias is cancelled', async () => {
       const variantQuickPickStub = stubQuickPickForCall(0);
       const acceleratorQuickPickStub = stubQuickPickForCall(1);
       const aliasInputBoxStub = stubInputBoxForCall(0);
@@ -117,12 +117,12 @@ describe("ServerPicker", () => {
       await variantPickerShown;
       const acceleratorPickerShown = acceleratorQuickPickStub.nextShow();
       variantQuickPickStub.onDidChangeSelection.yield([
-        { value: Variant.GPU, label: "GPU" },
+        { value: Variant.GPU, label: 'GPU' },
       ]);
       await acceleratorPickerShown;
       const aliasInputShown = aliasInputBoxStub.nextShow();
       acceleratorQuickPickStub.onDidChangeSelection.yield([
-        { value: "T4", label: "T4" },
+        { value: 'T4', label: 'T4' },
       ]);
       await aliasInputShown;
       aliasInputBoxStub.onDidHide.yield();
@@ -130,7 +130,7 @@ describe("ServerPicker", () => {
       await expect(prompt).to.eventually.be.undefined;
     });
 
-    it("prompting for an accelerated is skipped when there are none", async () => {
+    it('prompting for an accelerated is skipped when there are none', async () => {
       const variantQuickPickStub = stubQuickPickForCall(0);
       const acceleratorQuickPickStub = stubQuickPickForCall(1);
       const aliasInputBoxStub = stubInputBoxForCall(0);
@@ -140,14 +140,14 @@ describe("ServerPicker", () => {
       await variantPickerShown;
       const aliasInputShown = aliasInputBoxStub.nextShow();
       variantQuickPickStub.onDidChangeSelection.yield([
-        { value: Variant.DEFAULT, label: "CPU" },
+        { value: Variant.DEFAULT, label: 'CPU' },
       ]);
 
       await aliasInputShown;
       sinon.assert.notCalled(acceleratorQuickPickStub.show);
     });
 
-    it("returns the server type when all prompts are answered", async () => {
+    it('returns the server type when all prompts are answered', async () => {
       const variantQuickPickStub = stubQuickPickForCall(0);
       const acceleratorQuickPickStub = stubQuickPickForCall(1);
       const aliasInputBoxStub = stubInputBoxForCall(0);
@@ -157,26 +157,26 @@ describe("ServerPicker", () => {
       await variantPickerShown;
       const acceleratorPickerShown = acceleratorQuickPickStub.nextShow();
       variantQuickPickStub.onDidChangeSelection.yield([
-        { value: Variant.GPU, label: "GPU" },
+        { value: Variant.GPU, label: 'GPU' },
       ]);
       await acceleratorPickerShown;
       const aliasInputShown = aliasInputBoxStub.nextShow();
       acceleratorQuickPickStub.onDidChangeSelection.yield([
-        { value: "T4", label: "T4" },
+        { value: 'T4', label: 'T4' },
       ]);
       await aliasInputShown;
-      aliasInputBoxStub.value = "foo";
-      aliasInputBoxStub.onDidChangeValue.yield("foo");
+      aliasInputBoxStub.value = 'foo';
+      aliasInputBoxStub.onDidChangeValue.yield('foo');
       aliasInputBoxStub.onDidAccept.yield();
 
       await expect(prompt).to.eventually.be.deep.equal({
-        label: "foo",
+        label: 'foo',
         variant: Variant.GPU,
-        accelerator: "T4",
+        accelerator: 'T4',
       });
     });
 
-    it("returns a validation error message if over character limit", async () => {
+    it('returns a validation error message if over character limit', async () => {
       const variantQuickPickStub = stubQuickPickForCall(0);
       const aliasInputBoxStub = stubInputBoxForCall(0);
 
@@ -185,16 +185,16 @@ describe("ServerPicker", () => {
       await variantPickerShown;
       const aliasInputShown = aliasInputBoxStub.nextShow();
       variantQuickPickStub.onDidChangeSelection.yield([
-        { value: Variant.DEFAULT, label: "CPU" },
+        { value: Variant.DEFAULT, label: 'CPU' },
       ]);
       await aliasInputShown;
-      aliasInputBoxStub.value = "s".repeat(11);
+      aliasInputBoxStub.value = 's'.repeat(11);
       aliasInputBoxStub.onDidChangeValue.yield(aliasInputBoxStub.value);
 
       expect(aliasInputBoxStub.validationMessage).to.match(/less than 10/);
     });
 
-    it("returns the server type with the placeholder as the label when the alias is omitted", async () => {
+    it('returns the server type with the placeholder as the label when the alias is omitted', async () => {
       const variantQuickPickStub = stubQuickPickForCall(0);
       const acceleratorQuickPickStub = stubQuickPickForCall(1);
       const aliasInputBoxStub = stubInputBoxForCall(0);
@@ -204,27 +204,27 @@ describe("ServerPicker", () => {
       await variantPickerShown;
       const acceleratorPickerShown = acceleratorQuickPickStub.nextShow();
       variantQuickPickStub.onDidChangeSelection.yield([
-        { value: Variant.GPU, label: "GPU" },
+        { value: Variant.GPU, label: 'GPU' },
       ]);
       await acceleratorPickerShown;
       assignmentStub.getDefaultLabel
-        .withArgs(Variant.GPU, "T4")
-        .resolves("Colab GPU T4");
+        .withArgs(Variant.GPU, 'T4')
+        .resolves('Colab GPU T4');
       const aliasInputShown = aliasInputBoxStub.nextShow();
       acceleratorQuickPickStub.onDidChangeSelection.yield([
-        { value: "T4", label: "T4" },
+        { value: 'T4', label: 'T4' },
       ]);
       await aliasInputShown;
       aliasInputBoxStub.onDidAccept.yield();
 
       await expect(prompt).to.eventually.be.deep.equal({
-        label: "Colab GPU T4",
+        label: 'Colab GPU T4',
         variant: Variant.GPU,
-        accelerator: "T4",
+        accelerator: 'T4',
       });
     });
 
-    it("can navigate back when no accelerator was prompted", async () => {
+    it('can navigate back when no accelerator was prompted', async () => {
       const variantQuickPickStub = stubQuickPickForCall(0);
       const aliasInputBoxStub = stubInputBoxForCall(0);
       const variantPickerShown = variantQuickPickStub.nextShow();
@@ -234,7 +234,7 @@ describe("ServerPicker", () => {
       await variantPickerShown;
       const aliasInputShown = aliasInputBoxStub.nextShow();
       variantQuickPickStub.onDidChangeSelection.yield([
-        { value: Variant.DEFAULT, label: "CPU" },
+        { value: Variant.DEFAULT, label: 'CPU' },
       ]);
       await aliasInputShown;
       const secondVariantQuickPickStub = stubQuickPickForCall(1);
@@ -245,7 +245,7 @@ describe("ServerPicker", () => {
       await secondVariantPickerShown;
     });
 
-    it("sets the previously specified value when navigating back", async () => {
+    it('sets the previously specified value when navigating back', async () => {
       const variantQuickPickStub = stubQuickPickForCall(0);
       const acceleratorQuickPickStub = stubQuickPickForCall(1);
       const aliasInputBoxStub = stubInputBoxForCall(0);
@@ -256,16 +256,16 @@ describe("ServerPicker", () => {
       await variantPickerShown;
       const acceleratorPickerShown = acceleratorQuickPickStub.nextShow();
       variantQuickPickStub.onDidChangeSelection.yield([
-        { value: Variant.GPU, label: "GPU" },
+        { value: Variant.GPU, label: 'GPU' },
       ]);
       await acceleratorPickerShown;
       const aliasInputShown = aliasInputBoxStub.nextShow();
       acceleratorQuickPickStub.onDidChangeSelection.yield([
-        { value: "T4", label: "T4" },
+        { value: 'T4', label: 'T4' },
       ]);
       await aliasInputShown;
-      aliasInputBoxStub.value = "foo";
-      aliasInputBoxStub.onDidChangeValue.yield("foo");
+      aliasInputBoxStub.value = 'foo';
+      aliasInputBoxStub.onDidChangeValue.yield('foo');
       // Navigate back.
       const secondAcceleratorQuickPickStub = stubQuickPickForCall(2);
       const secondVariantQuickPickStub = stubQuickPickForCall(3);
@@ -276,7 +276,7 @@ describe("ServerPicker", () => {
       );
       await secondAcceleratorPickerShown;
       expect(secondAcceleratorQuickPickStub.activeItems).to.be.deep.equal([
-        { value: "T4", label: "T4" },
+        { value: 'T4', label: 'T4' },
       ]);
       const secondVariantPickerShown = secondVariantQuickPickStub.nextShow();
       secondAcceleratorQuickPickStub.onDidTriggerButton.yield(
@@ -284,11 +284,11 @@ describe("ServerPicker", () => {
       );
       await secondVariantPickerShown;
       expect(secondVariantQuickPickStub.activeItems).to.be.deep.equal([
-        { value: Variant.GPU, label: "GPU" },
+        { value: Variant.GPU, label: 'GPU' },
       ]);
     });
 
-    it("sets the right step", async () => {
+    it('sets the right step', async () => {
       const variantQuickPickStub = stubQuickPickForCall(0);
       const aliasInputBoxStub = stubInputBoxForCall(0);
       const variantPickerShown = variantQuickPickStub.nextShow();
@@ -301,7 +301,7 @@ describe("ServerPicker", () => {
       expect(variantQuickPickStub.totalSteps).to.equal(2);
 
       variantQuickPickStub.onDidChangeSelection.yield([
-        { value: Variant.DEFAULT, label: "CPU" },
+        { value: Variant.DEFAULT, label: 'CPU' },
       ]);
 
       await aliasInputShown;
@@ -309,7 +309,7 @@ describe("ServerPicker", () => {
       expect(aliasInputBoxStub.totalSteps).to.equal(2);
     });
 
-    it("sets the right step when accelerators are available", async () => {
+    it('sets the right step when accelerators are available', async () => {
       const variantQuickPickStub = stubQuickPickForCall(0);
       const acceleratorQuickPickStub = stubQuickPickForCall(1);
       const aliasInputBoxStub = stubInputBoxForCall(0);
@@ -324,14 +324,14 @@ describe("ServerPicker", () => {
       expect(variantQuickPickStub.totalSteps).to.equal(2);
 
       variantQuickPickStub.onDidChangeSelection.yield([
-        { value: Variant.GPU, label: "GPU" },
+        { value: Variant.GPU, label: 'GPU' },
       ]);
       await acceleratorPickerShown;
       expect(acceleratorQuickPickStub.step).to.equal(2);
       expect(acceleratorQuickPickStub.totalSteps).to.equal(3);
 
       acceleratorQuickPickStub.onDidChangeSelection.yield([
-        { value: "T4", label: "T4" },
+        { value: 'T4', label: 'T4' },
       ]);
       await aliasInputShown;
       expect(aliasInputBoxStub.step).to.equal(3);

--- a/src/common/async.ts
+++ b/src/common/async.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { log } from "./logging";
+import { log } from './logging';
 
 /**
  * Run an async worker task, canceling in-flight work with an
@@ -35,7 +35,7 @@ export class LatestCancelable<T extends unknown[]> {
     } catch (err: unknown) {
       if (
         abort.signal.aborted ||
-        (err instanceof Error && err.name === "AbortError")
+        (err instanceof Error && err.name === 'AbortError')
       ) {
         // Throwing an abort is expected.
       } else {

--- a/src/common/async.unit.test.ts
+++ b/src/common/async.unit.test.ts
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import sinon from "sinon";
-import { Deferred } from "../test/helpers/async";
-import { ColabLogWatcher } from "../test/helpers/logging";
-import { newVsCodeStub } from "../test/helpers/vscode";
-import { LatestCancelable } from "./async";
-import { LogLevel } from "./logging";
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { Deferred } from '../test/helpers/async';
+import { ColabLogWatcher } from '../test/helpers/logging';
+import { newVsCodeStub } from '../test/helpers/vscode';
+import { LatestCancelable } from './async';
+import { LogLevel } from './logging';
 
-describe("LatestCancelable", () => {
+describe('LatestCancelable', () => {
   let logs: ColabLogWatcher;
   let worker: sinon.SinonStub<[...unknown[], AbortSignal], Promise<void>>;
   let cancelable: LatestCancelable<unknown[]>;
@@ -20,21 +20,21 @@ describe("LatestCancelable", () => {
   beforeEach(() => {
     logs = new ColabLogWatcher(newVsCodeStub(), LogLevel.Trace);
     worker = sinon.stub();
-    cancelable = new LatestCancelable("test-worker", worker);
+    cancelable = new LatestCancelable('test-worker', worker);
   });
 
   afterEach(() => {
     logs.dispose();
   });
 
-  it("should run the worker", async () => {
+  it('should run the worker', async () => {
     worker.resolves();
 
     await cancelable.run();
     sinon.assert.calledOnce(worker);
   });
 
-  it("should cancel previous worker and not affect the running state of a new task", async () => {
+  it('should cancel previous worker and not affect the running state of a new task', async () => {
     const firstRunStarted = new Deferred<void>();
     const firstRunCompleter = new Deferred<void>();
     const secondRunStarted = new Deferred<void>();
@@ -46,7 +46,7 @@ describe("LatestCancelable", () => {
         firstRunStarted.resolve();
         const signal = args.pop() as AbortSignal;
         await new Promise<void>((resolve) => {
-          signal.addEventListener("abort", () => {
+          signal.addEventListener('abort', () => {
             resolve();
           });
         });
@@ -80,19 +80,19 @@ describe("LatestCancelable", () => {
     expect(firstSignal.aborted).to.be.true;
   });
 
-  it("should be a no-op when cancelling and no task is running", () => {
+  it('should be a no-op when cancelling and no task is running', () => {
     expect(() => {
       cancelable.cancel();
     }).to.not.throw();
   });
 
-  it("should forward arguments to the worker", async () => {
+  it('should forward arguments to the worker', async () => {
     worker.resolves();
-    await cancelable.run("foo", 123);
-    sinon.assert.calledOnceWithExactly(worker, "foo", 123, sinon.match.any);
+    await cancelable.run('foo', 123);
+    sinon.assert.calledOnceWithExactly(worker, 'foo', 123, sinon.match.any);
   });
 
-  it("should report running state correctly", async () => {
+  it('should report running state correctly', async () => {
     const d = new Deferred<void>();
     const workerStarted = new Deferred<void>();
     worker.callsFake(async () => {
@@ -113,13 +113,13 @@ describe("LatestCancelable", () => {
     expect(cancelable.isRunning()).to.be.false;
   });
 
-  it("should cancel in-flight work", async () => {
+  it('should cancel in-flight work', async () => {
     const d = new Deferred<void>();
     const workerStarted = new Deferred<void>();
     worker.callsFake(async (...args) => {
       workerStarted.resolve();
       const signal = args.pop() as AbortSignal;
-      signal.addEventListener("abort", () => {
+      signal.addEventListener('abort', () => {
         d.resolve();
       });
       await d.promise;
@@ -139,19 +139,19 @@ describe("LatestCancelable", () => {
     expect(cancelable.isRunning()).to.be.false;
   });
 
-  it("should handle errors gracefully", async () => {
-    worker.rejects(new Error("🤮"));
+  it('should handle errors gracefully', async () => {
+    worker.rejects(new Error('🤮'));
     await cancelable.run();
     expect(logs.output).to.match(/LatestCancelable worker error/);
   });
 
-  it("should ignore abort errors", async () => {
+  it('should ignore abort errors', async () => {
     worker.callsFake((...args) => {
       const signal = args.pop() as AbortSignal;
       return new Promise((_resolve, reject) => {
-        const err = new Error("AbortError");
-        err.name = "AbortError";
-        signal.addEventListener("abort", () => {
+        const err = new Error('AbortError');
+        err.name = 'AbortError';
+        signal.addEventListener('abort', () => {
           reject(err);
         });
       });

--- a/src/common/logging/console.ts
+++ b/src/common/logging/console.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { buildTimestampLevelPrefix } from "./util";
-import { ActionableLogLevel, Logger, LogLevel } from ".";
+import { buildTimestampLevelPrefix } from './util';
+import { ActionableLogLevel, Logger, LogLevel } from '.';
 
 /**
  * A logger that emits to the global {@link console}.

--- a/src/common/logging/decorators.ts
+++ b/src/common/logging/decorators.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getLevel, log, LogLevel } from ".";
+import { getLevel, log, LogLevel } from '.';
 
 /**
  * A decorator that traces the entry and exit (or error) of a method.
@@ -17,7 +17,7 @@ export function traceMethod(
   const originalMethod: unknown = descriptor.value;
 
   // Ensure the property is a function.
-  if (typeof originalMethod !== "function") {
+  if (typeof originalMethod !== 'function') {
     return descriptor;
   }
 
@@ -35,7 +35,7 @@ export function traceMethod(
     try {
       log.trace(`${targetPrefix} called with`, ...args);
     } catch (err: unknown) {
-      log.trace("Error in trace decorator (entry)", err);
+      log.trace('Error in trace decorator (entry)', err);
     }
 
     let result: unknown;
@@ -46,7 +46,7 @@ export function traceMethod(
       try {
         log.trace(`${targetPrefix} threw error (sync)`, error);
       } catch (e) {
-        log.trace("Error in trace decorator (sync error)", e);
+        log.trace('Error in trace decorator (sync error)', e);
       }
       // Re-throw the original error.
       throw error;
@@ -60,7 +60,7 @@ export function traceMethod(
           try {
             log.trace(`${targetPrefix} Promise resolved with`, resolvedValue);
           } catch (e) {
-            log.trace("Error in trace decorator (resolve)", e);
+            log.trace('Error in trace decorator (resolve)', e);
           }
           return resolvedValue;
         },
@@ -68,7 +68,7 @@ export function traceMethod(
           try {
             log.trace(`${targetPrefix} Promise rejected with`, error);
           } catch (e) {
-            log.trace("Error in trace decorator (reject)", e);
+            log.trace('Error in trace decorator (reject)', e);
           }
           throw error;
         },
@@ -79,7 +79,7 @@ export function traceMethod(
     try {
       log.trace(`${targetPrefix} returned (sync)`, result);
     } catch (e) {
-      log.trace("Error in trace decorator (sync return)", e);
+      log.trace('Error in trace decorator (sync return)', e);
     }
     return result;
   };
@@ -93,7 +93,7 @@ export function traceMethod(
 function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return (
     value !== null &&
-    (typeof value === "object" || typeof value === "function") &&
-    typeof (value as { then?: unknown }).then === "function"
+    (typeof value === 'object' || typeof value === 'function') &&
+    typeof (value as { then?: unknown }).then === 'function'
   );
 }

--- a/src/common/logging/decorators.unit.test.ts
+++ b/src/common/logging/decorators.unit.test.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import { ColabLogWatcher } from "../../test/helpers/logging";
-import { newVsCodeStub } from "../../test/helpers/vscode";
-import { traceMethod } from "./decorators";
-import { LogLevel } from ".";
+import { expect } from 'chai';
+import { ColabLogWatcher } from '../../test/helpers/logging';
+import { newVsCodeStub } from '../../test/helpers/vscode';
+import { traceMethod } from './decorators';
+import { LogLevel } from '.';
 
 // A simple class to test the method decorator.
 class TestClass {
@@ -26,16 +26,16 @@ class TestClass {
 
   @traceMethod
   syncErrorMethod(): void {
-    throw new Error("Synchronous error");
+    throw new Error('Synchronous error');
   }
 
   @traceMethod
   async asyncErrorMethod(): Promise<void> {
-    return Promise.reject(new Error("Asynchronous error"));
+    return Promise.reject(new Error('Asynchronous error'));
   }
 }
 
-describe("traceMethod", () => {
+describe('traceMethod', () => {
   let logs: ColabLogWatcher;
   let test: TestClass;
 
@@ -48,7 +48,7 @@ describe("traceMethod", () => {
     logs.dispose();
   });
 
-  it("logs entry and exit of synchronous method", () => {
+  it('logs entry and exit of synchronous method', () => {
     test.syncMethod(2, 3);
 
     const output = logs.output;
@@ -56,23 +56,23 @@ describe("traceMethod", () => {
     expect(output).to.match(/TestClass\.syncMethod returned \(sync\)\s+5/);
   });
 
-  it("logs entry and exit of asynchronous method", async () => {
+  it('logs entry and exit of asynchronous method', async () => {
     await test.asyncMethod(4, 5);
 
     const output = logs.output;
     expect(output).to.match(/TestClass\.asyncMethod called with\s+4\s+5/);
-    expect(output).to.include("TestClass.asyncMethod returned a Promise");
+    expect(output).to.include('TestClass.asyncMethod returned a Promise');
     expect(output).to.match(
       /TestClass\.asyncMethod Promise resolved with\s+20/,
     );
   });
 
-  it("logs result of asynchronous method once resolved", async () => {
+  it('logs result of asynchronous method once resolved', async () => {
     const asyncMethod = test.asyncMethod(4, 5);
 
     const output = logs.output;
     expect(output).to.match(/TestClass\.asyncMethod called with\s+4\s+5/);
-    expect(output).to.include("TestClass.asyncMethod returned a Promise");
+    expect(output).to.include('TestClass.asyncMethod returned a Promise');
     expect(output).not.to.match(/resolved/);
 
     await asyncMethod;
@@ -81,10 +81,10 @@ describe("traceMethod", () => {
     );
   });
 
-  it("logs entry and error of synchronous method that throws", () => {
+  it('logs entry and error of synchronous method that throws', () => {
     expect(() => {
       test.syncErrorMethod();
-    }).to.throw("Synchronous error");
+    }).to.throw('Synchronous error');
 
     const output = logs.output;
     expect(output).to.match(/TestClass\.syncErrorMethod called with/);
@@ -93,14 +93,14 @@ describe("traceMethod", () => {
     );
   });
 
-  it("logs entry and error of asynchronous method once rejected", async () => {
+  it('logs entry and error of asynchronous method once rejected', async () => {
     await expect(test.asyncErrorMethod()).to.be.rejectedWith(
-      "Asynchronous error",
+      'Asynchronous error',
     );
 
     const output = logs.output;
     expect(output).to.match(/TestClass\.asyncErrorMethod called with/);
-    expect(output).to.include("TestClass.asyncErrorMethod returned a Promise");
+    expect(output).to.include('TestClass.asyncErrorMethod returned a Promise');
     expect(output).to.match(
       /TestClass\.asyncErrorMethod Promise rejected with\s+Error: Asynchronous error/,
     );

--- a/src/common/logging/index.ts
+++ b/src/common/logging/index.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from "vscode";
-import { Disposable, ExtensionMode } from "vscode";
-import { ConsoleLogger } from "./console";
-import { OutputChannelLogger } from "./output-channel";
+import * as vscode from 'vscode';
+import { Disposable, ExtensionMode } from 'vscode';
+import { ConsoleLogger } from './console';
+import { OutputChannelLogger } from './output-channel';
 
 /**
  * Supports logging a message at varying severity levels.
@@ -53,18 +53,18 @@ export function initializeLogger(
   mode: ExtensionMode,
 ): Disposable {
   if (loggers.length > 0) {
-    throw new Error("Loggers have already been initialized.");
+    throw new Error('Loggers have already been initialized.');
   }
 
   level = getConfiguredLogLevel(vs);
   const configListener = vs.workspace.onDidChangeConfiguration((e) => {
-    if (e.affectsConfiguration("colab.logging")) {
+    if (e.affectsConfiguration('colab.logging')) {
       level = getConfiguredLogLevel(vs);
     }
   });
 
   // Create the output channel once.
-  const outputChannel = vs.window.createOutputChannel("Colab");
+  const outputChannel = vs.window.createOutputChannel('Colab');
   loggers.push(new OutputChannelLogger(outputChannel));
 
   if (mode === vs.ExtensionMode.Development) {
@@ -95,19 +95,19 @@ export function getLevel(): LogLevel {
  */
 export const log: Logger = {
   error: (msg: string, ...args: unknown[]) => {
-    doLog(LogLevel.Error, "error", msg, ...args);
+    doLog(LogLevel.Error, 'error', msg, ...args);
   },
   warn: (msg: string, ...args: unknown[]) => {
-    doLog(LogLevel.Warning, "warn", msg, ...args);
+    doLog(LogLevel.Warning, 'warn', msg, ...args);
   },
   info: (msg: string, ...args: unknown[]) => {
-    doLog(LogLevel.Info, "info", msg, ...args);
+    doLog(LogLevel.Info, 'info', msg, ...args);
   },
   debug: (msg: string, ...args: unknown[]) => {
-    doLog(LogLevel.Debug, "debug", msg, ...args);
+    doLog(LogLevel.Debug, 'debug', msg, ...args);
   },
   trace: (msg: string, ...args: unknown[]) => {
-    doLog(LogLevel.Trace, "trace", msg, ...args);
+    doLog(LogLevel.Trace, 'trace', msg, ...args);
   },
 };
 
@@ -142,8 +142,8 @@ const LOG_CONFIG_TO_LEVEL: Record<
 
 function getConfiguredLogLevel(vs: typeof vscode): LogLevel {
   const configLevel = vs.workspace
-    .getConfiguration("colab.logging")
-    .get<Lowercase<keyof typeof LogLevel>>("level", "info");
+    .getConfiguration('colab.logging')
+    .get<Lowercase<keyof typeof LogLevel>>('level', 'info');
 
   return LOG_CONFIG_TO_LEVEL[configLevel];
 }

--- a/src/common/logging/logging.unit.test.ts
+++ b/src/common/logging/logging.unit.test.ts
@@ -4,29 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import sinon, { SinonFakeTimers, SinonStubbedInstance } from "sinon";
+import { expect } from 'chai';
+import sinon, { SinonFakeTimers, SinonStubbedInstance } from 'sinon';
 import {
   ConfigurationChangeEvent,
   WorkspaceConfiguration,
   Disposable,
   ConfigurationScope,
-} from "vscode";
-import { TestEventEmitter } from "../../test/helpers/events";
-import { FakeLogOutputChannel } from "../../test/helpers/output-channel";
-import { newVsCodeStub, VsCodeStub } from "../../test/helpers/vscode";
-import { initializeLogger, log, LogLevel } from ".";
+} from 'vscode';
+import { TestEventEmitter } from '../../test/helpers/events';
+import { FakeLogOutputChannel } from '../../test/helpers/output-channel';
+import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
+import { initializeLogger, log, LogLevel } from '.';
 
-const TEST_ISO_TIME = "1994-08-24T14:34:00.010Z";
+const TEST_ISO_TIME = '1994-08-24T14:34:00.010Z';
 const TEST_DATE = new Date(TEST_ISO_TIME);
 
-describe("Logging Module", () => {
+describe('Logging Module', () => {
   let fakeClock: SinonFakeTimers;
   let consoleStub: SinonStubbedInstance<Console>;
   let logSink: FakeLogOutputChannel;
   let configChangeEmitter: TestEventEmitter<ConfigurationChangeEvent>;
   let logging: Disposable | undefined;
-  let logLevel: Lowercase<keyof typeof LogLevel> = "info";
+  let logLevel: Lowercase<keyof typeof LogLevel> = 'info';
   let vs: VsCodeStub;
 
   beforeEach(() => {
@@ -34,9 +34,9 @@ describe("Logging Module", () => {
     vs = newVsCodeStub();
     logSink = new FakeLogOutputChannel();
     (vs.window.createOutputChannel as sinon.SinonStub).returns(logSink);
-    vs.workspace.getConfiguration.withArgs("colab.logging").returns({
+    vs.workspace.getConfiguration.withArgs('colab.logging').returns({
       get: () => logLevel,
-    } as Pick<WorkspaceConfiguration, "get"> as WorkspaceConfiguration);
+    } as Pick<WorkspaceConfiguration, 'get'> as WorkspaceConfiguration);
     consoleStub = sinon.stub(console);
     configChangeEmitter = new TestEventEmitter<ConfigurationChangeEvent>();
     vs.workspace.onDidChangeConfiguration.callsFake(configChangeEmitter.event);
@@ -48,8 +48,8 @@ describe("Logging Module", () => {
     sinon.restore();
   });
 
-  describe("lifecycle", () => {
-    it("throws if doubly initialized", () => {
+  describe('lifecycle', () => {
+    it('throws if doubly initialized', () => {
       logging = initializeLogger(vs.asVsCode(), vs.ExtensionMode.Production);
 
       expect(() =>
@@ -57,13 +57,13 @@ describe("Logging Module", () => {
       ).to.throw(/already/);
     });
 
-    it("no-ops silently if used before being initialized", () => {
+    it('no-ops silently if used before being initialized', () => {
       expect(() => {
-        log.info("test");
+        log.info('test');
       }).not.to.throw();
     });
 
-    it("disposes config listener and output channel when disposed", () => {
+    it('disposes config listener and output channel when disposed', () => {
       logging = initializeLogger(vs.asVsCode(), vs.ExtensionMode.Production);
 
       logging.dispose();
@@ -73,32 +73,32 @@ describe("Logging Module", () => {
     });
   });
 
-  describe("in dev mode", () => {
+  describe('in dev mode', () => {
     beforeEach(() => {
       logging = initializeLogger(vs.asVsCode(), vs.ExtensionMode.Development);
     });
 
-    it("logs to console", () => {
-      log.info("test");
+    it('logs to console', () => {
+      log.info('test');
 
       sinon.assert.calledOnce(consoleStub.info);
     });
 
-    it("focuses output channel", () => {
+    it('focuses output channel', () => {
       sinon.assert.calledOnceWithMatch(logSink.show);
     });
   });
 
-  describe("logs", () => {
-    it("each of the log levels", () => {
-      logLevel = "trace";
+  describe('logs', () => {
+    it('each of the log levels', () => {
+      logLevel = 'trace';
       logging = initializeLogger(vs.asVsCode(), vs.ExtensionMode.Production);
 
-      log.error("error");
-      log.warn("warn");
-      log.info("info");
-      log.debug("debug");
-      log.trace("trace");
+      log.error('error');
+      log.warn('warn');
+      log.info('info');
+      log.debug('debug');
+      log.trace('trace');
 
       expect(logSink.content).to.equal(
         `
@@ -111,15 +111,15 @@ describe("Logging Module", () => {
       );
     });
 
-    it("only logs messages at or above the configured level", () => {
-      logLevel = "warning";
+    it('only logs messages at or above the configured level', () => {
+      logLevel = 'warning';
       logging = initializeLogger(vs.asVsCode(), vs.ExtensionMode.Production);
 
-      log.error("error");
-      log.warn("warn");
-      log.info("info");
-      log.debug("debug");
-      log.trace("trace");
+      log.error('error');
+      log.warn('warn');
+      log.info('info');
+      log.debug('debug');
+      log.trace('trace');
 
       expect(logSink.content).to.equal(
         `
@@ -129,19 +129,19 @@ describe("Logging Module", () => {
       );
     });
 
-    it("respects logging level configuration changes", () => {
-      logLevel = "info";
+    it('respects logging level configuration changes', () => {
+      logLevel = 'info';
       logging = initializeLogger(vs.asVsCode(), vs.ExtensionMode.Production);
-      log.info("first info");
+      log.info('first info');
 
-      logLevel = "error";
+      logLevel = 'error';
 
       const s: sinon.SinonStub<[string, ConfigurationScope], boolean> =
         sinon.stub();
-      s.withArgs("colab.logging").returns(true);
+      s.withArgs('colab.logging').returns(true);
       configChangeEmitter.fire({ affectsConfiguration: s });
-      log.info("second info");
-      log.error("first error");
+      log.info('second info');
+      log.error('first error');
 
       expect(logSink.content).to.equal(
         `

--- a/src/common/logging/output-channel.ts
+++ b/src/common/logging/output-channel.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OutputChannel } from "vscode";
-import { buildTimestampLevelPrefix } from "./util";
-import { ActionableLogLevel, Logger, LogLevel } from ".";
+import { OutputChannel } from 'vscode';
+import { buildTimestampLevelPrefix } from './util';
+import { ActionableLogLevel, Logger, LogLevel } from '.';
 
 /**
  * A logger that appends to the provided VS Code {@link OutputChannel}.
@@ -48,7 +48,7 @@ function format(
   args: unknown[],
 ): string {
   const prefix = buildTimestampLevelPrefix(level);
-  const padding = " ".repeat(prefix.length + 1);
+  const padding = ' '.repeat(prefix.length + 1);
 
   let res = `${prefix} ${message}`;
 
@@ -57,18 +57,18 @@ function format(
 
     if (arg instanceof Error) {
       argsStr = arg.stack ?? arg.message;
-    } else if (typeof arg === "object" && arg !== null) {
+    } else if (typeof arg === 'object' && arg !== null) {
       try {
         argsStr = JSON.stringify(arg, null, 2);
       } catch (_: unknown) {
-        argsStr = "[Unserializable Object]";
+        argsStr = '[Unserializable Object]';
       }
     } else {
       // Simply convert primitives to a string.
       argsStr = String(arg);
     }
 
-    res += `\n${padding}${argsStr.split("\n").join(`\n${padding}`)}`;
+    res += `\n${padding}${argsStr.split('\n').join(`\n${padding}`)}`;
   }
 
   return res;

--- a/src/common/logging/util.ts
+++ b/src/common/logging/util.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ActionableLogLevel, LogLevel } from ".";
+import { ActionableLogLevel, LogLevel } from '.';
 
 /**
  * Builds a log prefix containing a timestamp and log level.
@@ -20,11 +20,11 @@ export function buildTimestampLevelPrefix(level: ActionableLogLevel): string {
 }
 
 const LOG_LEVEL_STRING_MAP: Record<ActionableLogLevel, string> = {
-  [LogLevel.Trace]: "Trace",
-  [LogLevel.Debug]: "Debug",
-  [LogLevel.Info]: "Info",
-  [LogLevel.Warning]: "Warning",
-  [LogLevel.Error]: "Error",
+  [LogLevel.Trace]: 'Trace',
+  [LogLevel.Debug]: 'Debug',
+  [LogLevel.Info]: 'Info',
+  [LogLevel.Warning]: 'Warning',
+  [LogLevel.Error]: 'Error',
 };
 
 /**

--- a/src/common/loopback-server.ts
+++ b/src/common/loopback-server.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as http from "http";
-import vscode from "vscode";
-import { log } from "./logging";
+import * as http from 'http';
+import vscode from 'vscode';
+import { log } from './logging';
 
-const FAILED_TO_GET_PORT = new Error("Failed to acquire server port");
+const FAILED_TO_GET_PORT = new Error('Failed to acquire server port');
 
 /**
  * Handles the various events and requests for the loopback server.
@@ -53,15 +53,15 @@ export class LoopbackServer implements vscode.Disposable {
 
   constructor(private readonly handler: LoopbackHandler) {
     this.server = http.createServer();
-    this.server.on("request", (req, res) => {
+    this.server.on('request', (req, res) => {
       handler.handleRequest(req, res);
     });
-    this.server.on("error", (err) => {
+    this.server.on('error', (err) => {
       if (this.handler.handleError) {
         this.handler.handleError(err);
       }
     });
-    this.server.on("close", () => {
+    this.server.on('close', () => {
       if (this.handler.handleClose) {
         this.handler.handleClose();
       }
@@ -77,7 +77,7 @@ export class LoopbackServer implements vscode.Disposable {
     }
     this.server.close((err) => {
       if (err) {
-        log.error("Issue closing loopback server", err);
+        log.error('Issue closing loopback server', err);
       }
     });
   }
@@ -91,18 +91,18 @@ export class LoopbackServer implements vscode.Disposable {
    */
   async start(): Promise<number> {
     if (this.isDisposed) {
-      throw new Error("Local server has already been disposed");
+      throw new Error('Local server has already been disposed');
     }
     if (this.listen) {
       return this.listen;
     }
     this.listen = new Promise<number>((resolve, reject) => {
-      this.server.listen(0, "127.0.0.1", () => {
+      this.server.listen(0, '127.0.0.1', () => {
         const address = this.server.address();
         // A string is only ever returned when listening on a pipe or Unix
         // domain socket, which isn't the case here. Regardless, the check is
         // included to safely handle the address as an AddressInfo type.
-        if (address && typeof address !== "string") {
+        if (address && typeof address !== 'string') {
           resolve(address.port);
         } else {
           reject(FAILED_TO_GET_PORT);

--- a/src/common/loopback-server.unit.test.ts
+++ b/src/common/loopback-server.unit.test.ts
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import http from "http";
-import { AddressInfo } from "net";
-import { assert, expect } from "chai";
-import * as sinon from "sinon";
-import { createHttpServerMock } from "../test/helpers/http-server";
-import { LoopbackHandler, LoopbackServer } from "./loopback-server";
+import http from 'http';
+import { AddressInfo } from 'net';
+import { assert, expect } from 'chai';
+import * as sinon from 'sinon';
+import { createHttpServerMock } from '../test/helpers/http-server';
+import { LoopbackHandler, LoopbackServer } from './loopback-server';
 
 const DEFAULT_ADDRESS: AddressInfo = {
-  address: "127.0.0.1",
-  family: "IPv4",
+  address: '127.0.0.1',
+  family: 'IPv4',
   port: 12345,
 };
 
-describe("LoopbackServer", () => {
+describe('LoopbackServer', () => {
   let handler: sinon.SinonStubbedInstance<LoopbackHandler>;
   let server: LoopbackServer;
   let fakeServer: sinon.SinonStubbedInstance<http.Server>;
@@ -29,7 +29,7 @@ describe("LoopbackServer", () => {
       handleClose: sinon.stub(),
     };
     fakeServer = createHttpServerMock(DEFAULT_ADDRESS);
-    sinon.stub(http, "createServer").returns(fakeServer);
+    sinon.stub(http, 'createServer').returns(fakeServer);
 
     server = new LoopbackServer(handler);
   });
@@ -39,27 +39,27 @@ describe("LoopbackServer", () => {
     server.dispose();
   });
 
-  describe("dispose", () => {
-    it("does nothing when no server is running", () => {
+  describe('dispose', () => {
+    it('does nothing when no server is running', () => {
       // Required since `listening` is a readonly getter.
-      Object.defineProperty(fakeServer, "listening", { get: () => false });
+      Object.defineProperty(fakeServer, 'listening', { get: () => false });
       server.dispose();
 
       sinon.assert.notCalled(fakeServer.close);
     });
 
-    describe("when a server is listening", () => {
+    describe('when a server is listening', () => {
       beforeEach(async () => {
         await server.start();
       });
 
-      it("closes the server", () => {
+      it('closes the server', () => {
         server.dispose();
 
         sinon.assert.calledOnce(fakeServer.close);
       });
 
-      it("does nothing if called more than once", () => {
+      it('does nothing if called more than once', () => {
         server.dispose();
         server.dispose();
 
@@ -68,28 +68,28 @@ describe("LoopbackServer", () => {
     });
   });
 
-  describe("start", () => {
-    it("rejects when a port cannot be obtained", async () => {
+  describe('start', () => {
+    it('rejects when a port cannot be obtained', async () => {
       fakeServer.address.returns(null);
 
       await expect(server.start()).to.be.rejectedWith(
-        "Failed to acquire server port",
+        'Failed to acquire server port',
       );
     });
 
     it("rejects if a proxied address' port cannot be parsed", async () => {
-      fakeServer.address.returns("not-a-port");
+      fakeServer.address.returns('not-a-port');
 
       await expect(server.start()).to.be.rejectedWith(
-        "Failed to acquire server port",
+        'Failed to acquire server port',
       );
     });
 
-    it("resolves a port number when started successfully", async () => {
+    it('resolves a port number when started successfully', async () => {
       await expect(server.start()).to.eventually.equal(DEFAULT_ADDRESS.port);
     });
 
-    it("resolves the existing promise if start is called more than once", async () => {
+    it('resolves the existing promise if start is called more than once', async () => {
       const firstStart = server.start();
       const secondStart = server.start();
 
@@ -102,31 +102,31 @@ describe("LoopbackServer", () => {
     });
   });
 
-  describe("server started", () => {
+  describe('server started', () => {
     beforeEach(async () => {
       await server.start();
     });
 
-    it("invokes the handler for incoming requests", () => {
+    it('invokes the handler for incoming requests', () => {
       const req = {} as http.IncomingMessage;
       const res = {} as http.ServerResponse;
 
-      fakeServer.emit("request", req, res);
+      fakeServer.emit('request', req, res);
 
       sinon.assert.calledOnceWithExactly(handler.handleRequest, req, res);
     });
 
-    it("invokes the handler on error", () => {
-      const err = new Error("test error");
+    it('invokes the handler on error', () => {
+      const err = new Error('test error');
 
-      fakeServer.emit("error", err);
+      fakeServer.emit('error', err);
 
       assert.isDefined(handler.handleError);
       sinon.assert.calledOnceWithExactly(handler.handleError, err);
     });
 
-    it("invokes the handler on close", () => {
-      fakeServer.emit("close");
+    it('invokes the handler on close', () => {
+      fakeServer.emit('close');
 
       assert.isDefined(handler.handleClose);
       sinon.assert.calledOnce(handler.handleClose);

--- a/src/common/multi-step-quickpick.ts
+++ b/src/common/multi-step-quickpick.ts
@@ -10,17 +10,17 @@ import {
   QuickInput,
   Event,
   QuickInputButton,
-} from "vscode";
-import vscode from "vscode";
+} from 'vscode';
+import vscode from 'vscode';
 
 /**
  * Represents an action that can be taken during an input flow.
  */
 export class InputFlowAction extends Error {
   /** Navigate back in the input flow. */
-  static back = new InputFlowAction("back");
+  static back = new InputFlowAction('back');
   /** Cancel the input flow. */
-  static cancel = new InputFlowAction("cancel");
+  static cancel = new InputFlowAction('cancel');
 }
 
 /**
@@ -203,7 +203,7 @@ export class MultiStepInput {
         input.title = opts.title;
         input.step = opts.step;
         input.totalSteps = opts.totalSteps;
-        input.value = opts.value || "";
+        input.value = opts.value || '';
         input.password = opts.password ?? false;
         input.prompt = opts.prompt;
         input.placeholder = opts.placeholder;

--- a/src/common/multi-step-quickpick.unit.test.ts
+++ b/src/common/multi-step-quickpick.unit.test.ts
@@ -4,25 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import * as sinon from "sinon";
-import { Disposable, InputBox, QuickPick, QuickPickItem } from "vscode";
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { Disposable, InputBox, QuickPick, QuickPickItem } from 'vscode';
 import {
   buildInputBoxStub,
   buildQuickPickStub,
   InputBoxStub,
   QuickPickStub,
-} from "../test/helpers/quick-input";
-import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
+} from '../test/helpers/quick-input';
+import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
 import {
   InputBoxOptions,
   InputFlowAction,
   InputStep,
   MultiStepInput,
   QuickPickOptions,
-} from "./multi-step-quickpick";
+} from './multi-step-quickpick';
 
-describe("MultiStepQuickPick", () => {
+describe('MultiStepQuickPick', () => {
   let vsCodeStub: VsCodeStub;
 
   beforeEach(() => {
@@ -33,7 +33,7 @@ describe("MultiStepQuickPick", () => {
     sinon.restore();
   });
 
-  describe("run", () => {
+  describe('run', () => {
     function inputStepStub(): sinon.SinonStub<
       [input: MultiStepInput],
       Thenable<InputStep | undefined>
@@ -41,7 +41,7 @@ describe("MultiStepQuickPick", () => {
       return sinon.stub();
     }
 
-    it("runs a single step", async () => {
+    it('runs a single step', async () => {
       const start = inputStepStub().returns(Promise.resolve(undefined));
 
       await expect(MultiStepInput.run(vsCodeStub.asVsCode(), start)).to
@@ -50,7 +50,7 @@ describe("MultiStepQuickPick", () => {
       sinon.assert.calledOnce(start);
     });
 
-    it("runs multiple steps", async () => {
+    it('runs multiple steps', async () => {
       const second = inputStepStub().returns(Promise.resolve(undefined));
       const first = inputStepStub().returns(Promise.resolve(second));
 
@@ -72,7 +72,7 @@ describe("MultiStepQuickPick", () => {
       sinon.assert.calledOnce(first);
     });
 
-    it("goes back a step when one past the first", async () => {
+    it('goes back a step when one past the first', async () => {
       // First > Second > (back) First > Second > Done.
       const second = inputStepStub();
       second.onFirstCall().throws(InputFlowAction.back);
@@ -85,7 +85,7 @@ describe("MultiStepQuickPick", () => {
       sinon.assert.callOrder(first, second, first, second);
     });
 
-    it("goes back a step when multiple past the first", async () => {
+    it('goes back a step when multiple past the first', async () => {
       // First > Second > Third (back) Second > Third > Done.
       const third = inputStepStub();
       third.onFirstCall().throws(InputFlowAction.back);
@@ -113,12 +113,12 @@ describe("MultiStepQuickPick", () => {
     });
   });
 
-  describe("showQuickPick", () => {
+  describe('showQuickPick', () => {
     const ONLY_FOO: QuickPickOptions<QuickPickItem> = {
-      title: "Select foo",
+      title: 'Select foo',
       step: 1,
       totalSteps: 1,
-      items: [{ label: "foo" }],
+      items: [{ label: 'foo' }],
     };
     let onDidTriggerButtonDisposeStub: sinon.SinonStubbedInstance<Disposable>;
     let onDidHideDisposeStub: sinon.SinonStubbedInstance<Disposable>;
@@ -182,7 +182,7 @@ describe("MultiStepQuickPick", () => {
       sinon.assert.calledOnce(quickPickStub.dispose);
     });
 
-    it("resolves the selected item", async () => {
+    it('resolves the selected item', async () => {
       let selected: QuickPickItem | undefined;
       const step: InputStep = async (input: MultiStepInput) => {
         selected = await input.showQuickPick(ONLY_FOO);
@@ -193,21 +193,21 @@ describe("MultiStepQuickPick", () => {
       const input = MultiStepInput.run(vsCodeStub.asVsCode(), step);
       // Once the quick pick has been shown, select "foo".
       await inputShown;
-      quickPickStub.onDidChangeSelection.yield([{ label: "foo" }]);
+      quickPickStub.onDidChangeSelection.yield([{ label: 'foo' }]);
 
       await expect(input).to.eventually.be.fulfilled;
-      expect(selected).to.deep.equal({ label: "foo" });
+      expect(selected).to.deep.equal({ label: 'foo' });
       sinon.assert.calledOnce(quickPickStub.dispose);
     });
 
-    it("configures the provided options", async () => {
+    it('configures the provided options', async () => {
       const opts: QuickPickOptions<QuickPickItem> = {
-        title: "Select foo",
+        title: 'Select foo',
         step: 1,
         totalSteps: 1,
-        placeholder: "foo",
-        items: [{ label: "foo" }],
-        activeItem: { label: "foo" },
+        placeholder: 'foo',
+        items: [{ label: 'foo' }],
+        activeItem: { label: 'foo' },
         buttons: [vsCodeStub.QuickInputButtons.Back],
         ignoreFocusOut: true,
       };
@@ -226,12 +226,12 @@ describe("MultiStepQuickPick", () => {
         ...optsToCompare,
         activeItems: [activeItem],
       });
-      quickPickStub.onDidChangeSelection.yield([{ label: "foo" }]);
+      quickPickStub.onDidChangeSelection.yield([{ label: 'foo' }]);
 
       await expect(input).to.eventually.be.fulfilled;
     });
 
-    it("disposes the input and registered listeners", async () => {
+    it('disposes the input and registered listeners', async () => {
       const step: InputStep = async (input: MultiStepInput) => {
         await input.showQuickPick(ONLY_FOO);
         return undefined;
@@ -241,7 +241,7 @@ describe("MultiStepQuickPick", () => {
       const input = MultiStepInput.run(vsCodeStub.asVsCode(), step);
       // Once the quick pick has been shown, select "foo".
       await inputShown;
-      quickPickStub.onDidChangeSelection.yield([{ label: "foo" }]);
+      quickPickStub.onDidChangeSelection.yield([{ label: 'foo' }]);
 
       await expect(input).to.eventually.be.fulfilled;
       sinon.assert.calledOnce(quickPickStub.dispose);
@@ -255,13 +255,13 @@ describe("MultiStepQuickPick", () => {
     });
   });
 
-  describe("showInputBox", () => {
+  describe('showInputBox', () => {
     const ENTER_A_VALUE: InputBoxOptions = {
-      title: "Got a value?",
+      title: 'Got a value?',
       step: 1,
       totalSteps: 1,
-      value: "",
-      prompt: "Enter a value",
+      value: '',
+      prompt: 'Enter a value',
       validate: () => undefined,
     };
     let onDidTriggerButtonDisposeStub: sinon.SinonStubbedInstance<Disposable>;
@@ -329,7 +329,7 @@ describe("MultiStepQuickPick", () => {
       sinon.assert.calledOnce(inputBoxStub.dispose);
     });
 
-    it("resolves the selected item", async () => {
+    it('resolves the selected item', async () => {
       let entered: string | undefined;
       const step: InputStep = async (input: MultiStepInput) => {
         entered = await input.showInputBox(ENTER_A_VALUE);
@@ -340,22 +340,22 @@ describe("MultiStepQuickPick", () => {
       const input = MultiStepInput.run(vsCodeStub.asVsCode(), step);
       // Once the input box has been shown, enter "foo".
       await inputShown;
-      inputBoxStub.value = "foo";
+      inputBoxStub.value = 'foo';
       inputBoxStub.onDidChangeValue.yield(inputBoxStub.value);
       inputBoxStub.onDidAccept.yield();
 
       await expect(input).to.eventually.be.fulfilled;
-      expect(entered).to.deep.equal("foo");
+      expect(entered).to.deep.equal('foo');
       sinon.assert.calledOnce(inputBoxStub.dispose);
     });
 
-    it("validates the input as it changes", async () => {
+    it('validates the input as it changes', async () => {
       const needFoo = "Nope, need 'foo'";
       let entered: string | undefined;
       const step: InputStep = async (input: MultiStepInput) => {
         entered = await input.showInputBox({
           ...ENTER_A_VALUE,
-          validate: (text) => (text === "foo" ? undefined : needFoo),
+          validate: (text) => (text === 'foo' ? undefined : needFoo),
         });
         return undefined;
       };
@@ -365,30 +365,30 @@ describe("MultiStepQuickPick", () => {
       // Once the input box has been shown, simulate typing "foo" (character
       // by character).
       await inputShown;
-      inputBoxStub.value = "f";
+      inputBoxStub.value = 'f';
       inputBoxStub.onDidChangeValue.yield(inputBoxStub.value);
       expect(inputBoxStub.validationMessage).to.equal(needFoo);
-      inputBoxStub.value = "fo";
+      inputBoxStub.value = 'fo';
       inputBoxStub.onDidChangeValue.yield(inputBoxStub.value);
       expect(inputBoxStub.validationMessage).to.equal(needFoo);
-      inputBoxStub.value = "foo";
+      inputBoxStub.value = 'foo';
       inputBoxStub.onDidChangeValue.yield(inputBoxStub.value);
       expect(inputBoxStub.validationMessage).to.equal(undefined);
       inputBoxStub.onDidAccept.yield();
 
       await expect(input).to.eventually.be.fulfilled;
-      expect(entered).to.deep.equal("foo");
+      expect(entered).to.deep.equal('foo');
       sinon.assert.calledOnce(inputBoxStub.dispose);
     });
 
-    it("configures the provided options", async () => {
+    it('configures the provided options', async () => {
       const opts: InputBoxOptions = {
-        title: "Got a value?",
+        title: 'Got a value?',
         step: 1,
         totalSteps: 1,
-        value: "",
-        prompt: "Enter a value",
-        placeholder: "42",
+        value: '',
+        prompt: 'Enter a value',
+        placeholder: '42',
         validate: () => undefined,
         buttons: [vsCodeStub.QuickInputButtons.Back],
         ignoreFocusOut: true,
@@ -406,14 +406,14 @@ describe("MultiStepQuickPick", () => {
       await inputShown;
       const { validate: _, ...optsToCompare } = opts;
       expect(inputBoxStub).to.deep.include(optsToCompare);
-      inputBoxStub.value = "foo";
+      inputBoxStub.value = 'foo';
       inputBoxStub.onDidChangeValue.yield(inputBoxStub.value);
       inputBoxStub.onDidAccept.yield();
 
       await expect(input).to.eventually.be.fulfilled;
     });
 
-    it("disposes the input and registered listeners", async () => {
+    it('disposes the input and registered listeners', async () => {
       const step: InputStep = async (input: MultiStepInput) => {
         await input.showInputBox(ENTER_A_VALUE);
         return undefined;
@@ -423,7 +423,7 @@ describe("MultiStepQuickPick", () => {
       const input = MultiStepInput.run(vsCodeStub.asVsCode(), step);
       // Once the input box has been shown, enter "foo".
       await inputShown;
-      inputBoxStub.value = "foo";
+      inputBoxStub.value = 'foo';
       inputBoxStub.onDidChangeValue.yield(inputBoxStub.value);
       inputBoxStub.onDidAccept.yield();
 

--- a/src/common/task-runner.ts
+++ b/src/common/task-runner.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Disposable } from "vscode";
-import { log } from "./logging";
+import { Disposable } from 'vscode';
+import { log } from './logging';
 
 /**
  * Configuration for the {@link SequentialTaskRunner}.
@@ -165,7 +165,7 @@ export class SequentialTaskRunner implements Disposable {
   private async runWorker(): Promise<void> {
     const abort = new AbortController();
     abort.signal.addEventListener(
-      "abort",
+      'abort',
       () => {
         const reason: unknown = abort.signal.reason;
         if (reason instanceof TimeoutError) {
@@ -260,10 +260,10 @@ export class SequentialTaskRunner implements Disposable {
         });
       };
 
-      signal.addEventListener("abort", onAbort, { once: true });
+      signal.addEventListener('abort', onAbort, { once: true });
 
       void task.finally(() => {
-        signal.removeEventListener("abort", onAbort);
+        signal.removeEventListener('abort', onAbort);
       });
     });
 
@@ -276,27 +276,27 @@ class NonGracefulAbandonError extends Error {
     super(
       `Task "${taskName}" did not complete within a ${timeoutMs.toString()}ms grace period after being abandoned.`,
     );
-    this.name = "NonGracefulAbandonError";
+    this.name = 'NonGracefulAbandonError';
   }
 }
 
 class TimeoutError extends Error {
   constructor(taskName: string, afterMs: number) {
     super(`Task "${taskName}" timed out after ${afterMs.toString()}ms`);
-    this.name = "TimeoutError";
+    this.name = 'TimeoutError';
   }
 }
 
 class OverrunAbandonError extends Error {
   constructor(taskName: string) {
     super(`Task "${taskName}" abandoned for a new run`);
-    this.name = "OverrunAbandonError";
+    this.name = 'OverrunAbandonError';
   }
 }
 
 class DisposedError extends Error {
   constructor(taskName: string) {
     super(`Task "${taskName}" aborted due to runner being disposed`);
-    this.name = "DisposedError";
+    this.name = 'DisposedError';
   }
 }

--- a/src/common/task-runner.unit.test.ts
+++ b/src/common/task-runner.unit.test.ts
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import sinon, { SinonFakeTimers } from "sinon";
-import { ColabLogWatcher } from "../test/helpers/logging";
-import { newVsCodeStub } from "../test/helpers/vscode";
-import { LogLevel } from "./logging";
+import { expect } from 'chai';
+import sinon, { SinonFakeTimers } from 'sinon';
+import { ColabLogWatcher } from '../test/helpers/logging';
+import { newVsCodeStub } from '../test/helpers/vscode';
+import { LogLevel } from './logging';
 import {
   Config,
   OverrunPolicy,
   SequentialTaskRunner,
   StartMode,
   Task,
-} from "./task-runner";
+} from './task-runner';
 
 const INTERVAL_TIMEOUT_MS = 1000;
 const TASK_TIMEOUT_MS = 100;
@@ -36,7 +36,7 @@ interface TestRun {
 }
 
 class TestTask implements Task {
-  readonly name = "test task";
+  readonly name = 'test task';
   readonly run = sinon.stub<[AbortSignal], Promise<void>>();
 
   nextRun(): TestRun {
@@ -59,7 +59,7 @@ class TestTask implements Task {
     };
     const started = new Promise<void>((resolveStarted) => {
       this.run.onCall(callIndex).callsFake((signal: AbortSignal) => {
-        signal.addEventListener("abort", () => {
+        signal.addEventListener('abort', () => {
           abortResolver();
         });
 
@@ -85,7 +85,7 @@ class TestTask implements Task {
   }
 }
 
-describe("SequentialTaskRunner", () => {
+describe('SequentialTaskRunner', () => {
   let clock: SinonFakeTimers;
   let logs: ColabLogWatcher;
   let testTask: TestTask;
@@ -107,7 +107,7 @@ describe("SequentialTaskRunner", () => {
 
   beforeEach(() => {
     clock = sinon.useFakeTimers({
-      toFake: ["setInterval", "clearInterval", "setTimeout"],
+      toFake: ['setInterval', 'clearInterval', 'setTimeout'],
     });
     logs = new ColabLogWatcher(newVsCodeStub(), LogLevel.Warning);
     testTask = new TestTask();
@@ -118,7 +118,7 @@ describe("SequentialTaskRunner", () => {
     clock.restore();
   });
 
-  describe("dispose", () => {
+  describe('dispose', () => {
     let runner: SequentialTaskRunner;
 
     beforeEach(() => {
@@ -129,7 +129,7 @@ describe("SequentialTaskRunner", () => {
       runner.dispose();
     });
 
-    it("cancels any scheduled tasks", async () => {
+    it('cancels any scheduled tasks', async () => {
       runner.start(StartMode.Scheduled);
 
       runner.dispose();
@@ -138,43 +138,43 @@ describe("SequentialTaskRunner", () => {
       sinon.assert.notCalled(testTask.run);
     });
 
-    it("aborts in-flight tasks", async () => {
+    it('aborts in-flight tasks', async () => {
       const run = testTask.nextRun();
       runner.start();
       await tickPast(INTERVAL_TIMEOUT_MS);
 
       runner.dispose();
 
-      await expect(run.aborted, "Task should be aborted when disposed").to
+      await expect(run.aborted, 'Task should be aborted when disposed').to
         .eventually.be.fulfilled;
-      expect(logs.output, "Nothing should be logged on a clean disposal").is
+      expect(logs.output, 'Nothing should be logged on a clean disposal').is
         .empty;
     });
   });
 
-  describe("start", () => {
-    it("runs the task immediately when StartMode.Immediately is configured", async () => {
+  describe('start', () => {
+    it('runs the task immediately when StartMode.Immediately is configured', async () => {
       const runner = buildRunner();
       const run = testTask.nextRun();
 
       runner.start(StartMode.Immediately);
 
-      await expect(run.started, "Task should start immediately").to.eventually
+      await expect(run.started, 'Task should start immediately').to.eventually
         .be.fulfilled;
     });
 
-    it("schedules the task to be run after the configured interval", async () => {
+    it('schedules the task to be run after the configured interval', async () => {
       const runner = buildRunner();
       const run = testTask.nextRun();
 
       runner.start(StartMode.Scheduled);
       await tickPast(INTERVAL_TIMEOUT_MS);
 
-      await expect(run.started, "Task should start after scheduled interval").to
+      await expect(run.started, 'Task should start after scheduled interval').to
         .eventually.be.fulfilled;
     });
 
-    it("does nothing if the task is already started", async () => {
+    it('does nothing if the task is already started', async () => {
       const runner = buildRunner();
       const run = testTask.nextRun();
 
@@ -182,51 +182,51 @@ describe("SequentialTaskRunner", () => {
       runner.start(StartMode.Immediately);
       await tickPast(INTERVAL_TIMEOUT_MS);
 
-      await expect(run.started, "Task should start after scheduled interval").to
+      await expect(run.started, 'Task should start after scheduled interval').to
         .eventually.be.fulfilled;
       sinon.assert.calledOnce(testTask.run);
     });
 
-    it("resumes a previously stopped runner", async () => {
+    it('resumes a previously stopped runner', async () => {
       const runner = buildRunner();
       const firstRun = testTask.nextRun();
       runner.start(StartMode.Immediately);
-      await expect(firstRun.started, "First run should start").to.eventually.be
+      await expect(firstRun.started, 'First run should start').to.eventually.be
         .fulfilled;
 
       runner.stop();
 
-      await expect(firstRun.aborted, "First run should be aborted").to
+      await expect(firstRun.aborted, 'First run should be aborted').to
         .eventually.be.fulfilled;
       await tickPast(ABANDON_GRACE_MS);
       const secondRun = testTask.nextRun();
 
       runner.start(StartMode.Immediately);
 
-      await expect(secondRun.started, "Second run should start").to.eventually
+      await expect(secondRun.started, 'Second run should start').to.eventually
         .be.fulfilled;
       sinon.assert.calledTwice(testTask.run);
     });
 
-    it("runs multiple times", async () => {
+    it('runs multiple times', async () => {
       const runner = buildRunner();
 
       const firstRun = testTask.nextRun();
       runner.start(StartMode.Immediately);
-      await expect(firstRun.started, "First run should start").to.eventually.be
+      await expect(firstRun.started, 'First run should start').to.eventually.be
         .fulfilled;
       firstRun.resolve();
 
       const secondRun = testTask.nextRun();
       await tickPast(INTERVAL_TIMEOUT_MS);
-      await expect(secondRun.started, "Second run should start").to.eventually
+      await expect(secondRun.started, 'Second run should start').to.eventually
         .be.fulfilled;
       secondRun.resolve();
     });
   });
 
-  describe("stop", () => {
-    it("cancels the next scheduled task run", async () => {
+  describe('stop', () => {
+    it('cancels the next scheduled task run', async () => {
       const runner = buildRunner();
       runner.start(StartMode.Scheduled);
 
@@ -236,23 +236,23 @@ describe("SequentialTaskRunner", () => {
       sinon.assert.notCalled(testTask.run);
     });
 
-    it("aborts in-flight tasks", async () => {
+    it('aborts in-flight tasks', async () => {
       const runner = buildRunner();
       const run = testTask.nextRun();
       runner.start(StartMode.Immediately);
-      await expect(run.started, "Task should start immediately").to.eventually
+      await expect(run.started, 'Task should start immediately').to.eventually
         .be.fulfilled;
 
       runner.stop();
 
-      await expect(run.aborted, "Task should be aborted").to.eventually.be
+      await expect(run.aborted, 'Task should be aborted').to.eventually.be
         .fulfilled;
       sinon.assert.calledOnce(testTask.run);
     });
   });
 
-  describe("when overrun (AllowToComplete policy)", () => {
-    it("does nothing for the current interval", async () => {
+  describe('when overrun (AllowToComplete policy)', () => {
+    it('does nothing for the current interval', async () => {
       const runner = buildRunner(OverrunPolicy.AllowToComplete, {
         abandonGraceMs: ABANDON_GRACE_MS,
         intervalTimeoutMs: INTERVAL_TIMEOUT_MS,
@@ -260,7 +260,7 @@ describe("SequentialTaskRunner", () => {
       });
       const firstRun = testTask.nextRun();
       runner.start(StartMode.Immediately);
-      await expect(firstRun.started, "Task should start immediately").to
+      await expect(firstRun.started, 'Task should start immediately').to
         .eventually.be.fulfilled;
 
       await tickPast(INTERVAL_TIMEOUT_MS);
@@ -269,7 +269,7 @@ describe("SequentialTaskRunner", () => {
     });
   });
 
-  describe("when overrun (AbandonAndRun policy)", () => {
+  describe('when overrun (AbandonAndRun policy)', () => {
     let runner: SequentialTaskRunner;
     let firstRun: TestRun;
     let secondRun: TestRun;
@@ -283,7 +283,7 @@ describe("SequentialTaskRunner", () => {
       });
       firstRun = testTask.nextRun();
       runner.start(StartMode.Immediately);
-      await expect(firstRun.started, "First run should start immediately").to
+      await expect(firstRun.started, 'First run should start immediately').to
         .eventually.be.fulfilled;
       secondRun = testTask.nextRun();
       // Don't resolve the first run, to simulate it being in-flight and overrun
@@ -295,40 +295,40 @@ describe("SequentialTaskRunner", () => {
       runner.dispose();
     });
 
-    it("aborts the in-flight task and starts a new one after the abandon grace period", async () => {
-      await expect(firstRun.aborted, "First run should be aborted").to
+    it('aborts the in-flight task and starts a new one after the abandon grace period', async () => {
+      await expect(firstRun.aborted, 'First run should be aborted').to
         .eventually.be.fulfilled;
 
       await clock.tickAsync(ABANDON_GRACE_MS / 2);
-      expect(secondRun.started, "Second run should not start yet").to.not.be
+      expect(secondRun.started, 'Second run should not start yet').to.not.be
         .fulfilled;
       sinon.assert.calledOnce(testTask.run);
 
       await clock.tickAsync(ABANDON_GRACE_MS);
-      await expect(secondRun.started, "Second run should start").to.eventually
+      await expect(secondRun.started, 'Second run should start').to.eventually
         .be.fulfilled;
       sinon.assert.calledTwice(testTask.run);
     });
 
-    it("logs a warning message immediately", () => {
+    it('logs a warning message immediately', () => {
       expect(logs.output).to.match(
         new RegExp(`Warning.*${testTask.name}.*new run`),
       );
     });
 
-    it("grants a grace period for the aborted task to complete cleanly", async () => {
-      await expect(firstRun.aborted, "First run should be aborted").to
+    it('grants a grace period for the aborted task to complete cleanly', async () => {
+      await expect(firstRun.aborted, 'First run should be aborted').to
         .eventually.be.fulfilled;
       await tickPast(ABANDON_GRACE_MS / 2);
       // Verify the second run hasn't started, before the grace period.
-      expect(secondRun.started, "Second run should not start yet").to.not.be
+      expect(secondRun.started, 'Second run should not start yet').to.not.be
         .fulfilled;
 
       firstRun.resolve();
 
       // Wait for grace period to pass and second task to start.
       await tickPast(ABANDON_GRACE_MS);
-      await expect(secondRun.started, "Second run should start").to.eventually
+      await expect(secondRun.started, 'Second run should start').to.eventually
         .be.fulfilled;
 
       // Check that no non-graceful error was logged. A warning for overrun is
@@ -341,8 +341,8 @@ describe("SequentialTaskRunner", () => {
       );
     });
 
-    it("logs an error if the aborted task fails to complete within its grace period", async () => {
-      await expect(firstRun.aborted, "First run should be aborted").to
+    it('logs an error if the aborted task fails to complete within its grace period', async () => {
+      await expect(firstRun.aborted, 'First run should be aborted').to
         .eventually.be.fulfilled;
 
       // Don't resolve the first run, let the grace period expire.
@@ -353,7 +353,7 @@ describe("SequentialTaskRunner", () => {
       );
     });
 
-    it("handles multiple overruns", async () => {
+    it('handles multiple overruns', async () => {
       // The beforeEach already triggered the *first* overrun.
       await expect(firstRun.aborted).to.eventually.be.fulfilled;
       await tickPast(ABANDON_GRACE_MS);
@@ -371,7 +371,7 @@ describe("SequentialTaskRunner", () => {
       sinon.assert.calledThrice(testTask.run);
     });
 
-    it("does not start a new task if disposed during an overrun grace period", async () => {
+    it('does not start a new task if disposed during an overrun grace period', async () => {
       // The beforeEach already triggered the overrun.
       // firstRun is in its grace period.
       await expect(firstRun.aborted).to.eventually.be.fulfilled;
@@ -384,7 +384,7 @@ describe("SequentialTaskRunner", () => {
       await clock.runAllAsync();
 
       // The secondRun (which was queued) should never have started.
-      expect(secondRun.started, "Second run should not have started").to.not.be
+      expect(secondRun.started, 'Second run should not have started').to.not.be
         .fulfilled;
 
       // Only the very first run should have been called.
@@ -392,8 +392,8 @@ describe("SequentialTaskRunner", () => {
     });
   });
 
-  describe("timeout", () => {
-    it("aborts the in-flight task", async () => {
+  describe('timeout', () => {
+    it('aborts the in-flight task', async () => {
       const runner = buildRunner();
       const run = testTask.nextRun();
       runner.start(StartMode.Immediately);
@@ -401,11 +401,11 @@ describe("SequentialTaskRunner", () => {
 
       await tickPast(TASK_TIMEOUT_MS);
 
-      await expect(run.aborted, "Task should be aborted on timeout").to
+      await expect(run.aborted, 'Task should be aborted on timeout').to
         .eventually.be.fulfilled;
     });
 
-    it("logs an error message for the timeout", async () => {
+    it('logs an error message for the timeout', async () => {
       const runner = buildRunner();
       const run = testTask.nextRun();
       runner.start(StartMode.Immediately);
@@ -419,7 +419,7 @@ describe("SequentialTaskRunner", () => {
       );
     });
 
-    it("logs a second error if the timed-out task fails to complete within its grace period", async () => {
+    it('logs a second error if the timed-out task fails to complete within its grace period', async () => {
       const runner = buildRunner();
       const run = testTask.nextRun();
       runner.start(StartMode.Immediately);
@@ -436,7 +436,7 @@ describe("SequentialTaskRunner", () => {
       );
     });
 
-    it("does not log non-graceful error if disposed during timeout grace period", async () => {
+    it('does not log non-graceful error if disposed during timeout grace period', async () => {
       const runner = buildRunner();
       const run = testTask.nextRun();
       runner.start(StartMode.Immediately);
@@ -464,7 +464,7 @@ describe("SequentialTaskRunner", () => {
     });
   });
 
-  describe("task errors", () => {
+  describe('task errors', () => {
     let runner: SequentialTaskRunner;
     let run: TestRun;
 
@@ -472,7 +472,7 @@ describe("SequentialTaskRunner", () => {
       runner = buildRunner();
       run = testTask.nextRun();
       runner.start(StartMode.Immediately);
-      await expect(run.started, "First run should start immediately").to
+      await expect(run.started, 'First run should start immediately').to
         .eventually.be.fulfilled;
     });
 
@@ -483,8 +483,8 @@ describe("SequentialTaskRunner", () => {
       }
     });
 
-    it("logs the unhandled error from the task", async () => {
-      run.reject(new Error("🤮"));
+    it('logs the unhandled error from the task', async () => {
+      run.reject(new Error('🤮'));
       await tickPast(ABANDON_GRACE_MS); // Allow promise to settle
 
       expect(logs.output).to.match(
@@ -493,24 +493,24 @@ describe("SequentialTaskRunner", () => {
       expect(logs.output).to.match(/🤮/);
     });
 
-    it("continues to run the task on the next interval", async () => {
-      run.reject(new Error("🤮"));
+    it('continues to run the task on the next interval', async () => {
+      run.reject(new Error('🤮'));
       const secondRun = testTask.nextRun();
       await tickPast(INTERVAL_TIMEOUT_MS);
 
-      await expect(secondRun.started, "Second run should start").to.eventually
+      await expect(secondRun.started, 'Second run should start').to.eventually
         .be.fulfilled;
       sinon.assert.calledTwice(testTask.run);
     });
 
-    it("logs unhandled error if task rejects during grace period", async () => {
+    it('logs unhandled error if task rejects during grace period', async () => {
       // Trigger timeout to start grace period
       await tickPast(TASK_TIMEOUT_MS);
       await expect(run.aborted).to.eventually.be.fulfilled;
 
       // Reject the task *during* the grace period
       await clock.tickAsync(ABANDON_GRACE_MS / 2);
-      run.reject(new Error("Failed during cleanup"));
+      run.reject(new Error('Failed during cleanup'));
 
       // Let all timers finish
       await clock.tickAsync(ABANDON_GRACE_MS / 2);

--- a/src/common/toggleable.ts
+++ b/src/common/toggleable.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { LatestCancelable } from "./async";
+import { LatestCancelable } from './async';
 
 /**
  * An entity which can be turned "on" and "off".
@@ -30,19 +30,19 @@ type ToggleDirection = Lowercase<keyof Toggleable>;
  * when toggling.
  */
 export abstract class AsyncToggle implements Toggleable {
-  private lastToggle?: "on" | "off";
+  private lastToggle?: 'on' | 'off';
   private runner = new LatestCancelable<[ToggleDirection]>(
-    "AsyncToggle",
+    'AsyncToggle',
     async (to, signal) => {
       if (this.lastToggle === to) {
         return;
       }
       this.lastToggle = to;
       switch (to) {
-        case "on":
+        case 'on':
           await this.turnOn(signal);
           break;
-        case "off":
+        case 'off':
           await this.turnOff(signal);
           break;
       }
@@ -50,10 +50,10 @@ export abstract class AsyncToggle implements Toggleable {
   );
 
   on(): void {
-    void this.runner.run("on");
+    void this.runner.run('on');
   }
   off(): void {
-    void this.runner.run("off");
+    void this.runner.run('off');
   }
 
   protected abstract turnOn(signal: AbortSignal): Promise<void>;

--- a/src/common/toggleable.unit.test.ts
+++ b/src/common/toggleable.unit.test.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import sinon from "sinon";
-import { ControllableAsyncToggle, Deferred } from "../test/helpers/async";
-import { ColabLogWatcher } from "../test/helpers/logging";
-import { newVsCodeStub } from "../test/helpers/vscode";
-import { LogLevel } from "./logging";
-import { AsyncToggle } from "./toggleable";
+import sinon from 'sinon';
+import { ControllableAsyncToggle, Deferred } from '../test/helpers/async';
+import { ColabLogWatcher } from '../test/helpers/logging';
+import { newVsCodeStub } from '../test/helpers/vscode';
+import { LogLevel } from './logging';
+import { AsyncToggle } from './toggleable';
 
 /**
  * A derived class with the abstract methods of the SUT (AsyncToggle) stubbed.
@@ -29,14 +29,14 @@ class TestToggle extends AsyncToggle {
    * @param turning - the direction to gate.
    */
   gate(
-    turning: "turnOn" | "turnOff",
+    turning: 'turnOn' | 'turnOff',
     call: number,
   ): { resolve: () => void; aborted: Promise<void> } {
-    const turn = turning === "turnOn" ? this.turnOnStub : this.turnOffStub;
+    const turn = turning === 'turnOn' ? this.turnOnStub : this.turnOffStub;
     const d = new Deferred<void>();
     const aborted = new Deferred<void>();
     turn.onCall(call).callsFake(async (signal: AbortSignal) => {
-      signal.addEventListener("abort", () => {
+      signal.addEventListener('abort', () => {
         aborted.resolve();
       });
       if (signal.aborted) {
@@ -48,7 +48,7 @@ class TestToggle extends AsyncToggle {
   }
 }
 
-describe("AsyncToggle", () => {
+describe('AsyncToggle', () => {
   let logs: ColabLogWatcher;
   let toggle: TestToggle;
   let toggleSpy: ControllableAsyncToggle;
@@ -65,15 +65,15 @@ describe("AsyncToggle", () => {
     logs.dispose();
   });
 
-  describe("on", () => {
-    it("should turn on when called", async () => {
+  describe('on', () => {
+    it('should turn on when called', async () => {
       toggle.on();
 
       await toggleSpy.turnOn.call(0).waitForCompletion();
     });
 
-    it("should not turn on if already turning on", async () => {
-      const first = toggle.gate("turnOn", 0);
+    it('should not turn on if already turning on', async () => {
+      const first = toggle.gate('turnOn', 0);
       toggle.on();
       await toggleSpy.turnOn.call(0).waitForStart();
 
@@ -83,7 +83,7 @@ describe("AsyncToggle", () => {
       sinon.assert.calledOnce(toggle.turnOnStub);
     });
 
-    it("should not turn on if already on", async () => {
+    it('should not turn on if already on', async () => {
       toggle.on();
       await toggleSpy.turnOn.call(0).waitForCompletion();
 
@@ -96,8 +96,8 @@ describe("AsyncToggle", () => {
       sinon.assert.calledOnce(toggle.turnOnStub);
     });
 
-    it("should be cancelled if off is called", async () => {
-      const turnOn = toggle.gate("turnOn", 0);
+    it('should be cancelled if off is called', async () => {
+      const turnOn = toggle.gate('turnOn', 0);
       toggle.on();
       await toggleSpy.turnOn.call(0).waitForStart();
 
@@ -109,15 +109,15 @@ describe("AsyncToggle", () => {
     });
   });
 
-  describe("off", () => {
-    it("should turn off when called", async () => {
+  describe('off', () => {
+    it('should turn off when called', async () => {
       toggle.off();
 
       await toggleSpy.turnOff.call(0).waitForCompletion();
     });
 
-    it("should not turn off if already turning off", async () => {
-      const first = toggle.gate("turnOff", 0);
+    it('should not turn off if already turning off', async () => {
+      const first = toggle.gate('turnOff', 0);
       toggle.off();
       await toggleSpy.turnOff.call(0).waitForStart();
 
@@ -127,7 +127,7 @@ describe("AsyncToggle", () => {
       sinon.assert.calledOnce(toggle.turnOffStub);
     });
 
-    it("should not turn off if already off", async () => {
+    it('should not turn off if already off', async () => {
       toggle.off();
       await toggleSpy.turnOff.call(0).waitForCompletion();
 
@@ -140,8 +140,8 @@ describe("AsyncToggle", () => {
       sinon.assert.calledOnce(toggle.turnOffStub);
     });
 
-    it("should be cancelled if on is called", async () => {
-      const turnOff = toggle.gate("turnOff", 0);
+    it('should be cancelled if on is called', async () => {
+      const turnOff = toggle.gate('turnOff', 0);
       toggle.off();
       await toggleSpy.turnOff.call(0).waitForStart();
 
@@ -153,21 +153,21 @@ describe("AsyncToggle", () => {
     });
   });
 
-  it("should handle rapid toggling", async () => {
+  it('should handle rapid toggling', async () => {
     // Start toggling on but gate it from completing.
-    const turnOn1 = toggle.gate("turnOn", 0);
+    const turnOn1 = toggle.gate('turnOn', 0);
     toggle.on();
     await toggleSpy.turnOn.call(0).waitForStart();
 
     // Toggle off before on completes.
-    const turnOff1 = toggle.gate("turnOff", 0);
+    const turnOff1 = toggle.gate('turnOff', 0);
     toggle.off();
     await toggleSpy.turnOff.call(0).waitForStart();
     await turnOn1.aborted;
     turnOn1.resolve();
 
     // Toggle on to completion before off completes.
-    const turnOn2 = toggle.gate("turnOn", 1);
+    const turnOn2 = toggle.gate('turnOn', 1);
     toggle.on();
     await toggleSpy.turnOn.call(1).waitForStart();
     await turnOff1.aborted;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const PROVIDER_ID = "google";
+export const PROVIDER_ID = 'google';

--- a/src/config/package-info.ts
+++ b/src/config/package-info.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Extension } from "vscode";
-import { z } from "zod";
+import { Extension } from 'vscode';
+import { z } from 'zod';
 
 /**
  * A partial representation of the package.json file.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,35 +4,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Jupyter } from "@vscode/jupyter-extension";
-import { OAuth2Client } from "google-auth-library";
-import vscode, { Disposable } from "vscode";
-import { GoogleAuthProvider } from "./auth/auth-provider";
-import { getOAuth2Flows } from "./auth/flows/flows";
-import { login } from "./auth/login";
-import { AuthStorage } from "./auth/storage";
-import { ColabClient } from "./colab/client";
+import { Jupyter } from '@vscode/jupyter-extension';
+import { OAuth2Client } from 'google-auth-library';
+import vscode, { Disposable } from 'vscode';
+import { GoogleAuthProvider } from './auth/auth-provider';
+import { getOAuth2Flows } from './auth/flows/flows';
+import { login } from './auth/login';
+import { AuthStorage } from './auth/storage';
+import { ColabClient } from './colab/client';
 import {
   COLAB_TOOLBAR,
   REMOVE_SERVER,
   SIGN_OUT,
-} from "./colab/commands/constants";
-import { notebookToolbar } from "./colab/commands/notebook";
-import { removeServer } from "./colab/commands/server";
-import { ConnectionRefreshController } from "./colab/connection-refresher";
-import { ConsumptionNotifier } from "./colab/consumption/notifier";
-import { ConsumptionPoller } from "./colab/consumption/poller";
-import { ServerKeepAliveController } from "./colab/keep-alive";
-import { ServerPicker } from "./colab/server-picker";
-import { CONFIG } from "./colab-config";
-import { initializeLogger, log } from "./common/logging";
-import { Toggleable } from "./common/toggleable";
-import { getPackageInfo } from "./config/package-info";
-import { AssignmentManager } from "./jupyter/assignments";
-import { getJupyterApi } from "./jupyter/jupyter-extension";
-import { ColabJupyterServerProvider } from "./jupyter/provider";
-import { ServerStorage } from "./jupyter/storage";
-import { ExtensionUriHandler } from "./system/uri";
+} from './colab/commands/constants';
+import { notebookToolbar } from './colab/commands/notebook';
+import { removeServer } from './colab/commands/server';
+import { ConnectionRefreshController } from './colab/connection-refresher';
+import { ConsumptionNotifier } from './colab/consumption/notifier';
+import { ConsumptionPoller } from './colab/consumption/poller';
+import { ServerKeepAliveController } from './colab/keep-alive';
+import { ServerPicker } from './colab/server-picker';
+import { CONFIG } from './colab-config';
+import { initializeLogger, log } from './common/logging';
+import { Toggleable } from './common/toggleable';
+import { getPackageInfo } from './config/package-info';
+import { AssignmentManager } from './jupyter/assignments';
+import { getJupyterApi } from './jupyter/jupyter-extension';
+import { ColabJupyterServerProvider } from './jupyter/provider';
+import { ServerStorage } from './jupyter/storage';
+import { ExtensionUriHandler } from './system/uri';
 
 // Called when the extension is activated.
 export async function activate(context: vscode.ExtensionContext) {
@@ -114,7 +114,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 function logEnvInfo(jupyter: vscode.Extension<Jupyter>) {
   log.info(`${vscode.env.appName}: ${vscode.version}`);
-  log.info(`Remote: ${vscode.env.remoteName ?? "N/A"}`);
+  log.info(`Remote: ${vscode.env.remoteName ?? 'N/A'}`);
   log.info(`App Host: ${vscode.env.appHost}`);
   const jupyterVersion = getPackageInfo(jupyter).version;
   log.info(`Jupyter extension version: ${jupyterVersion}`);

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -4,35 +4,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { randomUUID, UUID } from "crypto";
+import { randomUUID, UUID } from 'crypto';
 import fetch, {
   Headers,
   Request,
   RequestInfo,
   RequestInit,
   Response,
-} from "node-fetch";
-import vscode from "vscode";
+} from 'node-fetch';
+import vscode from 'vscode';
 import {
   Assignment,
   ListedAssignment,
   RuntimeProxyInfo,
   Variant,
   variantToMachineType,
-} from "../colab/api";
+} from '../colab/api';
 import {
   ColabClient,
   DenylistedError,
   InsufficientQuotaError,
   NotFoundError,
   TooManyAssignmentsError,
-} from "../colab/client";
-import { REMOVE_SERVER } from "../colab/commands/constants";
+} from '../colab/client';
+import { REMOVE_SERVER } from '../colab/commands/constants';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
-} from "../colab/headers";
-import { log } from "../common/logging";
+} from '../colab/headers';
+import { log } from '../common/logging';
 import {
   AllServers,
   ColabAssignedServer,
@@ -41,8 +41,8 @@ import {
   DEFAULT_CPU_SERVER,
   isColabAssignedServer,
   UnownedServer,
-} from "./servers";
-import { ServerStorage } from "./storage";
+} from './servers';
+import { ServerStorage } from './storage';
 
 /**
  * An {@link vscode.Event} which fires when a {@link ColabAssignedServer} is
@@ -160,7 +160,7 @@ export class AssignmentManager implements vscode.Disposable {
    * and can be refreshed by calling {@link refreshConnection}.
    */
   async getServers(
-    from: "extension",
+    from: 'extension',
     signal?: AbortSignal,
   ): Promise<ColabAssignedServer[]>;
 
@@ -169,7 +169,7 @@ export class AssignmentManager implements vscode.Disposable {
    * the VS Code extension.
    */
   async getServers(
-    from: "external",
+    from: 'external',
     signal?: AbortSignal,
   ): Promise<UnownedServer[]>;
 
@@ -177,20 +177,20 @@ export class AssignmentManager implements vscode.Disposable {
    * Retrieves the list of all servers that are assigned both in and outside VS
    * Code.
    */
-  async getServers(from: "all", signal?: AbortSignal): Promise<AllServers>;
+  async getServers(from: 'all', signal?: AbortSignal): Promise<AllServers>;
 
   async getServers(
-    from: "extension" | "external" | "all",
+    from: 'extension' | 'external' | 'all',
     signal?: AbortSignal,
   ): Promise<ColabAssignedServer[] | UnownedServer[] | AllServers> {
     let storedServers = await this.storage.list();
-    if (from === "extension" && storedServers.length === 0) {
+    if (from === 'extension' && storedServers.length === 0) {
       return storedServers;
     }
 
     const allAssignments = await this.client.listAssignments(signal);
 
-    if (from === "extension" || from === "all") {
+    if (from === 'extension' || from === 'all') {
       storedServers = (
         await this.reconcileStoredServers(storedServers, allAssignments)
       ).map((server) => ({
@@ -203,7 +203,7 @@ export class AssignmentManager implements vscode.Disposable {
     }
 
     let unownedServers: UnownedServer[] = [];
-    if (from === "external" || from === "all") {
+    if (from === 'external' || from === 'all') {
       const storedEndpointSet = new Set(storedServers.map((s) => s.endpoint));
       unownedServers = await Promise.all(
         allAssignments
@@ -223,9 +223,9 @@ export class AssignmentManager implements vscode.Disposable {
     }
 
     switch (from) {
-      case "extension":
+      case 'extension':
         return storedServers;
-      case "external":
+      case 'external':
         return unownedServers;
       default:
         return {
@@ -341,7 +341,7 @@ export class AssignmentManager implements vscode.Disposable {
   async latestServer(
     signal?: AbortSignal,
   ): Promise<ColabAssignedServer | undefined> {
-    const assigned = await this.getServers("extension", signal);
+    const assigned = await this.getServers('extension', signal);
     let latest: ColabAssignedServer | undefined;
     for (const server of assigned) {
       if (!latest || server.dateAssigned > latest.dateAssigned) {
@@ -367,7 +367,7 @@ export class AssignmentManager implements vscode.Disposable {
     await this.reconcileAssignedServers(signal);
     const server = await this.storage.get(id);
     if (!server) {
-      throw new NotFoundError("Server is not assigned");
+      throw new NotFoundError('Server is not assigned');
     }
     const newConnectionInfo = await this.client.refreshConnection(
       server.endpoint,
@@ -428,8 +428,8 @@ export class AssignmentManager implements vscode.Disposable {
     accelerator?: string,
     signal?: AbortSignal,
   ): Promise<string> {
-    const servers = await this.getServers("extension", signal);
-    const a = accelerator && accelerator !== "NONE" ? ` ${accelerator}` : "";
+    const servers = await this.getServers('extension', signal);
+    const a = accelerator && accelerator !== 'NONE' ? ` ${accelerator}` : '';
     const v = variantToMachineType(variant);
     const labelBase = `Colab ${v}${a}`;
     const labelRegex = new RegExp(`^${labelBase}(?:\\s\\((\\d+)\\))?$`);
@@ -521,7 +521,7 @@ export class AssignmentManager implements vscode.Disposable {
   private async notifyMaxAssignmentsExceeded() {
     // TODO: Account for subscription tiers in actions.
     const selectedAction = await this.vs.window.showErrorMessage(
-      "Unable to assign server. You have too many, remove one to continue.",
+      'Unable to assign server. You have too many, remove one to continue.',
       AssignmentsExceededActions.REMOVE_SERVER,
     );
     switch (selectedAction) {
@@ -542,7 +542,7 @@ export class AssignmentManager implements vscode.Disposable {
     if (selectedAction === LEARN_MORE) {
       this.vs.env.openExternal(
         this.vs.Uri.parse(
-          "https://research.google.com/colaboratory/faq.html#resource-limits",
+          'https://research.google.com/colaboratory/faq.html#resource-limits',
         ),
       );
     }
@@ -564,7 +564,7 @@ export class AssignmentManager implements vscode.Disposable {
     const serverDescriptor =
       removed.length === 1
         ? `${removed[0]} was`
-        : `${removed.slice(0, numRemoved - 1).join(", ")} and ${removed[numRemoved - 1]} were`;
+        : `${removed.slice(0, numRemoved - 1).join(', ')} and ${removed[numRemoved - 1]} were`;
     const viewIssue = await this.vs.window.showInformationMessage(
       `To work around [microsoft/vscode-jupyter #17094](https://github.com/microsoft/vscode-jupyter/issues/17094) - please re-open notebooks ${serverDescriptor} previously connected to.`,
       `View Issue`,
@@ -572,7 +572,7 @@ export class AssignmentManager implements vscode.Disposable {
     if (viewIssue) {
       this.vs.env.openExternal(
         this.vs.Uri.parse(
-          "https://github.com/microsoft/vscode-jupyter/issues/17094",
+          'https://github.com/microsoft/vscode-jupyter/issues/17094',
         ),
       );
     }
@@ -580,12 +580,12 @@ export class AssignmentManager implements vscode.Disposable {
 }
 
 enum AssignmentsExceededActions {
-  REMOVE_SERVER = "Remove Server",
+  REMOVE_SERVER = 'Remove Server',
 }
 
-const LEARN_MORE = "Learn More";
+const LEARN_MORE = 'Learn More';
 
-const UNKNOWN_REMOTE_SERVER_NAME = "Untitled";
+const UNKNOWN_REMOTE_SERVER_NAME = 'Untitled';
 
 /**
  * Creates a fetch function that adds the Colab runtime proxy token as a header.
@@ -622,5 +622,5 @@ function colabProxyFetch(
 }
 
 function isRequest(info: RequestInfo): info is Request {
-  return typeof info !== "string" && !("href" in info);
+  return typeof info !== 'string' && !('href' in info);
 }

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { randomUUID } from "crypto";
-import { assert, expect } from "chai";
-import fetch, { Headers } from "node-fetch";
-import sinon, { SinonFakeTimers, SinonStubbedInstance } from "sinon";
-import { MessageItem, Uri } from "vscode";
+import { randomUUID } from 'crypto';
+import { assert, expect } from 'chai';
+import fetch, { Headers } from 'node-fetch';
+import sinon, { SinonFakeTimers, SinonStubbedInstance } from 'sinon';
+import { MessageItem, Uri } from 'vscode';
 import {
   Assignment,
   RuntimeProxyInfo,
@@ -16,56 +16,56 @@ import {
   SubscriptionState,
   SubscriptionTier,
   Variant,
-} from "../colab/api";
+} from '../colab/api';
 import {
   ColabClient,
   DenylistedError,
   InsufficientQuotaError,
   NotFoundError,
   TooManyAssignmentsError,
-} from "../colab/client";
-import { REMOVE_SERVER } from "../colab/commands/constants";
+} from '../colab/client';
+import { REMOVE_SERVER } from '../colab/commands/constants';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
-} from "../colab/headers";
-import { TestEventEmitter } from "../test/helpers/events";
-import { ServerStorageFake } from "../test/helpers/server-storage";
-import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
-import { isUUID } from "../utils/uuid";
-import { AssignmentChangeEvent, AssignmentManager } from "./assignments";
+} from '../colab/headers';
+import { TestEventEmitter } from '../test/helpers/events';
+import { ServerStorageFake } from '../test/helpers/server-storage';
+import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
+import { isUUID } from '../utils/uuid';
+import { AssignmentChangeEvent, AssignmentManager } from './assignments';
 import {
   ColabAssignedServer,
   ColabServerDescriptor,
   DEFAULT_CPU_SERVER,
-} from "./servers";
-import { ServerStorage } from "./storage";
+} from './servers';
+import { ServerStorage } from './storage';
 
 const NOW = new Date();
 const TOKEN_EXPIRY_MS = 1000 * 60 * 60;
 
 const defaultAssignmentDescriptor: ColabServerDescriptor = {
-  label: "Colab GPU A100",
+  label: 'Colab GPU A100',
   variant: Variant.GPU,
-  accelerator: "A100",
+  accelerator: 'A100',
 };
 
 const defaultAssignment: Assignment & { runtimeProxyInfo: RuntimeProxyInfo } = {
-  accelerator: "A100",
-  endpoint: "m-s-foo",
+  accelerator: 'A100',
+  endpoint: 'm-s-foo',
   idleTimeoutSec: 30,
   subscriptionState: SubscriptionState.UNSUBSCRIBED,
   subscriptionTier: SubscriptionTier.NONE,
   variant: Variant.GPU,
   machineShape: Shape.STANDARD,
   runtimeProxyInfo: {
-    token: "mock-token",
+    token: 'mock-token',
     tokenExpiresInSeconds: TOKEN_EXPIRY_MS / 1000,
-    url: "https://example.com",
+    url: 'https://example.com',
   },
 };
 
-describe("AssignmentManager", () => {
+describe('AssignmentManager', () => {
   let fakeClock: SinonFakeTimers;
   let vsCodeStub: VsCodeStub;
   let colabClientStub: SinonStubbedInstance<ColabClient>;
@@ -91,7 +91,7 @@ describe("AssignmentManager", () => {
         (a): Assignment => ({
           ...defaultAssignment,
           variant: a.variant,
-          accelerator: a.accelerator ?? "NONE",
+          accelerator: a.accelerator ?? 'NONE',
         }),
       ),
     );
@@ -100,7 +100,7 @@ describe("AssignmentManager", () => {
         (a): ColabAssignedServer => ({
           ...defaultServer,
           variant: a.variant,
-          accelerator: a.accelerator ?? "NONE",
+          accelerator: a.accelerator ?? 'NONE',
           label: a.label,
         }),
       ),
@@ -142,15 +142,15 @@ describe("AssignmentManager", () => {
     sinon.restore();
   });
 
-  describe("getAvailableServerDescriptors", () => {
-    it("returns the default CPU and the eligible servers", async () => {
+  describe('getAvailableServerDescriptors', () => {
+    it('returns the default CPU and the eligible servers', async () => {
       colabClientStub.getCcuInfo.resolves({
         currentBalance: 1,
         consumptionRateHourly: 2,
         assignmentsCount: 0,
-        eligibleGpus: ["T4", "A100"],
+        eligibleGpus: ['T4', 'A100'],
         ineligibleGpus: [],
-        eligibleTpus: ["V5E1", "V6E1"],
+        eligibleTpus: ['V5E1', 'V6E1'],
         ineligibleTpus: [],
         freeCcuQuotaInfo: {
           remainingTokens: 4,
@@ -163,31 +163,31 @@ describe("AssignmentManager", () => {
       expect(servers).to.deep.equal([
         DEFAULT_CPU_SERVER,
         {
-          label: "Colab GPU T4",
+          label: 'Colab GPU T4',
           variant: Variant.GPU,
-          accelerator: "T4",
+          accelerator: 'T4',
         },
         {
-          label: "Colab GPU A100",
+          label: 'Colab GPU A100',
           variant: Variant.GPU,
-          accelerator: "A100",
+          accelerator: 'A100',
         },
         {
-          label: "Colab TPU V5E1",
+          label: 'Colab TPU V5E1',
           variant: Variant.TPU,
-          accelerator: "V5E1",
+          accelerator: 'V5E1',
         },
         {
-          label: "Colab TPU V6E1",
+          label: 'Colab TPU V6E1',
           variant: Variant.TPU,
-          accelerator: "V6E1",
+          accelerator: 'V6E1',
         },
       ]);
     });
   });
 
-  describe("reconcileAssignedServers", () => {
-    it("does nothing when there are no stored servers", async () => {
+  describe('reconcileAssignedServers', () => {
+    it('does nothing when there are no stored servers', async () => {
       await assignmentManager.reconcileAssignedServers();
 
       sinon.assert.notCalled(vsCodeStub.commands.executeCommand);
@@ -195,7 +195,7 @@ describe("AssignmentManager", () => {
       sinon.assert.notCalled(vsCodeStub.window.showInformationMessage);
     });
 
-    it("does nothing when no servers need reconciling", async () => {
+    it('does nothing when no servers need reconciling', async () => {
       await serverStorage.store([defaultServer]);
       colabClientStub.listAssignments.resolves([defaultAssignment]);
 
@@ -206,13 +206,13 @@ describe("AssignmentManager", () => {
       sinon.assert.notCalled(vsCodeStub.window.showInformationMessage);
     });
 
-    it("reconciles a single assigned server when it is the only one", async () => {
+    it('reconciles a single assigned server when it is the only one', async () => {
       await serverStorage.store([defaultServer]);
       colabClientStub.listAssignments.resolves([]);
 
       await assignmentManager.reconcileAssignedServers();
 
-      await expect(assignmentManager.getServers("extension")).to.eventually.be
+      await expect(assignmentManager.getServers('extension')).to.eventually.be
         .empty;
       sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
         added: [],
@@ -225,7 +225,7 @@ describe("AssignmentManager", () => {
       );
     });
 
-    describe("with multiple servers", () => {
+    describe('with multiple servers', () => {
       let servers: [ColabAssignedServer, ColabAssignedServer];
       let assignments: [Assignment, Assignment];
 
@@ -234,12 +234,12 @@ describe("AssignmentManager", () => {
           defaultServer,
           {
             ...defaultServer,
-            label: "Second Server",
+            label: 'Second Server',
             id: randomUUID(),
-            endpoint: "m-s-bar",
+            endpoint: 'm-s-bar',
             connectionInformation: {
               ...defaultServer.connectionInformation,
-              baseUrl: vsCodeStub.Uri.parse("https://example2.com"),
+              baseUrl: vsCodeStub.Uri.parse('https://example2.com'),
             },
           },
         ];
@@ -247,7 +247,7 @@ describe("AssignmentManager", () => {
           defaultAssignment,
           {
             ...defaultAssignment,
-            endpoint: "m-s-bar",
+            endpoint: 'm-s-bar',
             runtimeProxyInfo: {
               ...defaultAssignment.runtimeProxyInfo,
               url: servers[1].connectionInformation.baseUrl.toString(),
@@ -256,13 +256,13 @@ describe("AssignmentManager", () => {
         ];
       });
 
-      it("reconciles a single assigned server when there are others", async () => {
+      it('reconciles a single assigned server when there are others', async () => {
         await serverStorage.store(servers);
         colabClientStub.listAssignments.resolves([assignments[0]]);
 
         await assignmentManager.reconcileAssignedServers();
 
-        const serversAfter = await assignmentManager.getServers("extension");
+        const serversAfter = await assignmentManager.getServers('extension');
         expect(stripFetches(serversAfter)).to.deep.equal([servers[0]]);
         sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
           added: [],
@@ -275,17 +275,17 @@ describe("AssignmentManager", () => {
         );
       });
 
-      it("reconciles multiple assigned servers when all need reconciling", async () => {
+      it('reconciles multiple assigned servers when all need reconciling', async () => {
         const threeServers = [
           ...servers,
-          { ...defaultServer, label: "Third Server" },
+          { ...defaultServer, label: 'Third Server' },
         ];
         await serverStorage.store(threeServers);
         colabClientStub.listAssignments.resolves([]);
 
         await assignmentManager.reconcileAssignedServers();
 
-        await expect(assignmentManager.getServers("extension")).to.eventually.be
+        await expect(assignmentManager.getServers('extension')).to.eventually.be
           .empty;
         sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
           added: [],
@@ -303,15 +303,15 @@ describe("AssignmentManager", () => {
         );
       });
 
-      it("reconciles multiple assigned servers when some need reconciling", async () => {
+      it('reconciles multiple assigned servers when some need reconciling', async () => {
         const thirdServer: ColabAssignedServer = {
           ...defaultServer,
-          label: "Third Server",
+          label: 'Third Server',
           id: randomUUID(),
-          endpoint: "m-s-baz",
+          endpoint: 'm-s-baz',
           connectionInformation: {
             ...defaultServer.connectionInformation,
-            baseUrl: vsCodeStub.Uri.parse("https://example3.com"),
+            baseUrl: vsCodeStub.Uri.parse('https://example3.com'),
           },
         };
         const twoServers = servers;
@@ -321,7 +321,7 @@ describe("AssignmentManager", () => {
 
         await assignmentManager.reconcileAssignedServers();
 
-        const serversAfter = await assignmentManager.getServers("extension");
+        const serversAfter = await assignmentManager.getServers('extension');
         expect(stripFetches(serversAfter)).to.deep.equal([
           servers[0],
           servers[1],
@@ -337,21 +337,21 @@ describe("AssignmentManager", () => {
         );
       });
 
-      it("reconciles ignoring assignments originating out of VS Code", async () => {
+      it('reconciles ignoring assignments originating out of VS Code', async () => {
         await serverStorage.store(servers);
         const colabAssignment: Assignment = {
           ...defaultAssignment,
-          endpoint: "m-s-baz",
+          endpoint: 'm-s-baz',
           runtimeProxyInfo: {
             ...defaultAssignment.runtimeProxyInfo,
-            url: "https://not-from-vs-code.com",
+            url: 'https://not-from-vs-code.com',
           },
         };
         colabClientStub.listAssignments.resolves([colabAssignment]);
 
         await assignmentManager.reconcileAssignedServers();
 
-        await expect(assignmentManager.getServers("extension")).to.eventually.be
+        await expect(assignmentManager.getServers('extension')).to.eventually.be
           .empty;
         sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
           added: [],
@@ -366,15 +366,15 @@ describe("AssignmentManager", () => {
     });
   });
 
-  describe("hasAssignedServers", () => {
-    it("returns false when no servers are assigned", async () => {
+  describe('hasAssignedServers', () => {
+    it('returns false when no servers are assigned', async () => {
       colabClientStub.listAssignments.resolves([]);
 
       await expect(assignmentManager.hasAssignedServer()).to.eventually.be
         .false;
     });
 
-    it("returns true when at least one server is assigned", async () => {
+    it('returns true when at least one server is assigned', async () => {
       colabClientStub.listAssignments.resolves([defaultAssignment]);
       await serverStorage.store([defaultServer]);
       await setupAssignments([defaultAssignmentDescriptor]);
@@ -382,8 +382,8 @@ describe("AssignmentManager", () => {
       await expect(assignmentManager.hasAssignedServer()).to.eventually.be.true;
     });
 
-    it("returns true when multiple servers are assigned", async () => {
-      const secondEndpoint = "m-s-foo";
+    it('returns true when multiple servers are assigned', async () => {
+      const secondEndpoint = 'm-s-foo';
       colabClientStub.listAssignments.resolves([
         defaultAssignment,
         { ...defaultAssignment, endpoint: secondEndpoint },
@@ -397,61 +397,61 @@ describe("AssignmentManager", () => {
     });
   });
 
-  describe("getServers", () => {
-    describe("from extension", () => {
-      it("returns an empty list when no servers are assigned", async () => {
-        const servers = await assignmentManager.getServers("extension");
+  describe('getServers', () => {
+    describe('from extension', () => {
+      it('returns an empty list when no servers are assigned', async () => {
+        const servers = await assignmentManager.getServers('extension');
 
         expect(servers).to.deep.equal([]);
       });
 
-      describe("when a server is assigned", () => {
+      describe('when a server is assigned', () => {
         beforeEach(async () => {
           colabClientStub.listAssignments.resolves([defaultAssignment]);
           await serverStorage.store([defaultServer]);
         });
 
-        it("returns the assigned server when there is one", async () => {
-          const servers = await assignmentManager.getServers("extension");
+        it('returns the assigned server when there is one', async () => {
+          const servers = await assignmentManager.getServers('extension');
 
           expect(stripFetches(servers)).to.deep.equal([defaultServer]);
         });
 
-        it("returns multiple assigned servers when there are some", async () => {
+        it('returns multiple assigned servers when there are some', async () => {
           const storedServers = [
             { ...defaultServer, id: randomUUID() },
             { ...defaultServer, id: randomUUID() },
           ];
           await serverStorage.store(storedServers);
 
-          const servers = await assignmentManager.getServers("extension");
+          const servers = await assignmentManager.getServers('extension');
 
           expect(stripFetches(servers)).to.deep.equal(storedServers);
         });
 
-        it("reconciles assigned servers before returning", async () => {
+        it('reconciles assigned servers before returning', async () => {
           colabClientStub.listAssignments.resolves([defaultAssignment]);
           const noLongerAssignedServer = {
             ...defaultServer,
-            endpoint: "no-longer-assigned",
+            endpoint: 'no-longer-assigned',
           };
           await serverStorage.store([defaultServer, noLongerAssignedServer]);
 
-          const results = await assignmentManager.getServers("extension");
+          const results = await assignmentManager.getServers('extension');
 
           expect(stripFetches(results)).to.deep.equal([defaultServer]);
         });
 
-        it("includes a fetch implementation that attaches Colab connection info", async () => {
-          const servers = await assignmentManager.getServers("extension");
+        it('includes a fetch implementation that attaches Colab connection info', async () => {
+          const servers = await assignmentManager.getServers('extension');
           assert.lengthOf(servers, 1);
           const server = servers[0];
           assert.isDefined(server.connectionInformation.fetch);
-          const fetchStub = sinon.stub(fetch, "default");
+          const fetchStub = sinon.stub(fetch, 'default');
 
-          await server.connectionInformation.fetch("https://example.com");
+          await server.connectionInformation.fetch('https://example.com');
 
-          sinon.assert.calledOnceWithMatch(fetchStub, "https://example.com", {
+          sinon.assert.calledOnceWithMatch(fetchStub, 'https://example.com', {
             headers: new Headers({
               [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
                 server.connectionInformation.token,
@@ -462,42 +462,42 @@ describe("AssignmentManager", () => {
       });
     });
 
-    const endpointWithName = "test-endpoint-with-name";
-    const endpointWithoutName = "test-endpoint-without-name";
-    const endpointWithoutSession = "test-endpoint-without-session";
+    const endpointWithName = 'test-endpoint-with-name';
+    const endpointWithoutName = 'test-endpoint-without-name';
+    const endpointWithoutSession = 'test-endpoint-without-session';
     const assignmentWithName = {
       endpoint: endpointWithName,
       variant: Variant.DEFAULT,
       machineShape: Shape.STANDARD,
-      accelerator: "",
+      accelerator: '',
     };
     const assignmentWithoutName = {
       endpoint: endpointWithoutName,
       variant: Variant.DEFAULT,
       machineShape: Shape.STANDARD,
-      accelerator: "",
+      accelerator: '',
     };
     const assignmentWithoutSession = {
       endpoint: endpointWithoutSession,
       variant: Variant.DEFAULT,
       machineShape: Shape.STANDARD,
-      accelerator: "",
+      accelerator: '',
     };
     const defaultSession = {
-      id: "",
-      path: "",
-      type: "",
+      id: '',
+      path: '',
+      type: '',
       kernel: {
-        lastActivity: "",
-        executionState: "",
-        id: "",
-        name: "",
+        lastActivity: '',
+        executionState: '',
+        id: '',
+        name: '',
         connections: 1,
       },
     };
 
-    describe("from external", () => {
-      it("returns unowned servers", async () => {
+    describe('from external', () => {
+      it('returns unowned servers', async () => {
         // Given 3 total assignments
         colabClientStub.listAssignments.resolves([
           assignmentWithName,
@@ -507,7 +507,7 @@ describe("AssignmentManager", () => {
         colabClientStub.listSessions.withArgs(endpointWithName).resolves([
           {
             ...defaultSession,
-            name: "test-session-name",
+            name: 'test-session-name',
           },
         ]);
         colabClientStub.listSessions
@@ -521,28 +521,28 @@ describe("AssignmentManager", () => {
         await serverStorage.store([assignedServer]);
 
         // When we get servers from external
-        const results = await assignmentManager.getServers("external");
+        const results = await assignmentManager.getServers('external');
 
         // Then only 2 unowned external servers are returned
         expect(results).to.deep.equal([
           {
-            label: "test-session-name",
+            label: 'test-session-name',
             endpoint: endpointWithName,
             variant: Variant.DEFAULT,
-            accelerator: "",
+            accelerator: '',
           },
           {
-            label: "Untitled",
+            label: 'Untitled',
             endpoint: endpointWithoutSession,
             variant: Variant.DEFAULT,
-            accelerator: "",
+            accelerator: '',
           },
         ]);
       });
     });
 
-    describe("from all", () => {
-      it("returns both assigned and unowned servers", async () => {
+    describe('from all', () => {
+      it('returns both assigned and unowned servers', async () => {
         // Given 3 total assignments
         colabClientStub.listAssignments.resolves([
           assignmentWithName,
@@ -552,7 +552,7 @@ describe("AssignmentManager", () => {
         colabClientStub.listSessions.withArgs(endpointWithName).resolves([
           {
             ...defaultSession,
-            name: "test-session-name",
+            name: 'test-session-name',
           },
         ]);
         colabClientStub.listSessions
@@ -566,7 +566,7 @@ describe("AssignmentManager", () => {
         await serverStorage.store([assignedServer]);
 
         // When we get servers from all
-        const results = await assignmentManager.getServers("all");
+        const results = await assignmentManager.getServers('all');
 
         // Then 1 assigned server and 2 unowned servers are returned
         expect(stripFetches([...results.assigned])).to.deep.equal([
@@ -574,21 +574,21 @@ describe("AssignmentManager", () => {
         ]);
         expect(results.unowned).to.deep.equal([
           {
-            label: "test-session-name",
+            label: 'test-session-name',
             endpoint: endpointWithName,
             variant: Variant.DEFAULT,
-            accelerator: "",
+            accelerator: '',
           },
           {
-            label: "Untitled",
+            label: 'Untitled',
             endpoint: endpointWithoutSession,
             variant: Variant.DEFAULT,
-            accelerator: "",
+            accelerator: '',
           },
         ]);
       });
 
-      it("returns only unowned servers when no server is assigned in VS Code", async () => {
+      it('returns only unowned servers when no server is assigned in VS Code', async () => {
         colabClientStub.listAssignments.resolves([
           assignmentWithName,
           assignmentWithoutName,
@@ -597,13 +597,13 @@ describe("AssignmentManager", () => {
         colabClientStub.listSessions.withArgs(endpointWithName).resolves([
           {
             ...defaultSession,
-            name: "test-session-name",
+            name: 'test-session-name',
           },
         ]);
         colabClientStub.listSessions.withArgs(endpointWithoutName).resolves([
           {
             ...defaultSession,
-            name: "",
+            name: '',
           },
         ]);
         colabClientStub.listSessions
@@ -611,34 +611,34 @@ describe("AssignmentManager", () => {
           .resolves([]);
         await serverStorage.store([]);
 
-        const results = await assignmentManager.getServers("all");
+        const results = await assignmentManager.getServers('all');
 
         expect(results).to.deep.equal({
           assigned: [],
           unowned: [
             {
-              label: "test-session-name",
+              label: 'test-session-name',
               endpoint: endpointWithName,
               variant: Variant.DEFAULT,
-              accelerator: "",
+              accelerator: '',
             },
             {
-              label: "Untitled",
+              label: 'Untitled',
               endpoint: endpointWithoutName,
               variant: Variant.DEFAULT,
-              accelerator: "",
+              accelerator: '',
             },
             {
-              label: "Untitled",
+              label: 'Untitled',
               endpoint: endpointWithoutSession,
               variant: Variant.DEFAULT,
-              accelerator: "",
+              accelerator: '',
             },
           ],
         });
       });
 
-      it("returns only assigned servers when no server is unowned", async () => {
+      it('returns only assigned servers when no server is unowned', async () => {
         colabClientStub.listAssignments.resolves([
           assignmentWithName,
           assignmentWithoutName,
@@ -662,7 +662,7 @@ describe("AssignmentManager", () => {
           assignedServer3,
         ]);
 
-        const results = await assignmentManager.getServers("all");
+        const results = await assignmentManager.getServers('all');
 
         expect(stripFetches([...results.assigned])).to.deep.equal([
           assignedServer1,
@@ -672,7 +672,7 @@ describe("AssignmentManager", () => {
         expect(results.unowned).to.be.empty;
       });
 
-      it("reconciles assigned servers before returning", async () => {
+      it('reconciles assigned servers before returning', async () => {
         colabClientStub.listAssignments.resolves([assignmentWithName]);
         const assignedServer = {
           ...defaultServer,
@@ -680,11 +680,11 @@ describe("AssignmentManager", () => {
         };
         const noLongerAssignedServer = {
           ...defaultServer,
-          endpoint: "no-longer-assigned",
+          endpoint: 'no-longer-assigned',
         };
         await serverStorage.store([assignedServer, noLongerAssignedServer]);
 
-        const results = await assignmentManager.getServers("all");
+        const results = await assignmentManager.getServers('all');
 
         expect(stripFetches([...results.assigned])).to.deep.equal([
           assignedServer,
@@ -693,14 +693,14 @@ describe("AssignmentManager", () => {
     });
   });
 
-  describe("getLastKnownAssignedServers", () => {
-    it("returns an empty list when there are no stored servers", async () => {
+  describe('getLastKnownAssignedServers', () => {
+    it('returns an empty list when there are no stored servers', async () => {
       expect(
         await assignmentManager.getLastKnownAssignedServers(),
       ).to.deep.equal([]);
     });
 
-    it("returns all stored servers with connection info omitted", async () => {
+    it('returns all stored servers with connection info omitted', async () => {
       const storedServers = [
         { ...defaultServer, id: randomUUID() },
         { ...defaultServer, id: randomUUID() },
@@ -730,8 +730,8 @@ describe("AssignmentManager", () => {
     });
   });
 
-  describe("assignServer", () => {
-    it("throws an error when the assignment does not include a URL to connect to", () => {
+  describe('assignServer', () => {
+    it('throws an error when the assignment does not include a URL to connect to', () => {
       colabClientStub.assign
         .withArgs(
           sinon.match(isUUID),
@@ -743,7 +743,7 @@ describe("AssignmentManager", () => {
             ...defaultAssignment,
             runtimeProxyInfo: {
               ...defaultAssignment.runtimeProxyInfo,
-              url: "",
+              url: '',
             },
           },
           isNew: false,
@@ -754,7 +754,7 @@ describe("AssignmentManager", () => {
       ).to.be.rejectedWith(/connection info/);
     });
 
-    it("throws an error when the assignment does not include a token to connect with", () => {
+    it('throws an error when the assignment does not include a token to connect with', () => {
       colabClientStub.assign
         .withArgs(
           sinon.match(isUUID),
@@ -766,7 +766,7 @@ describe("AssignmentManager", () => {
             ...defaultAssignment,
             runtimeProxyInfo: {
               ...defaultAssignment.runtimeProxyInfo,
-              token: "",
+              token: '',
             },
           },
           isNew: false,
@@ -777,7 +777,7 @@ describe("AssignmentManager", () => {
       ).to.be.rejectedWith(/connection info/);
     });
 
-    describe("when a server is assigned", () => {
+    describe('when a server is assigned', () => {
       let assignedServer: ColabAssignedServer;
 
       beforeEach(async () => {
@@ -796,14 +796,14 @@ describe("AssignmentManager", () => {
         );
       });
 
-      it("stores and returns the server", () => {
+      it('stores and returns the server', () => {
         const { id: assignedId, ...got } = stripFetch(assignedServer);
         const { id: defaultId, ...want } = defaultServer;
         expect(got).to.deep.equal(want);
         expect(assignedId).to.satisfy(isUUID);
       });
 
-      it("emits an assignment change event", () => {
+      it('emits an assignment change event', () => {
         const { id: defaultId, ...want } = defaultServer;
         sinon.assert.calledOnceWithMatch(assignmentChangeListener, {
           added: [sinon.match(want)],
@@ -812,13 +812,13 @@ describe("AssignmentManager", () => {
         });
       });
 
-      it("includes a fetch implementation that attaches Colab connection info", async () => {
+      it('includes a fetch implementation that attaches Colab connection info', async () => {
         assert.isDefined(assignedServer.connectionInformation.fetch);
-        const fetchStub = sinon.stub(fetch, "default");
+        const fetchStub = sinon.stub(fetch, 'default');
 
-        await assignedServer.connectionInformation.fetch("https://example.com");
+        await assignedServer.connectionInformation.fetch('https://example.com');
 
-        sinon.assert.calledOnceWithMatch(fetchStub, "https://example.com", {
+        sinon.assert.calledOnceWithMatch(fetchStub, 'https://example.com', {
           headers: new Headers({
             [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
               assignedServer.connectionInformation.token,
@@ -828,12 +828,12 @@ describe("AssignmentManager", () => {
       });
     });
 
-    describe("with too many assigned servers", () => {
+    describe('with too many assigned servers', () => {
       beforeEach(() => {
         colabClientStub.assign.rejects(new TooManyAssignmentsError());
       });
 
-      it("notifies the user", async () => {
+      it('notifies the user', async () => {
         await expect(
           assignmentManager.assignServer(defaultAssignmentDescriptor),
         ).to.eventually.be.rejectedWith(TooManyAssignmentsError);
@@ -844,9 +844,9 @@ describe("AssignmentManager", () => {
         );
       });
 
-      it("presents an action to remove servers", async () => {
+      it('presents an action to remove servers', async () => {
         (vsCodeStub.window.showErrorMessage as sinon.SinonStub).resolves(
-          "Remove Server",
+          'Remove Server',
         );
 
         await expect(
@@ -860,12 +860,12 @@ describe("AssignmentManager", () => {
       });
     });
 
-    describe("with insufficient quota", () => {
+    describe('with insufficient quota', () => {
       beforeEach(() => {
-        colabClientStub.assign.rejects(new InsufficientQuotaError("💰🐖"));
+        colabClientStub.assign.rejects(new InsufficientQuotaError('💰🐖'));
       });
 
-      it("notifies the user", async () => {
+      it('notifies the user', async () => {
         await expect(
           assignmentManager.assignServer(defaultAssignmentDescriptor),
         ).to.eventually.be.rejectedWith(InsufficientQuotaError);
@@ -876,10 +876,10 @@ describe("AssignmentManager", () => {
         );
       });
 
-      it("presents an action to learn more", async () => {
-        sinon.stub(assignmentManager, "hasAssignedServer").resolves(false);
+      it('presents an action to learn more', async () => {
+        sinon.stub(assignmentManager, 'hasAssignedServer').resolves(false);
         (vsCodeStub.window.showErrorMessage as sinon.SinonStub).resolves(
-          "Learn More",
+          'Learn More',
         );
 
         await expect(
@@ -891,19 +891,19 @@ describe("AssignmentManager", () => {
           sinon.match(function (url: Uri) {
             return (
               url.toString() ===
-              "https://research.google.com/colaboratory/faq.html#resource-limits"
+              'https://research.google.com/colaboratory/faq.html#resource-limits'
             );
           }),
         );
       });
     });
 
-    describe("when the user is banned", () => {
+    describe('when the user is banned', () => {
       beforeEach(() => {
-        colabClientStub.assign.rejects(new DenylistedError("👨‍⚖️"));
+        colabClientStub.assign.rejects(new DenylistedError('👨‍⚖️'));
       });
 
-      it("notifies the user", async () => {
+      it('notifies the user', async () => {
         await expect(
           assignmentManager.assignServer(defaultAssignmentDescriptor),
         ).to.eventually.be.rejectedWith(DenylistedError);
@@ -916,8 +916,8 @@ describe("AssignmentManager", () => {
     });
   });
 
-  describe("unassignServer", () => {
-    it("does nothing when the server does not exist", async () => {
+  describe('unassignServer', () => {
+    it('does nothing when the server does not exist', async () => {
       await assignmentManager.unassignServer(defaultServer);
 
       sinon.assert.notCalled(colabClientStub.unassign);
@@ -925,28 +925,28 @@ describe("AssignmentManager", () => {
       sinon.assert.notCalled(assignmentChangeListener);
     });
 
-    describe("when a server created in VS Code exists", () => {
+    describe('when a server created in VS Code exists', () => {
       beforeEach(async () => {
         await serverStorage.store([defaultServer]);
       });
 
-      it("deletes sessions", async () => {
+      it('deletes sessions', async () => {
         const session1 = {
-          id: "mock-session-id-1",
+          id: 'mock-session-id-1',
           kernel: {
-            id: "mock-kernel-id",
-            name: "mock-kernel-name",
+            id: 'mock-kernel-id',
+            name: 'mock-kernel-name',
             lastActivity: new Date().toISOString(),
-            executionState: "idle",
+            executionState: 'idle',
             connections: 1,
           },
-          name: "mock-session-name",
-          path: "mock-path",
-          type: "notebook",
+          name: 'mock-session-name',
+          path: 'mock-path',
+          type: 'notebook',
         };
         const session2 = {
           ...session1,
-          id: "mock-session-id-2",
+          id: 'mock-session-id-2',
         };
         colabClientStub.listSessions
           .withArgs(defaultServer)
@@ -967,7 +967,7 @@ describe("AssignmentManager", () => {
         );
       });
 
-      it("does not delete sessions when there are none", async () => {
+      it('does not delete sessions when there are none', async () => {
         colabClientStub.listSessions.resolves([]);
 
         await assignmentManager.unassignServer(defaultServer);
@@ -975,12 +975,12 @@ describe("AssignmentManager", () => {
         sinon.assert.notCalled(colabClientStub.deleteSession);
       });
 
-      it("unassigns the server", async () => {
+      it('unassigns the server', async () => {
         colabClientStub.listSessions.resolves([]);
 
         await assignmentManager.unassignServer(defaultServer);
 
-        const serversAfter = await assignmentManager.getServers("extension");
+        const serversAfter = await assignmentManager.getServers('extension');
         expect(serversAfter).to.be.empty;
         sinon.assert.calledOnceWithMatch(
           colabClientStub.unassign,
@@ -998,11 +998,11 @@ describe("AssignmentManager", () => {
       });
     });
 
-    describe("when an unowned server exists", () => {
-      it("unassigns the server", async () => {
+    describe('when an unowned server exists', () => {
+      it('unassigns the server', async () => {
         const remoteServer = {
-          endpoint: "test-endpoint",
-          label: "name",
+          endpoint: 'test-endpoint',
+          label: 'name',
           variant: Variant.DEFAULT,
         };
 
@@ -1016,19 +1016,19 @@ describe("AssignmentManager", () => {
     });
   });
 
-  describe("latestOrAutoAssignServer", () => {
-    it("assigns a new default server when none have been assigned", async () => {
+  describe('latestOrAutoAssignServer', () => {
+    it('assigns a new default server when none have been assigned', async () => {
       colabClientStub.listAssignments.resolves([]);
       const defaultCpuAssignment = {
         ...defaultAssignment,
         variant: Variant.DEFAULT,
-        accelerator: "NONE",
+        accelerator: 'NONE',
       };
       const defaultCpuServer = {
         ...defaultServer,
         variant: Variant.DEFAULT,
-        accelerator: "NONE",
-        label: "Colab CPU",
+        accelerator: 'NONE',
+        label: 'Colab CPU',
       };
       colabClientStub.assign
         .withArgs(sinon.match(isUUID), Variant.DEFAULT)
@@ -1041,13 +1041,13 @@ describe("AssignmentManager", () => {
       expect(got).to.deep.equal(want);
     });
 
-    it("reconciles servers before resolving", async () => {
+    it('reconciles servers before resolving', async () => {
       const deadServer = defaultServer;
       const olderActiveServer: ColabAssignedServer = {
         ...defaultServer,
         id: randomUUID(),
-        endpoint: "m-s-bar",
-        label: "Older server",
+        endpoint: 'm-s-bar',
+        label: 'Older server',
         dateAssigned: new Date(NOW.getTime() - 10000),
       };
       const olderActiveAssignment: Assignment = {
@@ -1063,21 +1063,21 @@ describe("AssignmentManager", () => {
     });
   });
 
-  describe("latestServer", () => {
-    it("returns undefined when none have been assigned", async () => {
+  describe('latestServer', () => {
+    it('returns undefined when none have been assigned', async () => {
       colabClientStub.listAssignments.resolves([]);
 
       const server = await assignmentManager.latestServer();
       expect(server).to.equal(undefined);
     });
 
-    it("reconciles servers before resolving", async () => {
+    it('reconciles servers before resolving', async () => {
       const deadServer = defaultServer;
       const olderActiveServer: ColabAssignedServer = {
         ...defaultServer,
         id: randomUUID(),
-        endpoint: "m-s-bar",
-        label: "Older server",
+        endpoint: 'm-s-bar',
+        label: 'Older server',
         dateAssigned: new Date(NOW.getTime() - 10000),
       };
       const olderActiveAssignment: Assignment = {
@@ -1095,15 +1095,15 @@ describe("AssignmentManager", () => {
     });
   });
 
-  describe("refreshConnection", () => {
+  describe('refreshConnection', () => {
     it("throws a not found error when refreshing a server that's not tracked", async () => {
       await expect(
         assignmentManager.refreshConnection(defaultServer.id),
       ).to.eventually.be.rejectedWith(NotFoundError);
     });
 
-    describe("with a refreshed connection", () => {
-      const newToken = "new-token";
+    describe('with a refreshed connection', () => {
+      const newToken = 'new-token';
       let refreshedServer: ColabAssignedServer;
 
       beforeEach(async () => {
@@ -1121,7 +1121,7 @@ describe("AssignmentManager", () => {
         );
       });
 
-      it("stores and returns the server with updated connection info", () => {
+      it('stores and returns the server with updated connection info', () => {
         const expectedServer: ColabAssignedServer = {
           ...defaultServer,
           connectionInformation: {
@@ -1136,15 +1136,15 @@ describe("AssignmentManager", () => {
         expect(stripFetch(refreshedServer)).to.deep.equal(expectedServer);
       });
 
-      it("includes a fetch implementation that attaches Colab connection info", async () => {
+      it('includes a fetch implementation that attaches Colab connection info', async () => {
         assert.isDefined(refreshedServer.connectionInformation.fetch);
-        const fetchStub = sinon.stub(fetch, "default");
+        const fetchStub = sinon.stub(fetch, 'default');
 
         await refreshedServer.connectionInformation.fetch(
-          "https://example.com",
+          'https://example.com',
         );
 
-        sinon.assert.calledOnceWithMatch(fetchStub, "https://example.com", {
+        sinon.assert.calledOnceWithMatch(fetchStub, 'https://example.com', {
           headers: new Headers({
             [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
               refreshedServer.connectionInformation.token,
@@ -1153,7 +1153,7 @@ describe("AssignmentManager", () => {
         });
       });
 
-      it("emits an assignment change event", () => {
+      it('emits an assignment change event', () => {
         sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
           added: [],
           removed: [],
@@ -1163,67 +1163,67 @@ describe("AssignmentManager", () => {
     });
   });
 
-  describe("getDefaultLabel", () => {
-    it("returns a simple variant-accelerator pair when there are no assigned servers", async () => {
+  describe('getDefaultLabel', () => {
+    it('returns a simple variant-accelerator pair when there are no assigned servers', async () => {
       await expect(
-        assignmentManager.getDefaultLabel(Variant.GPU, "A100"),
-      ).to.eventually.equal("Colab GPU A100");
+        assignmentManager.getDefaultLabel(Variant.GPU, 'A100'),
+      ).to.eventually.equal('Colab GPU A100');
     });
 
-    it("returns a simple variant-accelerator pair when there are only custom aliased servers", async () => {
+    it('returns a simple variant-accelerator pair when there are only custom aliased servers', async () => {
       const variant = Variant.GPU;
-      const accelerator = "A100";
-      await setupAssignments([{ variant, accelerator, label: "foo" }]);
+      const accelerator = 'A100';
+      await setupAssignments([{ variant, accelerator, label: 'foo' }]);
 
       await expect(
         assignmentManager.getDefaultLabel(variant, accelerator),
-      ).to.eventually.equal("Colab GPU A100");
+      ).to.eventually.equal('Colab GPU A100');
     });
 
-    it("returns the next sequential label with one matching assigned server", async () => {
+    it('returns the next sequential label with one matching assigned server', async () => {
       const variant = Variant.GPU;
-      const accelerator = "A100";
+      const accelerator = 'A100';
       await setupAssignments([
-        { variant, accelerator, label: "Colab GPU A100" },
+        { variant, accelerator, label: 'Colab GPU A100' },
       ]);
 
       await expect(
         assignmentManager.getDefaultLabel(variant, accelerator),
-      ).to.eventually.equal("Colab GPU A100 (1)");
+      ).to.eventually.equal('Colab GPU A100 (1)');
     });
 
-    it("returns the next sequential label with multiple assigned servers", async () => {
+    it('returns the next sequential label with multiple assigned servers', async () => {
       const variant = Variant.GPU;
-      const accelerator = "A100";
+      const accelerator = 'A100';
       await setupAssignments([
-        { variant, accelerator, label: "Colab GPU A100" },
-        { variant, accelerator, label: "Colab GPU A100 (1)" },
+        { variant, accelerator, label: 'Colab GPU A100' },
+        { variant, accelerator, label: 'Colab GPU A100 (1)' },
       ]);
 
       await expect(
         assignmentManager.getDefaultLabel(variant, accelerator),
-      ).to.eventually.equal("Colab GPU A100 (2)");
+      ).to.eventually.equal('Colab GPU A100 (2)');
     });
 
-    it("only increments from matching variant-accelerator server pairs", async () => {
+    it('only increments from matching variant-accelerator server pairs', async () => {
       await setupAssignments([
-        { variant: Variant.DEFAULT, label: "Colab CPU" },
+        { variant: Variant.DEFAULT, label: 'Colab CPU' },
         {
           variant: Variant.GPU,
-          accelerator: "A100",
-          label: "Colab GPU A100",
+          accelerator: 'A100',
+          label: 'Colab GPU A100',
         },
       ]);
 
       await expect(
-        assignmentManager.getDefaultLabel(Variant.GPU, "A100"),
-      ).to.eventually.equal("Colab GPU A100 (1)");
+        assignmentManager.getDefaultLabel(Variant.GPU, 'A100'),
+      ).to.eventually.equal('Colab GPU A100 (1)');
     });
 
     // To ensure a string sort isn't used, which would put "10" before "2".
-    it("uses the next sequential label with many assigned servers", async () => {
+    it('uses the next sequential label with many assigned servers', async () => {
       const variant = Variant.GPU;
-      const accelerator = "A100";
+      const accelerator = 'A100';
       await setupAssignments(
         Array.from({ length: 10 }, (_, i) => i + 1)
           .map((i) => ({
@@ -1231,40 +1231,40 @@ describe("AssignmentManager", () => {
             accelerator,
             label: `Colab GPU A100 (${i.toString()})`,
           }))
-          .concat({ variant, accelerator, label: "Colab GPU A100" }),
+          .concat({ variant, accelerator, label: 'Colab GPU A100' }),
       );
 
       await expect(
         assignmentManager.getDefaultLabel(variant, accelerator),
-      ).to.eventually.equal("Colab GPU A100 (11)");
+      ).to.eventually.equal('Colab GPU A100 (11)');
     });
 
-    it("uses the simple variant-accelerator label when the initial assignment is missing", async () => {
+    it('uses the simple variant-accelerator label when the initial assignment is missing', async () => {
       const variant = Variant.GPU;
-      const accelerator = "A100";
+      const accelerator = 'A100';
       await setupAssignments([
-        { variant, accelerator, label: "Colab GPU A100 (2)" },
+        { variant, accelerator, label: 'Colab GPU A100 (2)' },
       ]);
 
       await expect(
         assignmentManager.getDefaultLabel(variant, accelerator),
-      ).to.eventually.equal("Colab GPU A100");
+      ).to.eventually.equal('Colab GPU A100');
     });
 
     it("uses the next sequential label when there's an assigned server gap", async () => {
       const variant = Variant.GPU;
-      const accelerator = "A100";
+      const accelerator = 'A100';
       await setupAssignments([
-        { variant, accelerator, label: "Colab GPU A100 (2)" },
-        { variant, accelerator, label: "Colab GPU A100" },
+        { variant, accelerator, label: 'Colab GPU A100 (2)' },
+        { variant, accelerator, label: 'Colab GPU A100' },
       ]);
 
       await expect(
         assignmentManager.getDefaultLabel(variant, accelerator),
-      ).to.eventually.equal("Colab GPU A100 (1)");
+      ).to.eventually.equal('Colab GPU A100 (1)');
     });
 
-    it("reconciles servers before determining label", async () => {
+    it('reconciles servers before determining label', async () => {
       colabClientStub.listAssignments.resolves([]);
       await serverStorage.store([defaultServer]);
 
@@ -1277,7 +1277,7 @@ describe("AssignmentManager", () => {
     });
   });
 
-  describe("when the notification to reload notebooks is shown", () => {
+  describe('when the notification to reload notebooks is shown', () => {
     let showInfoMessageResolver: (value: MessageItem | undefined) => void;
     let showInfoMessage: Promise<MessageItem | undefined>;
 
@@ -1296,7 +1296,7 @@ describe("AssignmentManager", () => {
         added: [],
         removed: [
           {
-            server: { ...defaultServer, label: "server A" },
+            server: { ...defaultServer, label: 'server A' },
             userInitiated: false,
           },
         ],
@@ -1304,21 +1304,21 @@ describe("AssignmentManager", () => {
       });
     });
 
-    it("opens the Jupyter Github issue when the notification is clicked", async () => {
+    it('opens the Jupyter Github issue when the notification is clicked', async () => {
       showInfoMessageResolver({
-        title: "View Issue",
+        title: 'View Issue',
       });
 
       await expect(showInfoMessage).to.eventually.be.fulfilled;
       sinon.assert.calledWithMatch(
         vsCodeStub.env.openExternal,
         vsCodeStub.Uri.parse(
-          "https://github.com/microsoft/vscode-jupyter/issues/17094",
+          'https://github.com/microsoft/vscode-jupyter/issues/17094',
         ),
       );
     });
 
-    it("does not open the Jupyter Github issue when the notification is dismissed", async () => {
+    it('does not open the Jupyter Github issue when the notification is dismissed', async () => {
       showInfoMessageResolver(undefined);
 
       await expect(showInfoMessage).to.eventually.be.fulfilled;

--- a/src/jupyter/jupyter-extension.ts
+++ b/src/jupyter/jupyter-extension.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Jupyter } from "@vscode/jupyter-extension";
-import { satisfies as semVerSatisfies } from "semver";
-import vscode, { Extension } from "vscode";
-import { getPackageInfo } from "../config/package-info";
+import { Jupyter } from '@vscode/jupyter-extension';
+import { satisfies as semVerSatisfies } from 'semver';
+import vscode, { Extension } from 'vscode';
+import { getPackageInfo } from '../config/package-info';
 
-const JUPYTER_SEMVER_RANGE = ">=2025.0.0";
+const JUPYTER_SEMVER_RANGE = '>=2025.0.0';
 
 /**
  * Get the exported API from the Jupyter extension.
@@ -17,9 +17,9 @@ const JUPYTER_SEMVER_RANGE = ">=2025.0.0";
 export async function getJupyterApi(
   vs: typeof vscode,
 ): Promise<vscode.Extension<Jupyter>> {
-  const ext = vs.extensions.getExtension<Jupyter>("ms-toolsai.jupyter");
+  const ext = vs.extensions.getExtension<Jupyter>('ms-toolsai.jupyter');
   if (!ext) {
-    throw new Error("Jupyter Extension not installed");
+    throw new Error('Jupyter Extension not installed');
   }
   validateJupyterVersion(ext);
   if (!ext.isActive) {

--- a/src/jupyter/jupyter-extension.unit.test.ts
+++ b/src/jupyter/jupyter-extension.unit.test.ts
@@ -4,21 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Jupyter } from "@vscode/jupyter-extension";
-import { expect } from "chai";
-import { SinonStub } from "sinon";
-import sinon from "sinon";
-import vscode from "vscode";
-import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
-import { getJupyterApi } from "./jupyter-extension";
+import { Jupyter } from '@vscode/jupyter-extension';
+import { expect } from 'chai';
+import { SinonStub } from 'sinon';
+import sinon from 'sinon';
+import vscode from 'vscode';
+import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
+import { getJupyterApi } from './jupyter-extension';
 
 enum ExtensionStatus {
   Active,
   Inactive,
 }
 
-describe("Jupyter Extension", () => {
-  describe("getJupyterApi", () => {
+describe('Jupyter Extension', () => {
+  describe('getJupyterApi', () => {
     let vsCodeStub: VsCodeStub;
     let activateStub: SinonStub<[], Thenable<Jupyter>>;
 
@@ -35,11 +35,11 @@ describe("Jupyter Extension", () => {
       status: ExtensionStatus = ExtensionStatus.Active,
     ): Partial<vscode.Extension<Jupyter>> {
       return {
-        id: "ms-toolsai.jupyter",
+        id: 'ms-toolsai.jupyter',
         packageJSON: {
-          publisher: "ms-toolsai",
-          name: "jupyter",
-          version: "2025.8.0",
+          publisher: 'ms-toolsai',
+          name: 'jupyter',
+          version: '2025.8.0',
         },
         isActive: status === ExtensionStatus.Active,
         activate: activateStub,
@@ -53,21 +53,21 @@ describe("Jupyter Extension", () => {
       };
     }
 
-    it("rejects if the Jupyter extension is not installed", async () => {
+    it('rejects if the Jupyter extension is not installed', async () => {
       vsCodeStub.extensions.getExtension.returns(undefined);
 
       await expect(getJupyterApi(vsCodeStub.asVsCode())).to.be.rejectedWith(
-        "Jupyter Extension not installed",
+        'Jupyter Extension not installed',
       );
       sinon.assert.notCalled(activateStub);
     });
 
-    it("rejects if the Jupyter extension version is too low", async () => {
+    it('rejects if the Jupyter extension version is too low', async () => {
       const ext = getJupyterExtension();
       vsCodeStub.extensions.getExtension.returns({
         ...ext,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        packageJSON: { ...ext.packageJSON, version: "2023.8.1002501831" },
+        packageJSON: { ...ext.packageJSON, version: '2023.8.1002501831' },
       } as vscode.Extension<Jupyter>);
 
       await expect(getJupyterApi(vsCodeStub.asVsCode())).to.be.rejectedWith(
@@ -76,7 +76,7 @@ describe("Jupyter Extension", () => {
       sinon.assert.notCalled(activateStub);
     });
 
-    it("activates the extension if it is not active", async () => {
+    it('activates the extension if it is not active', async () => {
       const ext = getJupyterExtension(ExtensionStatus.Inactive);
       vsCodeStub.extensions.getExtension.returns(
         ext as vscode.Extension<Jupyter>,
@@ -88,7 +88,7 @@ describe("Jupyter Extension", () => {
       expect(result).to.equal(ext);
     });
 
-    it("returns the extension is already active", async () => {
+    it('returns the extension is already active', async () => {
       const ext = getJupyterExtension(ExtensionStatus.Active);
       vsCodeStub.extensions.getExtension.returns(
         ext as vscode.Extension<Jupyter>,

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -11,26 +11,26 @@ import {
   JupyterServerCommand,
   JupyterServerCommandProvider,
   JupyterServerProvider,
-} from "@vscode/jupyter-extension";
-import { CancellationToken, Disposable, Event, ProviderResult } from "vscode";
-import vscode from "vscode";
-import { AuthChangeEvent } from "../auth/auth-provider";
-import { SubscriptionTier } from "../colab/api";
-import { ColabClient } from "../colab/client";
+} from '@vscode/jupyter-extension';
+import { CancellationToken, Disposable, Event, ProviderResult } from 'vscode';
+import vscode from 'vscode';
+import { AuthChangeEvent } from '../auth/auth-provider';
+import { SubscriptionTier } from '../colab/api';
+import { ColabClient } from '../colab/client';
 import {
   AUTO_CONNECT,
   NEW_SERVER,
   OPEN_COLAB_WEB,
   SIGN_IN_VIEW_EXISTING,
   UPGRADE_TO_PRO,
-} from "../colab/commands/constants";
-import { openColabSignup, openColabWeb } from "../colab/commands/external";
-import { ServerPicker } from "../colab/server-picker";
-import { LatestCancelable } from "../common/async";
-import { traceMethod } from "../common/logging/decorators";
-import { InputFlowAction } from "../common/multi-step-quickpick";
-import { isUUID } from "../utils/uuid";
-import { AssignmentChangeEvent, AssignmentManager } from "./assignments";
+} from '../colab/commands/constants';
+import { openColabSignup, openColabWeb } from '../colab/commands/external';
+import { ServerPicker } from '../colab/server-picker';
+import { LatestCancelable } from '../common/async';
+import { traceMethod } from '../common/logging/decorators';
+import { InputFlowAction } from '../common/multi-step-quickpick';
+import { isUUID } from '../utils/uuid';
+import { AssignmentChangeEvent, AssignmentManager } from './assignments';
 
 /**
  * Colab Jupyter server provider.
@@ -51,7 +51,7 @@ export class ColabJupyterServerProvider
   private isAuthorized = false;
   private authorizedListener: Disposable;
   private setServerContextRunner = new LatestCancelable(
-    "hasAssignedServer",
+    'hasAssignedServer',
     this.setHasAssignedServerContext.bind(this),
   );
 
@@ -70,8 +70,8 @@ export class ColabJupyterServerProvider
       this.handleAssignmentsChange.bind(this),
     );
     this.serverCollection = jupyter.createJupyterServerCollection(
-      "colab",
-      "Colab",
+      'colab',
+      'Colab',
       this,
     );
     this.serverCollection.commandProvider = this;
@@ -94,7 +94,7 @@ export class ColabJupyterServerProvider
     if (!this.isAuthorized) {
       return [];
     }
-    return this.assignmentManager.getServers("extension");
+    return this.assignmentManager.getServers('extension');
   }
 
   /**
@@ -106,7 +106,7 @@ export class ColabJupyterServerProvider
     _token: CancellationToken,
   ): ProviderResult<JupyterServer> {
     if (!isUUID(server.id)) {
-      throw new Error("Unexpected server ID format, expected UUID");
+      throw new Error('Unexpected server ID format, expected UUID');
     }
     return this.assignmentManager.refreshConnection(server.id);
   }
@@ -183,7 +183,7 @@ export class ColabJupyterServerProvider
           openColabSignup(this.vs);
           return;
         default:
-          throw new Error("Unexpected command");
+          throw new Error('Unexpected command');
       }
     } catch (e: unknown) {
       if (e === InputFlowAction.back) {
@@ -198,7 +198,7 @@ export class ColabJupyterServerProvider
       // Throwing a CancellationError is meant to dismiss the dialog, but it
       // doesn't. Additionally, if any other error is thrown while handling
       // commands, the quick pick is left spinning in the "busy" state.
-      await this.vs.commands.executeCommand("workbench.action.closeQuickOpen");
+      await this.vs.commands.executeCommand('workbench.action.closeQuickOpen');
       throw e;
     }
   }
@@ -225,8 +225,8 @@ export class ColabJupyterServerProvider
       ? await this.assignmentManager.hasAssignedServer(signal)
       : false;
     await this.vs.commands.executeCommand(
-      "setContext",
-      "colab.hasAssignedServer",
+      'setContext',
+      'colab.hasAssignedServer',
       value,
     );
   }

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -4,67 +4,67 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { randomUUID } from "crypto";
+import { randomUUID } from 'crypto';
 import {
   Jupyter,
   JupyterServerCollection,
   JupyterServerCommandProvider,
   JupyterServerProvider,
-} from "@vscode/jupyter-extension";
-import { assert, expect } from "chai";
-import { SinonStubbedInstance } from "sinon";
-import * as sinon from "sinon";
-import { CancellationToken, CancellationTokenSource } from "vscode";
-import { AuthChangeEvent } from "../auth/auth-provider";
-import { SubscriptionTier, Variant } from "../colab/api";
-import { ColabClient } from "../colab/client";
+} from '@vscode/jupyter-extension';
+import { assert, expect } from 'chai';
+import { SinonStubbedInstance } from 'sinon';
+import * as sinon from 'sinon';
+import { CancellationToken, CancellationTokenSource } from 'vscode';
+import { AuthChangeEvent } from '../auth/auth-provider';
+import { SubscriptionTier, Variant } from '../colab/api';
+import { ColabClient } from '../colab/client';
 import {
   AUTO_CONNECT,
   NEW_SERVER,
   OPEN_COLAB_WEB,
   SIGN_IN_VIEW_EXISTING,
   UPGRADE_TO_PRO,
-} from "../colab/commands/constants";
+} from '../colab/commands/constants';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
-} from "../colab/headers";
-import { ServerPicker } from "../colab/server-picker";
-import { InputFlowAction } from "../common/multi-step-quickpick";
-import { TestEventEmitter } from "../test/helpers/events";
-import { TestUri } from "../test/helpers/uri";
+} from '../colab/headers';
+import { ServerPicker } from '../colab/server-picker';
+import { InputFlowAction } from '../common/multi-step-quickpick';
+import { TestEventEmitter } from '../test/helpers/events';
+import { TestUri } from '../test/helpers/uri';
 import {
   newVsCodeStub as newVsCodeStub,
   VsCodeStub,
-} from "../test/helpers/vscode";
-import { AssignmentChangeEvent, AssignmentManager } from "./assignments";
-import { ColabJupyterServerProvider } from "./provider";
-import { ColabAssignedServer, ColabServerDescriptor } from "./servers";
+} from '../test/helpers/vscode';
+import { AssignmentChangeEvent, AssignmentManager } from './assignments';
+import { ColabJupyterServerProvider } from './provider';
+import { ColabAssignedServer, ColabServerDescriptor } from './servers';
 
 const DEFAULT_SERVER: ColabAssignedServer = {
   id: randomUUID(),
-  label: "Colab GPU A100",
+  label: 'Colab GPU A100',
   variant: Variant.GPU,
-  accelerator: "A100",
-  endpoint: "m-s-foo",
+  accelerator: 'A100',
+  endpoint: 'm-s-foo',
   connectionInformation: {
-    baseUrl: TestUri.parse("https://example.com"),
-    token: "123",
+    baseUrl: TestUri.parse('https://example.com'),
+    token: '123',
     tokenExpiry: new Date(Date.now() + 1000 * 60 * 60),
     headers: {
-      [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: "123",
+      [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: '123',
       [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
     },
   },
   dateAssigned: new Date(),
 };
 
-describe("ColabJupyterServerProvider", () => {
+describe('ColabJupyterServerProvider', () => {
   let vsCodeStub: VsCodeStub;
   let cancellationTokenSource: CancellationTokenSource;
   let cancellationToken: CancellationToken;
   let jupyterStub: SinonStubbedInstance<
-    Pick<Jupyter, "createJupyterServerCollection">
+    Pick<Jupyter, 'createJupyterServerCollection'>
   >;
   let serverCollectionStub: SinonStubbedInstance<JupyterServerCollection>;
   let serverCollectionDisposeStub: sinon.SinonStub<[], void>;
@@ -79,7 +79,7 @@ describe("ColabJupyterServerProvider", () => {
   function stubHasAssignedServerSet(): Promise<boolean> {
     return new Promise<boolean>((r) => {
       vsCodeStub.commands.executeCommand
-        .withArgs("setContext", "colab.hasAssignedServer")
+        .withArgs('setContext', 'colab.hasAssignedServer')
         .callsFake((_command, _context, value: boolean) => {
           r(value);
           return Promise.resolve();
@@ -133,7 +133,7 @@ describe("ColabJupyterServerProvider", () => {
       ): JupyterServerCollection => {
         if (!isJupyterServerCommandProvider(serverProvider)) {
           throw new Error(
-            "Stub expects the `serverProvider` to also be the `JupyterServerCommandProvider`",
+            'Stub expects the `serverProvider` to also be the `JupyterServerCommandProvider`',
           );
         }
         serverCollectionStub = {
@@ -148,7 +148,7 @@ describe("ColabJupyterServerProvider", () => {
     authChangeEmitter = new TestEventEmitter<AuthChangeEvent>();
 
     assignmentStub = sinon.createStubInstance(AssignmentManager);
-    Object.defineProperty(assignmentStub, "onDidAssignmentsChange", {
+    Object.defineProperty(assignmentStub, 'onDidAssignmentsChange', {
       value: sinon.stub(),
     });
     colabClientStub = sinon.createStubInstance(ColabClient);
@@ -169,17 +169,17 @@ describe("ColabJupyterServerProvider", () => {
     sinon.restore();
   });
 
-  describe("lifecycle", () => {
+  describe('lifecycle', () => {
     it('registers the "Colab" Jupyter server collection', () => {
       sinon.assert.calledOnceWithExactly(
         jupyterStub.createJupyterServerCollection,
-        "colab",
-        "Colab",
+        'colab',
+        'Colab',
         serverProvider,
       );
     });
 
-    it("disposes the auth change event listener", () => {
+    it('disposes the auth change event listener', () => {
       serverProvider.dispose();
 
       expect(authChangeEmitter.hasListeners()).to.be.false;
@@ -192,11 +192,11 @@ describe("ColabJupyterServerProvider", () => {
     });
   });
 
-  describe("provideJupyterServers", () => {
-    it("returns no servers when none are assigned", async () => {
+  describe('provideJupyterServers', () => {
+    it('returns no servers when none are assigned', async () => {
       // Type assertion needed due to overloading on getServers
       (assignmentStub.getServers as sinon.SinonStub)
-        .withArgs("extension")
+        .withArgs('extension')
         .resolves([]);
 
       const servers =
@@ -205,10 +205,10 @@ describe("ColabJupyterServerProvider", () => {
       expect(servers).to.have.lengthOf(0);
     });
 
-    it("returns a single server when one is assigned", async () => {
+    it('returns a single server when one is assigned', async () => {
       // Type assertion needed due to overloading on getServers
       (assignmentStub.getServers as sinon.SinonStub)
-        .withArgs("extension")
+        .withArgs('extension')
         .resolves([DEFAULT_SERVER]);
 
       const servers =
@@ -217,14 +217,14 @@ describe("ColabJupyterServerProvider", () => {
       expect(servers).to.deep.equal([DEFAULT_SERVER]);
     });
 
-    it("returns multiple servers when they are assigned", async () => {
+    it('returns multiple servers when they are assigned', async () => {
       const assignedServers = [
         DEFAULT_SERVER,
         { ...DEFAULT_SERVER, id: randomUUID() },
       ];
       // Type assertion needed due to overloading on getServers
       (assignmentStub.getServers as sinon.SinonStub)
-        .withArgs("extension")
+        .withArgs('extension')
         .resolves(assignedServers);
 
       const servers =
@@ -233,7 +233,7 @@ describe("ColabJupyterServerProvider", () => {
       expect(servers).to.deep.equal(assignedServers);
     });
 
-    it("returns no servers when not signed in", async () => {
+    it('returns no servers when not signed in', async () => {
       toggleAuth(AuthState.SIGNED_OUT);
 
       const servers =
@@ -246,26 +246,26 @@ describe("ColabJupyterServerProvider", () => {
     });
   });
 
-  describe("resolveJupyterServer", () => {
-    it("throws when the server ID is not a UUID", () => {
-      const server = { ...DEFAULT_SERVER, id: "not-a-uuid" };
+  describe('resolveJupyterServer', () => {
+    it('throws when the server ID is not a UUID', () => {
+      const server = { ...DEFAULT_SERVER, id: 'not-a-uuid' };
 
       expect(() =>
         serverProvider.resolveJupyterServer(server, cancellationToken),
       ).to.throw(/expected UUID/);
     });
 
-    it("returns the assigned server with refreshed connection info", async () => {
+    it('returns the assigned server with refreshed connection info', async () => {
       const refreshedServer: ColabAssignedServer = {
         ...DEFAULT_SERVER,
         connectionInformation: {
           ...DEFAULT_SERVER.connectionInformation,
-          token: "456",
+          token: '456',
         },
       };
       // Type assertion needed due to overloading on getServers
       (assignmentStub.getServers as sinon.SinonStub)
-        .withArgs("extension")
+        .withArgs('extension')
         .resolves([DEFAULT_SERVER]);
       assignmentStub.refreshConnection
         .withArgs(DEFAULT_SERVER.id)
@@ -277,15 +277,15 @@ describe("ColabJupyterServerProvider", () => {
     });
   });
 
-  describe("commands", () => {
-    describe("provideCommands", () => {
-      describe("when signed in", () => {
+  describe('commands', () => {
+    describe('provideCommands', () => {
+      describe('when signed in', () => {
         beforeEach(() => {
           toggleAuth(AuthState.SIGNED_IN);
         });
 
-        it("excludes upgrade to pro command when getting the subscription tier fails", async () => {
-          colabClientStub.getSubscriptionTier.rejects(new Error("foo"));
+        it('excludes upgrade to pro command when getting the subscription tier fails', async () => {
+          colabClientStub.getSubscriptionTier.rejects(new Error('foo'));
 
           const commands = await serverProvider.provideCommands(
             undefined,
@@ -300,7 +300,7 @@ describe("ColabJupyterServerProvider", () => {
           ]);
         });
 
-        it("excludes upgrade to pro command for users with pro", async () => {
+        it('excludes upgrade to pro command for users with pro', async () => {
           colabClientStub.getSubscriptionTier.resolves(SubscriptionTier.PRO);
 
           const commands = await serverProvider.provideCommands(
@@ -316,7 +316,7 @@ describe("ColabJupyterServerProvider", () => {
           ]);
         });
 
-        it("excludes upgrade to pro command for users with pro-plus", async () => {
+        it('excludes upgrade to pro command for users with pro-plus', async () => {
           colabClientStub.getSubscriptionTier.resolves(
             SubscriptionTier.PRO_PLUS,
           );
@@ -334,7 +334,7 @@ describe("ColabJupyterServerProvider", () => {
           ]);
         });
 
-        it("returns commands to auto-connect, create a server, open Colab web and upgrade to pro for free users", async () => {
+        it('returns commands to auto-connect, create a server, open Colab web and upgrade to pro for free users', async () => {
           colabClientStub.getSubscriptionTier.resolves(SubscriptionTier.NONE);
 
           const commands = await serverProvider.provideCommands(
@@ -352,12 +352,12 @@ describe("ColabJupyterServerProvider", () => {
         });
       });
 
-      describe("when signed out", () => {
+      describe('when signed out', () => {
         beforeEach(() => {
           toggleAuth(AuthState.SIGNED_OUT);
         });
 
-        it("includes command to sign-in and view existing servers if there previously were some", async () => {
+        it('includes command to sign-in and view existing servers if there previously were some', async () => {
           assignmentStub.getLastKnownAssignedServers.resolves([DEFAULT_SERVER]);
 
           const commands = await serverProvider.provideCommands(
@@ -374,7 +374,7 @@ describe("ColabJupyterServerProvider", () => {
           ]);
         });
 
-        it("returns commands to auto-connect, create a server and open Colab web", async () => {
+        it('returns commands to auto-connect, create a server and open Colab web', async () => {
           assignmentStub.getLastKnownAssignedServers.resolves([]);
 
           const commands = await serverProvider.provideCommands(
@@ -392,12 +392,12 @@ describe("ColabJupyterServerProvider", () => {
       });
     });
 
-    describe("handleCommand", () => {
+    describe('handleCommand', () => {
       // See catch block of ColabJupyterServerProvider.handleCommand for
       // context. This is a required workaround until
       // https://github.com/microsoft/vscode-jupyter/issues/16469 is resolved.
-      it("dismisses the input when an error is thrown", async () => {
-        assignmentStub.latestOrAutoAssignServer.rejects(new Error("barf"));
+      it('dismisses the input when an error is thrown', async () => {
+        assignmentStub.latestOrAutoAssignServer.rejects(new Error('barf'));
 
         await expect(
           serverProvider.handleCommand(
@@ -408,7 +408,7 @@ describe("ColabJupyterServerProvider", () => {
 
         sinon.assert.calledWithExactly(
           vsCodeStub.commands.executeCommand,
-          "workbench.action.closeQuickOpen",
+          'workbench.action.closeQuickOpen',
         );
       });
 
@@ -424,7 +424,7 @@ describe("ColabJupyterServerProvider", () => {
 
         sinon.assert.calledOnceWithExactly(
           vsCodeStub.env.openExternal,
-          vsCodeStub.Uri.parse("https://colab.research.google.com"),
+          vsCodeStub.Uri.parse('https://colab.research.google.com'),
         );
       });
 
@@ -440,12 +440,12 @@ describe("ColabJupyterServerProvider", () => {
 
         sinon.assert.calledOnceWithExactly(
           vsCodeStub.env.openExternal,
-          vsCodeStub.Uri.parse("https://colab.research.google.com/signup"),
+          vsCodeStub.Uri.parse('https://colab.research.google.com/signup'),
         );
       });
 
-      describe("for signing-in to view existing servers", () => {
-        it("triggers server reconciliation and navigates back out of the flow", async () => {
+      describe('for signing-in to view existing servers', () => {
+        it('triggers server reconciliation and navigates back out of the flow', async () => {
           assignmentStub.reconcileAssignedServers.resolves();
 
           await expect(
@@ -459,8 +459,8 @@ describe("ColabJupyterServerProvider", () => {
         });
       });
 
-      describe("for auto-connecting", () => {
-        it("assigns the latest server or auto-assigns one", async () => {
+      describe('for auto-connecting', () => {
+        it('assigns the latest server or auto-assigns one', async () => {
           assignmentStub.latestOrAutoAssignServer.resolves(DEFAULT_SERVER);
 
           await expect(
@@ -472,8 +472,8 @@ describe("ColabJupyterServerProvider", () => {
         });
       });
 
-      describe("for new Colab server", () => {
-        it("returns undefined when navigating back out of the flow", async () => {
+      describe('for new Colab server', () => {
+        it('returns undefined when navigating back out of the flow', async () => {
           serverPickerStub.prompt.rejects(InputFlowAction.back);
 
           await expect(
@@ -485,13 +485,13 @@ describe("ColabJupyterServerProvider", () => {
           sinon.assert.calledOnce(serverPickerStub.prompt);
         });
 
-        it("completes assigning a server", async () => {
+        it('completes assigning a server', async () => {
           const availableServers = [DEFAULT_SERVER];
           assignmentStub.getAvailableServerDescriptors.resolves(
             availableServers,
           );
           const selectedServer: ColabServerDescriptor = {
-            label: "My new server",
+            label: 'My new server',
             variant: DEFAULT_SERVER.variant,
             accelerator: DEFAULT_SERVER.accelerator,
           };
@@ -516,19 +516,19 @@ describe("ColabJupyterServerProvider", () => {
     });
   });
 
-  describe("server changes", () => {
-    const events: Map<"added" | "removed" | "changed", AssignmentChangeEvent> =
-      new Map<"added" | "removed" | "changed", AssignmentChangeEvent>([
-        ["added", { added: [DEFAULT_SERVER], removed: [], changed: [] }],
+  describe('server changes', () => {
+    const events: Map<'added' | 'removed' | 'changed', AssignmentChangeEvent> =
+      new Map<'added' | 'removed' | 'changed', AssignmentChangeEvent>([
+        ['added', { added: [DEFAULT_SERVER], removed: [], changed: [] }],
         [
-          "removed",
+          'removed',
           {
             added: [],
             removed: [{ server: DEFAULT_SERVER, userInitiated: false }],
             changed: [],
           },
         ],
-        ["changed", { added: [], removed: [], changed: [DEFAULT_SERVER] }],
+        ['changed', { added: [], removed: [], changed: [DEFAULT_SERVER] }],
       ]);
     let listener: sinon.SinonStub<[]>;
 
@@ -547,8 +547,8 @@ describe("ColabJupyterServerProvider", () => {
     }
 
     // The provider setup starts signed-in, so no need to toggle to it.
-    describe("when signed in", () => {
-      it("sets colab.hasAssignedServer to true when there are assigned servers", async () => {
+    describe('when signed in', () => {
+      it('sets colab.hasAssignedServer to true when there are assigned servers', async () => {
         assignmentStub.hasAssignedServer.resolves(true);
         const setContext = stubHasAssignedServerSet();
 
@@ -561,7 +561,7 @@ describe("ColabJupyterServerProvider", () => {
         await expect(setContext).to.eventually.be.true;
       });
 
-      it("sets colab.hasAssignedServer to false when there are no assigned servers", async () => {
+      it('sets colab.hasAssignedServer to false when there are no assigned servers', async () => {
         assignmentStub.hasAssignedServer.resolves(false);
         const setContext = stubHasAssignedServerSet();
 
@@ -580,7 +580,7 @@ describe("ColabJupyterServerProvider", () => {
     // tests are added defensively in the case that there's a race condition
     // respecting an auth state change or we add other pruning mechanisms in the
     // future which don't require credentials.
-    describe("when signed out", () => {
+    describe('when signed out', () => {
       beforeEach(async () => {
         await toggleAuthCtxSettled(AuthState.SIGNED_OUT);
 
@@ -588,7 +588,7 @@ describe("ColabJupyterServerProvider", () => {
         assignmentStub.hasAssignedServer.reset();
       });
 
-      it("sets colab.hasAssignedServer to false even when there are assigned servers", async () => {
+      it('sets colab.hasAssignedServer to false even when there are assigned servers', async () => {
         const setContext = stubHasAssignedServerSet();
 
         assignmentStub.onDidAssignmentsChange.yield({
@@ -601,7 +601,7 @@ describe("ColabJupyterServerProvider", () => {
         sinon.assert.notCalled(assignmentStub.hasAssignedServer);
       });
 
-      it("sets colab.hasAssignedServer to false when there are no assigned servers", async () => {
+      it('sets colab.hasAssignedServer to false when there are no assigned servers', async () => {
         const setContext = stubHasAssignedServerSet();
 
         assignmentStub.onDidAssignmentsChange.yield({
@@ -615,8 +615,8 @@ describe("ColabJupyterServerProvider", () => {
       });
     });
 
-    it("warns of server removal when not initiated by the user", () => {
-      assignmentStub.onDidAssignmentsChange.yield(events.get("removed"));
+    it('warns of server removal when not initiated by the user', () => {
+      assignmentStub.onDidAssignmentsChange.yield(events.get('removed'));
 
       sinon.assert.calledOnceWithMatch(
         vsCodeStub.window.showWarningMessage,
@@ -625,7 +625,7 @@ describe("ColabJupyterServerProvider", () => {
     });
   });
 
-  describe("auth changes", () => {
+  describe('auth changes', () => {
     let listener: sinon.SinonStub<[]>;
 
     beforeEach(() => {
@@ -633,12 +633,12 @@ describe("ColabJupyterServerProvider", () => {
       serverProvider.onDidChangeServers(listener);
     });
 
-    describe("with assigned servers", () => {
+    describe('with assigned servers', () => {
       beforeEach(() => {
         assignmentStub.hasAssignedServer.resolves(true);
       });
 
-      it("sets colab.hasAssignedServer to true after signing in", async () => {
+      it('sets colab.hasAssignedServer to true after signing in', async () => {
         // Start signed out.
         await toggleAuthCtxSettled(AuthState.SIGNED_OUT);
         const setContext = stubHasAssignedServerSet();
@@ -648,7 +648,7 @@ describe("ColabJupyterServerProvider", () => {
         await expect(setContext).to.eventually.be.true;
       });
 
-      it("sets colab.hasAssignedServer to false after signing out", async () => {
+      it('sets colab.hasAssignedServer to false after signing out', async () => {
         const setContext = stubHasAssignedServerSet();
 
         toggleAuth(AuthState.SIGNED_OUT);
@@ -656,7 +656,7 @@ describe("ColabJupyterServerProvider", () => {
         await expect(setContext).to.eventually.be.false;
       });
 
-      it("fires onDidChangeServers as auth state changes", async () => {
+      it('fires onDidChangeServers as auth state changes', async () => {
         await toggleAuthCtxSettled(AuthState.SIGNED_OUT);
         sinon.assert.calledOnce(listener);
 
@@ -665,12 +665,12 @@ describe("ColabJupyterServerProvider", () => {
       });
     });
 
-    describe("without assigned servers", () => {
+    describe('without assigned servers', () => {
       beforeEach(() => {
         assignmentStub.hasAssignedServer.resolves(false);
       });
 
-      it("sets colab.hasAssignedServer to false after signing in", async () => {
+      it('sets colab.hasAssignedServer to false after signing in', async () => {
         // Start signed out.
         await toggleAuthCtxSettled(AuthState.SIGNED_OUT);
         const setContext = stubHasAssignedServerSet();
@@ -680,7 +680,7 @@ describe("ColabJupyterServerProvider", () => {
         await expect(setContext).to.eventually.be.false;
       });
 
-      it("sets colab.hasAssignedServer to false after signing out", async () => {
+      it('sets colab.hasAssignedServer to false after signing out', async () => {
         const setContext = stubHasAssignedServerSet();
 
         toggleAuth(AuthState.SIGNED_OUT);
@@ -688,7 +688,7 @@ describe("ColabJupyterServerProvider", () => {
         await expect(setContext).to.eventually.be.false;
       });
 
-      it("fires onDidChangeServers as auth state changes", async () => {
+      it('fires onDidChangeServers as auth state changes', async () => {
         await toggleAuthCtxSettled(AuthState.SIGNED_OUT);
         sinon.assert.calledOnce(listener);
 
@@ -719,13 +719,13 @@ describe("ColabJupyterServerProvider", () => {
 function isJupyterServerCommandProvider(
   obj: unknown,
 ): obj is JupyterServerCommandProvider {
-  if (typeof obj !== "object" || obj === null) {
+  if (typeof obj !== 'object' || obj === null) {
     return false;
   }
   return (
-    "provideCommands" in obj &&
-    "handleCommand" in obj &&
-    typeof obj.provideCommands === "function" &&
-    typeof obj.handleCommand === "function"
+    'provideCommands' in obj &&
+    'handleCommand' in obj &&
+    typeof obj.provideCommands === 'function' &&
+    typeof obj.handleCommand === 'function'
   );
 }

--- a/src/jupyter/servers.ts
+++ b/src/jupyter/servers.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { UUID } from "crypto";
+import { UUID } from 'crypto';
 import {
   JupyterServer,
   JupyterServerConnectionInformation,
-} from "@vscode/jupyter-extension";
-import { Variant } from "../colab/api";
+} from '@vscode/jupyter-extension';
+import { Variant } from '../colab/api';
 
 /**
  * Colab's Jupyter server descriptor which includes machine-specific
@@ -47,11 +47,11 @@ export type ColabAssignedServer = ColabJupyterServer & {
 export function isColabAssignedServer(
   s: ColabAssignedServer | UnownedServer,
 ): s is ColabAssignedServer {
-  return "connectionInformation" in s;
+  return 'connectionInformation' in s;
 }
 
 export const DEFAULT_CPU_SERVER: ColabServerDescriptor = {
-  label: "Colab CPU",
+  label: 'Colab CPU',
   variant: Variant.DEFAULT,
 };
 

--- a/src/jupyter/storage.ts
+++ b/src/jupyter/storage.ts
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { UUID } from "crypto";
-import vscode from "vscode";
-import { z } from "zod";
-import { Variant } from "../colab/api";
-import { PROVIDER_ID } from "../config/constants";
-import { isUUID } from "../utils/uuid";
-import { ColabAssignedServer } from "./servers";
+import { UUID } from 'crypto';
+import vscode from 'vscode';
+import { z } from 'zod';
+import { Variant } from '../colab/api';
+import { PROVIDER_ID } from '../config/constants';
+import { isUUID } from '../utils/uuid';
+import { ColabAssignedServer } from './servers';
 
 const ASSIGNED_SERVERS_KEY = `${PROVIDER_ID}.assigned_servers`;
 const AssignedServers = z.array(
   z.object({
     id: z
       .string()
-      .refine(isUUID, "String must be a valid UUID.")
+      .refine(isUUID, 'String must be a valid UUID.')
       .transform((s) => s as UUID),
     label: z.string().nonempty(),
     variant: z.enum(Variant),

--- a/src/jupyter/storage.unit.test.ts
+++ b/src/jupyter/storage.unit.test.ts
@@ -4,24 +4,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { randomUUID } from "crypto";
-import { assert, expect } from "chai";
-import sinon, { SinonStubbedInstance } from "sinon";
-import { SecretStorage } from "vscode";
-import { Variant } from "../colab/api";
-import { PROVIDER_ID } from "../config/constants";
-import { SecretStorageFake } from "../test/helpers/secret-storage";
-import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
-import { ColabAssignedServer } from "./servers";
-import { ServerStorage } from "./storage";
+import { randomUUID } from 'crypto';
+import { assert, expect } from 'chai';
+import sinon, { SinonStubbedInstance } from 'sinon';
+import { SecretStorage } from 'vscode';
+import { Variant } from '../colab/api';
+import { PROVIDER_ID } from '../config/constants';
+import { SecretStorageFake } from '../test/helpers/secret-storage';
+import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
+import { ColabAssignedServer } from './servers';
+import { ServerStorage } from './storage';
 
 const ASSIGNED_SERVERS_KEY = `${PROVIDER_ID}.assigned_servers`;
 const DEFAULT_ASSIGNED_DATE = new Date();
 
-describe("ServerStorage", () => {
+describe('ServerStorage', () => {
   let vsCodeStub: VsCodeStub;
   let secretsStub: SinonStubbedInstance<
-    Pick<SecretStorage, "get" | "store" | "delete">
+    Pick<SecretStorage, 'get' | 'store' | 'delete'>
   >;
   let defaultServer: ColabAssignedServer;
   let serverStorage: ServerStorage;
@@ -31,15 +31,15 @@ describe("ServerStorage", () => {
     secretsStub = new SecretStorageFake();
     defaultServer = {
       id: randomUUID(),
-      label: "foo",
+      label: 'foo',
       variant: Variant.DEFAULT,
       accelerator: undefined,
-      endpoint: "m-s-foo",
+      endpoint: 'm-s-foo',
       connectionInformation: {
-        baseUrl: vsCodeStub.Uri.parse("https://example.com"),
-        token: "123",
+        baseUrl: vsCodeStub.Uri.parse('https://example.com'),
+        token: '123',
         tokenExpiry: new Date(DEFAULT_ASSIGNED_DATE.getTime() + 1000 * 60 * 60),
-        headers: { foo: "bar" },
+        headers: { foo: 'bar' },
       },
       dateAssigned: DEFAULT_ASSIGNED_DATE,
     };
@@ -53,15 +53,15 @@ describe("ServerStorage", () => {
     sinon.restore();
   });
 
-  describe("when no servers are stored", () => {
-    describe("list", () => {
-      it("returns an empty array", async () => {
+  describe('when no servers are stored', () => {
+    describe('list', () => {
+      it('returns an empty array', async () => {
         await expect(serverStorage.list()).to.eventually.deep.equal([]);
 
         sinon.assert.calledOnce(secretsStub.get);
       });
 
-      it("caches empty array", async () => {
+      it('caches empty array', async () => {
         await serverStorage.list();
 
         // Calling the second time uses the cache.
@@ -71,16 +71,16 @@ describe("ServerStorage", () => {
       });
     });
 
-    describe("get", () => {
+    describe('get', () => {
       const id = randomUUID();
 
-      it("returns undefined", async () => {
+      it('returns undefined', async () => {
         await expect(serverStorage.get(id)).to.eventually.be.undefined;
 
         sinon.assert.calledOnce(secretsStub.get);
       });
 
-      it("caches empty array", async () => {
+      it('caches empty array', async () => {
         await expect(serverStorage.get(id)).to.eventually.be.undefined;
         // Calling the second time uses the cache.
         await expect(serverStorage.get(id)).to.eventually.be.undefined;
@@ -89,7 +89,7 @@ describe("ServerStorage", () => {
       });
     });
 
-    describe("store", () => {
+    describe('store', () => {
       beforeEach(async () => {
         await expect(serverStorage.store([defaultServer])).to.eventually.be
           .fulfilled;
@@ -97,7 +97,7 @@ describe("ServerStorage", () => {
 
       // TODO: Update tests now that we're accepting an array.
 
-      it("stores the server", async () => {
+      it('stores the server', async () => {
         sinon.assert.calledOnceWithMatch(
           secretsStub.store,
           ASSIGNED_SERVERS_KEY,
@@ -107,7 +107,7 @@ describe("ServerStorage", () => {
         ]);
       });
 
-      it("clears the cache", async () => {
+      it('clears the cache', async () => {
         secretsStub.get.resetHistory();
         await serverStorage.list();
         // Calling the second time uses the cache.
@@ -116,25 +116,25 @@ describe("ServerStorage", () => {
       });
     });
 
-    it("remove is a no-op", async () => {
+    it('remove is a no-op', async () => {
       await expect(serverStorage.remove(randomUUID())).to.eventually.be.false;
 
       sinon.assert.notCalled(secretsStub.store);
     });
 
-    describe("clear", () => {
+    describe('clear', () => {
       beforeEach(async () => {
         await expect(serverStorage.clear()).to.be.eventually.fulfilled;
       });
 
-      it("deletes the non-existent servers", () => {
+      it('deletes the non-existent servers', () => {
         sinon.assert.calledOnceWithExactly(
           secretsStub.delete,
           ASSIGNED_SERVERS_KEY,
         );
       });
 
-      it("clears the cache", async () => {
+      it('clears the cache', async () => {
         await serverStorage.list();
         // Calling the second time uses the cache.
         await serverStorage.list();
@@ -144,7 +144,7 @@ describe("ServerStorage", () => {
     });
   });
 
-  describe("when a single server is stored", () => {
+  describe('when a single server is stored', () => {
     beforeEach(async () => {
       await assert.isFulfilled(serverStorage.store([defaultServer]));
       sinon.assert.calledOnce(secretsStub.store);
@@ -153,8 +153,8 @@ describe("ServerStorage", () => {
       secretsStub.store.resetHistory();
     });
 
-    describe("list", () => {
-      it("returns the server", async () => {
+    describe('list', () => {
+      it('returns the server', async () => {
         await expect(serverStorage.list()).to.eventually.deep.equal([
           defaultServer,
         ]);
@@ -162,7 +162,7 @@ describe("ServerStorage", () => {
         sinon.assert.calledOnce(secretsStub.get);
       });
 
-      it("caches the returned server", async () => {
+      it('caches the returned server', async () => {
         await serverStorage.list();
 
         // Calling the second time uses the cache.
@@ -172,8 +172,8 @@ describe("ServerStorage", () => {
       });
     });
 
-    describe("get", () => {
-      it("returns the server", async () => {
+    describe('get', () => {
+      it('returns the server', async () => {
         await expect(
           serverStorage.get(defaultServer.id),
         ).to.eventually.deep.equal(defaultServer);
@@ -181,7 +181,7 @@ describe("ServerStorage", () => {
         sinon.assert.calledOnce(secretsStub.get);
       });
 
-      it("caches the returned server", async () => {
+      it('caches the returned server', async () => {
         await serverStorage.get(defaultServer.id);
 
         // Calling the second time uses the cache.
@@ -191,12 +191,12 @@ describe("ServerStorage", () => {
       });
     });
 
-    describe("store", () => {
-      it("stores a new server", async () => {
+    describe('store', () => {
+      it('stores a new server', async () => {
         const newServer: ColabAssignedServer = {
           ...defaultServer,
           id: randomUUID(),
-          label: "bar",
+          label: 'bar',
         };
 
         await expect(serverStorage.store([newServer])).to.eventually.be
@@ -213,10 +213,10 @@ describe("ServerStorage", () => {
         ]);
       });
 
-      it("does not override the date assigned", async () => {
+      it('does not override the date assigned', async () => {
         const updatedServer: ColabAssignedServer = {
           ...defaultServer,
-          label: "bar",
+          label: 'bar',
           // This date gets ignored.
           dateAssigned: new Date(DEFAULT_ASSIGNED_DATE.getTime() + 10000),
         };
@@ -236,10 +236,10 @@ describe("ServerStorage", () => {
         ]);
       });
 
-      it("stores an updated server", async () => {
+      it('stores an updated server', async () => {
         const updatedServer = {
           ...defaultServer,
-          label: "bar",
+          label: 'bar',
         };
 
         await expect(serverStorage.store([updatedServer])).to.eventually.be
@@ -254,8 +254,8 @@ describe("ServerStorage", () => {
         ]);
       });
 
-      describe("when storing is a no-op", () => {
-        it("does not store", async () => {
+      describe('when storing is a no-op', () => {
+        it('does not store', async () => {
           await expect(serverStorage.store([defaultServer])).to.eventually.be
             .fulfilled;
 
@@ -265,7 +265,7 @@ describe("ServerStorage", () => {
           ]);
         });
 
-        it("does not clear cache", async () => {
+        it('does not clear cache', async () => {
           // Populate the cache.
           await assert.isFulfilled(serverStorage.list());
 
@@ -279,10 +279,10 @@ describe("ServerStorage", () => {
         });
       });
 
-      it("clears the cache upon storing the server", async () => {
+      it('clears the cache upon storing the server', async () => {
         const updatedServer = {
           ...defaultServer,
-          label: "bar",
+          label: 'bar',
         };
 
         await expect(serverStorage.store([updatedServer])).to.eventually.be
@@ -298,36 +298,36 @@ describe("ServerStorage", () => {
       });
     });
 
-    describe("remove", () => {
-      describe("for the existing server", () => {
+    describe('remove', () => {
+      describe('for the existing server', () => {
         beforeEach(async () => {
           await expect(serverStorage.remove(defaultServer.id)).to.eventually.be
             .true;
           secretsStub.get.resetHistory();
         });
 
-        it("deletes it", async () => {
+        it('deletes it', async () => {
           sinon.assert.calledOnce(secretsStub.store);
           await expect(serverStorage.list()).to.eventually.deep.equal([]);
         });
 
-        it("clears the cache", async () => {
+        it('clears the cache', async () => {
           await expect(serverStorage.list()).to.be.eventually.fulfilled;
           sinon.assert.calledOnce(secretsStub.get);
         });
       });
 
-      describe("for a server that does not exist", () => {
+      describe('for a server that does not exist', () => {
         const nonExistentId = randomUUID();
 
-        it("is a no-op", async () => {
+        it('is a no-op', async () => {
           await expect(serverStorage.remove(nonExistentId)).to.eventually.be
             .false;
 
           sinon.assert.notCalled(secretsStub.store);
         });
 
-        it("does not clear the cache", async () => {
+        it('does not clear the cache', async () => {
           await assert.isFulfilled(serverStorage.list());
 
           await expect(serverStorage.remove(nonExistentId)).to.eventually.be
@@ -340,19 +340,19 @@ describe("ServerStorage", () => {
       });
     });
 
-    describe("clear", () => {
+    describe('clear', () => {
       beforeEach(async () => {
         await expect(serverStorage.clear()).to.be.eventually.fulfilled;
       });
 
-      it("deletes the server", () => {
+      it('deletes the server', () => {
         sinon.assert.calledOnceWithExactly(
           secretsStub.delete,
           ASSIGNED_SERVERS_KEY,
         );
       });
 
-      it("clears the cache", async () => {
+      it('clears the cache', async () => {
         await serverStorage.list();
 
         sinon.assert.calledOnce(secretsStub.get);
@@ -360,13 +360,13 @@ describe("ServerStorage", () => {
     });
   });
 
-  describe("when multiple servers are stored", () => {
+  describe('when multiple servers are stored', () => {
     let servers: ColabAssignedServer[];
 
     beforeEach(async () => {
       servers = [
-        { ...defaultServer, id: randomUUID(), label: "first" },
-        { ...defaultServer, id: randomUUID(), label: "second" },
+        { ...defaultServer, id: randomUUID(), label: 'first' },
+        { ...defaultServer, id: randomUUID(), label: 'second' },
       ];
       for (const server of servers) {
         await assert.isFulfilled(serverStorage.store([server]));
@@ -376,8 +376,8 @@ describe("ServerStorage", () => {
       secretsStub.store.resetHistory();
     });
 
-    describe("list", () => {
-      it("returns the servers", async () => {
+    describe('list', () => {
+      it('returns the servers', async () => {
         await expect(serverStorage.list()).to.eventually.have.same.deep.members(
           servers,
         );
@@ -385,7 +385,7 @@ describe("ServerStorage", () => {
         sinon.assert.calledOnce(secretsStub.get);
       });
 
-      it("caches the returned servers", async () => {
+      it('caches the returned servers', async () => {
         await expect(serverStorage.list()).to.eventually.have.same.deep.members(
           servers,
         );
@@ -399,8 +399,8 @@ describe("ServerStorage", () => {
       });
     });
 
-    describe("get", () => {
-      it("returns either of the servers", async () => {
+    describe('get', () => {
+      it('returns either of the servers', async () => {
         await expect(serverStorage.get(servers[0].id)).to.eventually.deep.equal(
           servers[0],
         );
@@ -409,7 +409,7 @@ describe("ServerStorage", () => {
         );
       });
 
-      it("caches the returned servers", async () => {
+      it('caches the returned servers', async () => {
         await serverStorage.get(servers[0].id);
 
         // Calling the second time uses the cache.
@@ -419,8 +419,8 @@ describe("ServerStorage", () => {
       });
     });
 
-    describe("store", () => {
-      it("stores a new server", async () => {
+    describe('store', () => {
+      it('stores a new server', async () => {
         const newServer = {
           ...defaultServer,
           id: randomUUID(),
@@ -438,10 +438,10 @@ describe("ServerStorage", () => {
         );
       });
 
-      it("stores an updated server", async () => {
+      it('stores an updated server', async () => {
         const updatedServer = {
           ...servers[0],
-          label: "bar",
+          label: 'bar',
         };
 
         await expect(serverStorage.store([updatedServer])).to.eventually.be
@@ -456,8 +456,8 @@ describe("ServerStorage", () => {
         );
       });
 
-      describe("when storing is a no-op", () => {
-        it("does not store", async () => {
+      describe('when storing is a no-op', () => {
+        it('does not store', async () => {
           await expect(serverStorage.store([servers[0]])).to.eventually.be
             .fulfilled;
 
@@ -467,7 +467,7 @@ describe("ServerStorage", () => {
           ).to.eventually.have.same.deep.members(servers);
         });
 
-        it("does not clear cache", async () => {
+        it('does not clear cache', async () => {
           // Populate the cache.
           await assert.isFulfilled(serverStorage.list());
 
@@ -481,10 +481,10 @@ describe("ServerStorage", () => {
         });
       });
 
-      it("clears the cache upon storing the server", async () => {
+      it('clears the cache upon storing the server', async () => {
         const updatedServer = {
           ...servers[0],
-          label: "bar",
+          label: 'bar',
         };
 
         await expect(serverStorage.store([updatedServer])).to.eventually.be
@@ -500,38 +500,38 @@ describe("ServerStorage", () => {
       });
     });
 
-    describe("remove", () => {
-      describe("for an existing server", () => {
+    describe('remove', () => {
+      describe('for an existing server', () => {
         beforeEach(async () => {
           await expect(serverStorage.remove(servers[0].id)).to.eventually.be
             .true;
           secretsStub.get.resetHistory();
         });
 
-        it("deletes it", async () => {
+        it('deletes it', async () => {
           sinon.assert.calledOnce(secretsStub.store);
           await expect(serverStorage.list()).to.eventually.deep.equal([
             servers[1],
           ]);
         });
 
-        it("clears the cache", async () => {
+        it('clears the cache', async () => {
           await expect(serverStorage.list()).to.be.eventually.fulfilled;
           sinon.assert.calledOnce(secretsStub.get);
         });
       });
 
-      describe("for a server that does not exist", () => {
+      describe('for a server that does not exist', () => {
         const nonExistentId = randomUUID();
 
-        it("is a no-op", async () => {
+        it('is a no-op', async () => {
           await expect(serverStorage.remove(nonExistentId)).to.eventually.be
             .false;
 
           sinon.assert.notCalled(secretsStub.store);
         });
 
-        it("does not clear the cache", async () => {
+        it('does not clear the cache', async () => {
           await assert.isFulfilled(serverStorage.list());
 
           await expect(serverStorage.remove(nonExistentId)).to.eventually.be
@@ -544,19 +544,19 @@ describe("ServerStorage", () => {
       });
     });
 
-    describe("clear", () => {
+    describe('clear', () => {
       beforeEach(async () => {
         await expect(serverStorage.clear()).to.be.eventually.fulfilled;
       });
 
-      it("deletes the servers", () => {
+      it('deletes the servers', () => {
         sinon.assert.calledOnceWithExactly(
           secretsStub.delete,
           ASSIGNED_SERVERS_KEY,
         );
       });
 
-      it("clears the cache", async () => {
+      it('clears the cache', async () => {
         await serverStorage.list();
 
         sinon.assert.calledOnce(secretsStub.get);

--- a/src/lsp/content-length-transformer.ts
+++ b/src/lsp/content-length-transformer.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Transform } from "stream";
+import { Transform } from 'stream';
 
 /**
  * Transformer that adds a Content-Length header prefix to incoming LSP
@@ -26,7 +26,7 @@ export class ContentLengthTransformer extends Transform {
     if (/^content-length/i.test(json)) {
       this.push(chunk);
     } else {
-      const l = Buffer.byteLength(json, "utf-8");
+      const l = Buffer.byteLength(json, 'utf-8');
       this.push(Buffer.from(`Content-Length: ${l.toString()}\r\n\r\n${json}`));
     }
 
@@ -35,19 +35,19 @@ export class ContentLengthTransformer extends Transform {
 }
 
 function chunkToString(chunk: string | Buffer | Uint8Array | DataView): string {
-  if (typeof chunk === "string") {
+  if (typeof chunk === 'string') {
     return chunk;
   }
   if (Buffer.isBuffer(chunk)) {
-    return chunk.toString("utf-8");
+    return chunk.toString('utf-8');
   }
   if (chunk instanceof DataView) {
     return Buffer.from(
       chunk.buffer,
       chunk.byteOffset,
       chunk.byteLength,
-    ).toString("utf-8");
+    ).toString('utf-8');
   }
   // Uint8Array or other ArrayBufferView
-  return Buffer.from(chunk).toString("utf-8");
+  return Buffer.from(chunk).toString('utf-8');
 }

--- a/src/lsp/content-length-transformer.unit.test.ts
+++ b/src/lsp/content-length-transformer.unit.test.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Readable } from "stream";
-import { expect } from "chai";
-import { ContentLengthTransformer } from "./content-length-transformer";
+import { Readable } from 'stream';
+import { expect } from 'chai';
+import { ContentLengthTransformer } from './content-length-transformer';
 
 async function transformChunks(
   chunks: (string | Buffer | Uint8Array | DataView)[],
@@ -14,33 +14,33 @@ async function transformChunks(
   const transformer = new ContentLengthTransformer();
   const readable = Readable.from(chunks);
 
-  let output = "";
-  readable.pipe(transformer).on("data", (data: Buffer | string) => {
-    output += data.toString("utf-8");
+  let output = '';
+  readable.pipe(transformer).on('data', (data: Buffer | string) => {
+    output += data.toString('utf-8');
   });
 
   return new Promise((resolve, reject) => {
-    readable.on("end", () => {
+    readable.on('end', () => {
       resolve(output);
     });
-    readable.on("error", reject);
+    readable.on('error', reject);
   });
 }
 
-describe("ContentLengthTransformer", () => {
-  it("adds the Content-Length header to a JSON string", async () => {
+describe('ContentLengthTransformer', () => {
+  it('adds the Content-Length header to a JSON string', async () => {
     const message = '{"jsonrpc":"2.0","method":"initialized","params":{}}';
 
     const result = await transformChunks([message]);
 
     const expected = `Content-Length: ${Buffer.byteLength(
       message,
-      "utf-8",
+      'utf-8',
     ).toString()}\r\n\r\n${message}`;
     expect(result).to.equal(expected);
   });
 
-  it("does not add the Content-Length header if one is already present", async () => {
+  it('does not add the Content-Length header if one is already present', async () => {
     const message =
       'Content-Length: 1234\r\n\r\n{"jsonrpc":"2.0","method":"initialized","params":{}}';
 
@@ -49,7 +49,7 @@ describe("ContentLengthTransformer", () => {
     expect(result).to.equal(message);
   });
 
-  it("does not add the Content-Length header if one is already present (case-insensitive)", async () => {
+  it('does not add the Content-Length header if one is already present (case-insensitive)', async () => {
     const message =
       'content-length: 1234\r\n\r\n{"jsonrpc":"2.0","method":"initialized","params":{}}';
 
@@ -58,9 +58,9 @@ describe("ContentLengthTransformer", () => {
     expect(result).to.equal(message);
   });
 
-  it("handles Buffer input", async () => {
+  it('handles Buffer input', async () => {
     const message = '{"jsonrpc":"2.0"}';
-    const buffer = Buffer.from(message, "utf-8");
+    const buffer = Buffer.from(message, 'utf-8');
 
     const result = await transformChunks([buffer]);
 
@@ -68,7 +68,7 @@ describe("ContentLengthTransformer", () => {
     expect(result).to.equal(expected);
   });
 
-  it("handles Uint8Array input", async () => {
+  it('handles Uint8Array input', async () => {
     const message = '{"jsonrpc":"2.0"}';
     const uint8Array = new TextEncoder().encode(message);
 
@@ -78,7 +78,7 @@ describe("ContentLengthTransformer", () => {
     expect(result).to.equal(expected);
   });
 
-  it("handles DataView input", async () => {
+  it('handles DataView input', async () => {
     const message = '{"jsonrpc":"2.0"}';
     const buffer = new TextEncoder().encode(message).buffer;
     const dataView = new DataView(buffer);
@@ -89,22 +89,22 @@ describe("ContentLengthTransformer", () => {
     expect(result).to.equal(expected);
   });
 
-  it("handles multiple chunks", async () => {
+  it('handles multiple chunks', async () => {
     const message1 = '{"jsonrpc":"2.0"}';
     const message2 = '{"method":"test"}';
 
     const result = await transformChunks([message1, message2]);
 
-    const message1Length = Buffer.byteLength(message1, "utf-8");
+    const message1Length = Buffer.byteLength(message1, 'utf-8');
     const expected1 = `Content-Length: ${message1Length.toString()}\r\n\r\n${message1}`;
-    const message2Length = Buffer.byteLength(message2, "utf-8");
+    const message2Length = Buffer.byteLength(message2, 'utf-8');
     const expected2 = `Content-Length: ${message2Length.toString()}\r\n\r\n${message2}`;
 
     expect(result).to.equal(expected1 + expected2);
   });
 
-  it("handles empty string input", async () => {
-    const result = await transformChunks([""]);
+  it('handles empty string input', async () => {
+    const result = await transformChunks(['']);
 
     const expected = `Content-Length: 0\r\n\r\n`;
     expect(result).to.equal(expected);

--- a/src/lsp/middleware.ts
+++ b/src/lsp/middleware.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode, { Uri, TextDocument } from "vscode";
+import vscode, { Uri, TextDocument } from 'vscode';
 import {
   ProvideDiagnosticSignature,
   ProvideWorkspaceDiagnosticSignature,
   vsdiag,
-} from "vscode-languageclient/node";
+} from 'vscode-languageclient/node';
 
 /**
  * Filters non IPython diagnostics.
@@ -104,7 +104,7 @@ function isFullReport(
   r?: vsdiag.DocumentDiagnosticReport | null,
 ): r is vsdiag.RelatedFullDocumentDiagnosticReport {
   // Avoid depending on language client which transitively depends on vscode.
-  return r?.kind.toString() === "full";
+  return r?.kind.toString() === 'full';
 }
 
 /**
@@ -119,11 +119,11 @@ function shouldKeepDiagnostic(
 
   // Bash commands are not recognized by Pyright, and will typically return the
   // error mentioned in https://github.com/microsoft/vscode-jupyter/issues/8055.
-  if (text.startsWith("!")) {
+  if (text.startsWith('!')) {
     return false;
   }
   // Pyright does not recognize magics.
-  if (text.startsWith("%")) {
+  if (text.startsWith('%')) {
     return false;
   }
   // IPython 7+ allows for calling await at the top level, outside of an async
@@ -131,8 +131,8 @@ function shouldKeepDiagnostic(
   const isStartOfLine = diagnostic.range.start.character === 0;
   if (
     isStartOfLine &&
-    text.startsWith("await") &&
-    diagnostic.message.includes("allowed only within async function")
+    text.startsWith('await') &&
+    diagnostic.message.includes('allowed only within async function')
   ) {
     return false;
   }

--- a/src/system/uri.ts
+++ b/src/system/uri.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode from "vscode";
-import { PackageInfo } from "../config/package-info";
+import vscode from 'vscode';
+import { PackageInfo } from '../config/package-info';
 
 /**
  * Builds the extension URI that can be used to redirect users back to VS Code,

--- a/src/system/uri.unit.test.ts
+++ b/src/system/uri.unit.test.ts
@@ -4,29 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { expect } from "chai";
-import * as sinon from "sinon";
-import { Uri } from "vscode";
-import { PackageInfo } from "../config/package-info";
-import { TestUri } from "../test/helpers/uri";
-import { newVsCodeStub, VsCodeStub } from "../test/helpers/vscode";
-import { buildExtensionUri, ExtensionUriHandler } from "./uri";
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { Uri } from 'vscode';
+import { PackageInfo } from '../config/package-info';
+import { TestUri } from '../test/helpers/uri';
+import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
+import { buildExtensionUri, ExtensionUriHandler } from './uri';
 
-it("buildExtensionUri", () => {
+it('buildExtensionUri', () => {
   const vs = newVsCodeStub();
-  vs.env.uriScheme = "vscode-insiders";
+  vs.env.uriScheme = 'vscode-insiders';
   const packageInfo: PackageInfo = {
-    publisher: "google",
-    name: "colab",
-    version: "0.0.1",
+    publisher: 'google',
+    name: 'colab',
+    version: '0.0.1',
   };
 
   expect(buildExtensionUri(vs.asVsCode(), packageInfo)).to.equal(
-    "vscode-insiders://google.colab",
+    'vscode-insiders://google.colab',
   );
 });
 
-describe("ExtensionUriHandler", () => {
+describe('ExtensionUriHandler', () => {
   let vs: VsCodeStub;
   let handler: ExtensionUriHandler;
 
@@ -40,7 +40,7 @@ describe("ExtensionUriHandler", () => {
     handler.dispose();
   });
 
-  it("disposes of the event emitter when disposed", () => {
+  it('disposes of the event emitter when disposed', () => {
     const disposeSpy = sinon.spy();
     const fakeEmitterInstance = {
       event: sinon.stub(),
@@ -57,21 +57,21 @@ describe("ExtensionUriHandler", () => {
     sinon.assert.calledOnce(disposeSpy);
   });
 
-  it("fires a single URI event", () => {
+  it('fires a single URI event', () => {
     const onReceivedUriStub: sinon.SinonStub<[Uri], void> = sinon.stub();
     handler.onReceivedUri(onReceivedUriStub);
-    const testUri = TestUri.parse("vscode://google.colab?foo=bar");
+    const testUri = TestUri.parse('vscode://google.colab?foo=bar');
 
     handler.handleUri(testUri);
 
     sinon.assert.calledOnceWithExactly(onReceivedUriStub, testUri);
   });
 
-  it("fires multiple URI events", () => {
+  it('fires multiple URI events', () => {
     const onReceivedUriStub: sinon.SinonStub<[Uri], void> = sinon.stub();
     handler.onReceivedUri(onReceivedUriStub);
-    const testUri1 = TestUri.parse("vscode://google.colab?foo=bar");
-    const testUri2 = TestUri.parse("vscode://google.colab?foo=baz");
+    const testUri1 = TestUri.parse('vscode://google.colab?foo=bar');
+    const testUri2 = TestUri.parse('vscode://google.colab?foo=baz');
 
     handler.handleUri(testUri1);
     handler.handleUri(testUri2);

--- a/src/test/e2e.mocharc.js
+++ b/src/test/e2e.mocharc.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const isDebugMode = process.argv.includes("--debug");
+const isDebugMode = process.argv.includes('--debug');
 module.exports = {
-  timeout: isDebugMode ? 99999999 : "2m",
+  timeout: isDebugMode ? 99999999 : '2m',
 };

--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from "fs";
-import { assert } from "chai";
-import dotenv from "dotenv";
-import * as chrome from "selenium-webdriver/chrome";
+import * as fs from 'fs';
+import { assert } from 'chai';
+import dotenv from 'dotenv';
+import * as chrome from 'selenium-webdriver/chrome';
 import {
   Builder,
   By,
@@ -20,13 +20,13 @@ import {
   Workbench,
   VSBrowser,
   until,
-} from "vscode-extension-tester";
-import { CONFIG } from "../colab-config";
+} from 'vscode-extension-tester';
+import { CONFIG } from '../colab-config';
 
 const ELEMENT_WAIT_MS = 10000;
 const CELL_EXECUTION_WAIT_MS = 30000;
 
-describe("Colab Extension", function () {
+describe('Colab Extension', function () {
   dotenv.config();
 
   let driver: WebDriver;
@@ -36,7 +36,7 @@ describe("Colab Extension", function () {
   before(async () => {
     assert.equal(
       CONFIG.Environment,
-      "production",
+      'production',
       'Unexpected extension environment. Run `npm run generate:config` with COLAB_EXTENSION_ENVIRONMENT="production".',
     );
     // Wait for VS Code UI to settle before running tests.
@@ -46,37 +46,37 @@ describe("Colab Extension", function () {
   });
 
   beforeEach(function () {
-    testTitle = this.currentTest?.fullTitle() ?? "";
+    testTitle = this.currentTest?.fullTitle() ?? '';
   });
 
-  describe("with a notebook", () => {
+  describe('with a notebook', () => {
     beforeEach(async () => {
       // Create an executable notebook. Note that it's created with a single
       // code cell by default.
-      await workbench.executeCommand("Create: New Jupyter Notebook");
+      await workbench.executeCommand('Create: New Jupyter Notebook');
       // Wait for the notebook editor to finish loading before we interact with
       // it.
       await notebookLoaded(driver);
-      await workbench.executeCommand("Notebook: Edit Cell");
+      await workbench.executeCommand('Notebook: Edit Cell');
       const cell = await driver.switchTo().activeElement();
-      await cell.sendKeys("1 + 1");
+      await cell.sendKeys('1 + 1');
     });
 
-    it("authenticates and executes the notebook on a Colab server", async () => {
+    it('authenticates and executes the notebook on a Colab server', async () => {
       // Select the Colab server provider from the kernel selector.
-      await workbench.executeCommand("Notebook: Select Notebook Kernel");
+      await workbench.executeCommand('Notebook: Select Notebook Kernel');
       await selectQuickPickItem({
-        item: "Colab",
-        quickPick: "Select Another Kernel",
+        item: 'Colab',
+        quickPick: 'Select Another Kernel',
       });
       await selectQuickPickItem({
-        item: "New Colab Server",
-        quickPick: "Select a Jupyter Server",
+        item: 'New Colab Server',
+        quickPick: 'Select a Jupyter Server',
       });
 
       // Accept the dialog allowing the Colab extension to sign in using Google.
       await pushDialogButton({
-        button: "Allow",
+        button: 'Allow',
         dialog: "The extension 'Colab' wants to sign in using Google.",
       });
       // Begin the sign-in process by copying the OAuth URL to the clipboard and
@@ -85,39 +85,39 @@ describe("Colab Extension", function () {
       // driver instance for the OAuth flow, since the original driver instance
       // does not have a handle to the window that would be spawned with "Open".
       await pushDialogButton({
-        button: "Copy",
-        dialog: "Do you want Code to open the external website?",
+        button: 'Copy',
+        dialog: 'Do you want Code to open the external website?',
       });
       // TODO: Remove this dynamic import
-      const clipboardy = await import("clipboardy");
+      const clipboardy = await import('clipboardy');
       await doOauthSignIn(/* oauthUrl= */ clipboardy.default.readSync());
 
       // Now that we're authenticated, we can resume creating a Colab server via
       // the open kernel selector.
       await selectQuickPickItem({
-        item: "CPU",
-        quickPick: "Select a variant (1/2)",
+        item: 'CPU',
+        quickPick: 'Select a variant (1/2)',
       });
       // Alias the server with the default name.
       const inputBox = await InputBox.create();
       await inputBox.sendKeys(Key.ENTER);
       await selectQuickPickItem({
-        item: "Python 3 (ipykernel)",
-        quickPick: "Select a Kernel from Colab CPU",
+        item: 'Python 3 (ipykernel)',
+        quickPick: 'Select a Kernel from Colab CPU',
       });
 
       // Execute the notebook and poll for the success indicator (green check).
       // Why not the cell output? Because the output is rendered in a webview.
-      await workbench.executeCommand("Notebook: Run All");
+      await workbench.executeCommand('Notebook: Run All');
       await driver.wait(
         async () => {
           const element = await workbench
             .getEnclosingElement()
-            .findElements(By.className("codicon-notebook-state-success"));
+            .findElements(By.className('codicon-notebook-state-success'));
           return element.length > 0;
         },
         CELL_EXECUTION_WAIT_MS,
-        "Notebook: Run All failed",
+        'Notebook: Run All failed',
       );
     });
   });
@@ -195,25 +195,25 @@ describe("Colab Extension", function () {
       const emailInput = await oauthDriver.findElement(
         By.css("input[type='email']"),
       );
-      await emailInput.sendKeys(process.env.TEST_ACCOUNT_EMAIL ?? "");
+      await emailInput.sendKeys(process.env.TEST_ACCOUNT_EMAIL ?? '');
       await emailInput.sendKeys(Key.ENTER);
 
       // Input the test account password. Note that we wait for the page to
       // settle to avoid getting a stale element reference.
       await oauthDriver.wait(
-        until.urlContains("accounts.google.com/v3/signin/challenge"),
+        until.urlContains('accounts.google.com/v3/signin/challenge'),
         ELEMENT_WAIT_MS,
       );
       await oauthDriver.sleep(1000);
       const passwordInput = await oauthDriver.findElement(
         By.css("input[type='password']"),
       );
-      await passwordInput.sendKeys(process.env.TEST_ACCOUNT_PASSWORD ?? "");
+      await passwordInput.sendKeys(process.env.TEST_ACCOUNT_PASSWORD ?? '');
       await passwordInput.sendKeys(Key.ENTER);
 
       // Click Continue to sign in to Colab.
       await oauthDriver.wait(
-        until.urlContains("accounts.google.com/signin/oauth/id"),
+        until.urlContains('accounts.google.com/signin/oauth/id'),
         ELEMENT_WAIT_MS,
       );
       await safeClick(
@@ -224,7 +224,7 @@ describe("Colab Extension", function () {
 
       // Click Allow or Continue to authorize the scope (handles both v1 and v2
       // consent screens).
-      await oauthDriver.wait(until.urlContains("consent"), ELEMENT_WAIT_MS);
+      await oauthDriver.wait(until.urlContains('consent'), ELEMENT_WAIT_MS);
       await safeClick(
         oauthDriver,
         By.xpath("//span[text()='Allow' or text()='Continue']"),
@@ -233,7 +233,7 @@ describe("Colab Extension", function () {
 
       // Check that the test account's authenticated. Close the browser window.
       await oauthDriver.wait(
-        until.urlContains("vscode/auth-success"),
+        until.urlContains('vscode/auth-success'),
         ELEMENT_WAIT_MS,
       );
       await oauthDriver.quit();
@@ -246,7 +246,7 @@ describe("Colab Extension", function () {
       fs.writeFileSync(
         `${screenshotsDir}/${testTitle} (oauth window).png`,
         await oauthDriver.takeScreenshot(),
-        "base64",
+        'base64',
       );
       throw _;
     }
@@ -257,12 +257,12 @@ describe("Colab Extension", function () {
  * Creates a new WebDriver instance for the OAuth flow.
  */
 function getOAuthDriver(): Promise<WebDriver> {
-  const authDriverArgsPrefix = "--auth-driver:";
+  const authDriverArgsPrefix = '--auth-driver:';
   const authDriverArgs = process.argv
     .filter((a) => a.startsWith(authDriverArgsPrefix))
     .map((a) => a.substring(authDriverArgsPrefix.length));
   return new Builder()
-    .forBrowser("chrome")
+    .forBrowser('chrome')
     .setChromeOptions(
       new chrome.Options().addArguments(...authDriverArgs) as chrome.Options,
     )
@@ -273,12 +273,12 @@ async function notebookLoaded(driver: WebDriver): Promise<void> {
   await driver.wait(
     async () => {
       const editors = await driver.findElements(
-        By.className("notebook-editor"),
+        By.className('notebook-editor'),
       );
       return editors.length > 0;
     },
     ELEMENT_WAIT_MS,
-    "Notebook editor did not load in time",
+    'Notebook editor did not load in time',
   );
 }
 

--- a/src/test/extension.vscode.test.ts
+++ b/src/test/extension.vscode.test.ts
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as assert from "assert";
-import vscode from "vscode";
+import * as assert from 'assert';
+import vscode from 'vscode';
 
-describe("Extension", () => {
-  it("should be present", () => {
-    assert.ok(vscode.extensions.getExtension("google.colab"));
+describe('Extension', () => {
+  it('should be present', () => {
+    assert.ok(vscode.extensions.getExtension('google.colab'));
   });
 
-  it("should activate", async () => {
-    const extension = vscode.extensions.getExtension("google.colab");
+  it('should activate', async () => {
+    const extension = vscode.extensions.getExtension('google.colab');
 
     await extension?.activate();
 

--- a/src/test/helpers/async.ts
+++ b/src/test/helpers/async.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AsyncToggle } from "../../common/toggleable";
+import { AsyncToggle } from '../../common/toggleable';
 
 /**
  * A simple Deferred promise helper.
@@ -71,8 +71,8 @@ export class ControllableAsyncToggle {
     // Cast to be able to wrap protected member so the async toggles are
     // controllable.
     this.openInstance = instance as PublicToggle;
-    this._turnOn = this.wrap("turnOn");
-    this._turnOff = this.wrap("turnOff");
+    this._turnOn = this.wrap('turnOn');
+    this._turnOff = this.wrap('turnOff');
   }
 
   get turnOn(): ControllableMethod {
@@ -83,7 +83,7 @@ export class ControllableAsyncToggle {
     return this._turnOff;
   }
 
-  private wrap(methodName: "turnOn" | "turnOff"): ControllableMethod {
+  private wrap(methodName: 'turnOn' | 'turnOff'): ControllableMethod {
     const originalMethod = this.openInstance[methodName].bind(
       this.openInstance,
     );

--- a/src/test/helpers/authentication.ts
+++ b/src/test/helpers/authentication.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode from "vscode";
+import vscode from 'vscode';
 
 /**
  * A fake implementation to back the `vscode.authentication` API.
@@ -88,13 +88,13 @@ export class FakeAuthenticationProviderManager {
 
     if (sessions.length > 1) {
       throw new Error(
-        "The fake implementation for getSession does not support multiple sessions",
+        'The fake implementation for getSession does not support multiple sessions',
       );
     }
 
     if (sessions.length !== 1) {
       throw new Error(
-        "The provider failed to create a session for the requested scopes",
+        'The provider failed to create a session for the requested scopes',
       );
     }
 
@@ -122,29 +122,29 @@ export function authUriMatch(
         const parsedUrl = new URL(urlString);
         const params = parsedUrl.searchParams;
 
-        if (parsedUrl.protocol !== "https:") {
+        if (parsedUrl.protocol !== 'https:') {
           this.errors.push(
             `Expected protocol "https:", but got "${parsedUrl.protocol}"`,
           );
         }
-        if (parsedUrl.hostname !== "accounts.google.com") {
+        if (parsedUrl.hostname !== 'accounts.google.com') {
           this.errors.push(
             `Expected hostname "accounts.google.com", but got "${parsedUrl.hostname}"`,
           );
         }
-        if (parsedUrl.pathname !== "/o/oauth2/v2/auth") {
+        if (parsedUrl.pathname !== '/o/oauth2/v2/auth') {
           this.errors.push(
             `Expected pathname "/o/oauth2/v2/auth", but got "${parsedUrl.pathname}"`,
           );
         }
 
         const expectedParams: Record<string, string> = {
-          access_type: "offline",
-          response_type: "code",
-          prompt: "consent",
-          code_challenge_method: "S256",
+          access_type: 'offline',
+          response_type: 'code',
+          prompt: 'consent',
+          code_challenge_method: 'S256',
           redirect_uri: redirectUri,
-          scope: scopes.join(" "),
+          scope: scopes.join(' '),
         };
 
         for (const key in expectedParams) {
@@ -152,22 +152,22 @@ export function authUriMatch(
           const expected = expectedParams[key];
           if (actual !== expected) {
             this.errors.push(
-              `For param "${key}", expected "${expected}", but got "${actual ?? ""}"`,
+              `For param "${key}", expected "${expected}", but got "${actual ?? ''}"`,
             );
           }
         }
 
-        const requiredDynamicParams = ["state", "code_challenge", "client_id"];
+        const requiredDynamicParams = ['state', 'code_challenge', 'client_id'];
         for (const key of requiredDynamicParams) {
           if (!params.has(key)) {
             this.errors.push(`Missing required dynamic param: "${key}"`);
           }
         }
 
-        const state = params.get("state");
+        const state = params.get('state');
         if (!state || !stateParam.test(state)) {
           this.errors.push(
-            `State param should match "${stateParam.source}", but got "${state ?? ""}"`,
+            `State param should match "${stateParam.source}", but got "${state ?? ''}"`,
           );
         }
       } catch (error) {
@@ -179,9 +179,9 @@ export function authUriMatch(
 
     toString: function (): string {
       if (this.errors.length > 0) {
-        return `The following issues were found:\n  - ${this.errors.join("\n  - ")}`;
+        return `The following issues were found:\n  - ${this.errors.join('\n  - ')}`;
       }
-      return "a valid Google Auth URL";
+      return 'a valid Google Auth URL';
     },
   };
 }

--- a/src/test/helpers/cancellation.ts
+++ b/src/test/helpers/cancellation.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode from "vscode";
-import { TestEventEmitter } from "./events";
+import vscode from 'vscode';
+import { TestEventEmitter } from './events';
 
 export class TestCancellationToken implements vscode.CancellationToken {
   private _isCancellationRequested = false;
@@ -49,14 +49,14 @@ export class TestCancellationTokenSource
 
   get token(): TestCancellationToken {
     if (this.disposed) {
-      throw new Error("CancellationTokenSource has been disposed");
+      throw new Error('CancellationTokenSource has been disposed');
     }
     return this._token;
   }
 
   cancel(): void {
     if (this.disposed) {
-      throw new Error("CancellationTokenSource has been disposed");
+      throw new Error('CancellationTokenSource has been disposed');
     }
     this._token.cancel();
   }

--- a/src/test/helpers/events.ts
+++ b/src/test/helpers/events.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode from "vscode";
+import vscode from 'vscode';
 
 export class TestEventEmitter<T> implements vscode.EventEmitter<T> {
   private listeners = new Set<(data: T) => void>();
@@ -13,7 +13,7 @@ export class TestEventEmitter<T> implements vscode.EventEmitter<T> {
   constructor() {
     this.event = (listener: (data: T) => void) => {
       if (this.disposed) {
-        throw new Error("EventEmitter has been disposed");
+        throw new Error('EventEmitter has been disposed');
       }
       this.listeners.add(listener);
 
@@ -29,7 +29,7 @@ export class TestEventEmitter<T> implements vscode.EventEmitter<T> {
 
   fire(data: T): void {
     if (this.disposed) {
-      throw new Error("EventEmitter has been disposed");
+      throw new Error('EventEmitter has been disposed');
     }
 
     for (const listener of this.listeners) {

--- a/src/test/helpers/http-server.ts
+++ b/src/test/helpers/http-server.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import EventEmitter from "events";
-import http from "http";
-import { AddressInfo } from "net";
-import * as sinon from "sinon";
+import EventEmitter from 'events';
+import http from 'http';
+import { AddressInfo } from 'net';
+import * as sinon from 'sinon';
 
 /**
  * Creates a stubbed instance of an {@link http.Server} which can trigger events
@@ -41,7 +41,7 @@ export function createHttpServerMock(
   fakeServer.address.returns(address);
   fakeServer.listen.yields();
   // Required since `listening` is a readonly getter.
-  Object.defineProperty(fakeServer, "listening", {
+  Object.defineProperty(fakeServer, 'listening', {
     get: () => true,
     // Make it configurable so we can override it in tests.
     configurable: true,

--- a/src/test/helpers/logging.ts
+++ b/src/test/helpers/logging.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Disposable, WorkspaceConfiguration } from "vscode";
-import { initializeLogger, LogLevel } from "../../common/logging";
-import { FakeLogOutputChannel } from "./output-channel";
-import { VsCodeStub } from "./vscode";
+import { Disposable, WorkspaceConfiguration } from 'vscode';
+import { initializeLogger, LogLevel } from '../../common/logging';
+import { FakeLogOutputChannel } from './output-channel';
+import { VsCodeStub } from './vscode';
 
 /**
  * Helper for capturing log output during tests.
@@ -20,11 +20,11 @@ export class ColabLogWatcher implements Disposable {
     this.logSink = new FakeLogOutputChannel();
     // Cast needed due to overloading.
     (vs.window.createOutputChannel as sinon.SinonStub)
-      .withArgs("Colab")
+      .withArgs('Colab')
       .returns(this.logSink);
-    vs.workspace.getConfiguration.withArgs("colab.logging").returns({
+    vs.workspace.getConfiguration.withArgs('colab.logging').returns({
       get: () => level,
-    } as Pick<WorkspaceConfiguration, "get"> as WorkspaceConfiguration);
+    } as Pick<WorkspaceConfiguration, 'get'> as WorkspaceConfiguration);
     vs.workspace.onDidChangeConfiguration.callsFake(() => {
       return {
         dispose() {
@@ -38,13 +38,13 @@ export class ColabLogWatcher implements Disposable {
     } catch (err: unknown) {
       const innerErrMsg = err instanceof Error ? err.message : String(err);
       const lines = [
-        "Failed to initialize logger for test.",
-        "Likely because a previous ColabLogWatcher was not disposed.",
-        "Ensure you call dispose() (e.g., in an afterEach) to clean up the watcher.",
-        "",
+        'Failed to initialize logger for test.',
+        'Likely because a previous ColabLogWatcher was not disposed.',
+        'Ensure you call dispose() (e.g., in an afterEach) to clean up the watcher.',
+        '',
         innerErrMsg,
       ];
-      throw new Error(lines.map((l, i) => (i === 0 ? l : `\t${l}`)).join("\n"));
+      throw new Error(lines.map((l, i) => (i === 0 ? l : `\t${l}`)).join('\n'));
     }
   }
 
@@ -55,7 +55,7 @@ export class ColabLogWatcher implements Disposable {
 
   get output(): string {
     if (!this.logging) {
-      throw new Error("Cannot get output after disposal.");
+      throw new Error('Cannot get output after disposal.');
     }
     return this.logSink.content;
   }

--- a/src/test/helpers/output-channel.ts
+++ b/src/test/helpers/output-channel.ts
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as sinon from "sinon";
-import { OutputChannel } from "vscode";
+import * as sinon from 'sinon';
+import { OutputChannel } from 'vscode';
 
 export class FakeLogOutputChannel implements OutputChannel {
-  readonly name = "fake";
+  readonly name = 'fake';
   readonly append = sinon.stub();
   readonly appendLine = sinon.stub<[string]>();
   readonly replace = sinon.stub();
@@ -26,6 +26,6 @@ export class FakeLogOutputChannel implements OutputChannel {
   }
 
   get content(): string {
-    return this.lines.join("\n");
+    return this.lines.join('\n');
   }
 }

--- a/src/test/helpers/quick-input.ts
+++ b/src/test/helpers/quick-input.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as sinon from "sinon";
-import { Disposable, InputBox, QuickPick, QuickPickItem } from "vscode";
+import * as sinon from 'sinon';
+import { Disposable, InputBox, QuickPick, QuickPickItem } from 'vscode';
 
 /**
  * Convenience type used for stubbing the input event listeners.
@@ -24,19 +24,19 @@ type Listener = [
 export type QuickPickStub = sinon.SinonStubbedInstance<
   Pick<
     QuickPick<QuickPickItem>,
-    | "title"
-    | "step"
-    | "totalSteps"
-    | "ignoreFocusOut"
-    | "placeholder"
-    | "items"
-    | "activeItems"
-    | "buttons"
-    | "onDidTriggerButton"
-    | "onDidHide"
-    | "onDidChangeSelection"
-    | "show"
-    | "dispose"
+    | 'title'
+    | 'step'
+    | 'totalSteps'
+    | 'ignoreFocusOut'
+    | 'placeholder'
+    | 'items'
+    | 'activeItems'
+    | 'buttons'
+    | 'onDidTriggerButton'
+    | 'onDidHide'
+    | 'onDidChangeSelection'
+    | 'show'
+    | 'dispose'
   >
 >;
 
@@ -96,21 +96,21 @@ export function buildQuickPickStub(
 export type InputBoxStub = sinon.SinonStubbedInstance<
   Pick<
     InputBox,
-    | "title"
-    | "step"
-    | "totalSteps"
-    | "value"
-    | "prompt"
-    | "validationMessage"
-    | "ignoreFocusOut"
-    | "placeholder"
-    | "buttons"
-    | "onDidTriggerButton"
-    | "onDidHide"
-    | "onDidAccept"
-    | "onDidChangeValue"
-    | "show"
-    | "dispose"
+    | 'title'
+    | 'step'
+    | 'totalSteps'
+    | 'value'
+    | 'prompt'
+    | 'validationMessage'
+    | 'ignoreFocusOut'
+    | 'placeholder'
+    | 'buttons'
+    | 'onDidTriggerButton'
+    | 'onDidHide'
+    | 'onDidAccept'
+    | 'onDidChangeValue'
+    | 'show'
+    | 'dispose'
   >
 >;
 
@@ -140,7 +140,7 @@ export function buildInputBoxStub(
     title: undefined,
     step: undefined,
     totalSteps: undefined,
-    value: "",
+    value: '',
     prompt: undefined,
     validationMessage: undefined,
     ignoreFocusOut: false,

--- a/src/test/helpers/secret-storage.ts
+++ b/src/test/helpers/secret-storage.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import sinon, { SinonStubbedInstance } from "sinon";
-import { SecretStorage } from "vscode";
+import sinon, { SinonStubbedInstance } from 'sinon';
+import { SecretStorage } from 'vscode';
 
 /**
  * A thin fake implementation backed by stubs of `SecretStorage` that stores
@@ -15,7 +15,7 @@ import { SecretStorage } from "vscode";
  */
 export class SecretStorageFake
   implements
-    SinonStubbedInstance<Pick<SecretStorage, "get" | "store" | "delete">>
+    SinonStubbedInstance<Pick<SecretStorage, 'get' | 'store' | 'delete'>>
 {
   private lastStore?: string;
 

--- a/src/test/helpers/server-storage.ts
+++ b/src/test/helpers/server-storage.ts
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { UUID } from "crypto";
-import { ColabAssignedServer } from "../../jupyter/servers";
-import { ServerStorage } from "../../jupyter/storage";
+import { UUID } from 'crypto';
+import { ColabAssignedServer } from '../../jupyter/servers';
+import { ServerStorage } from '../../jupyter/storage';
 
 /**
  * An in memory fake implementation of {@link ServerStorage}.
  */
 export class ServerStorageFake
-  implements Pick<ServerStorage, "list" | "get" | "store" | "remove" | "clear">
+  implements Pick<ServerStorage, 'list' | 'get' | 'store' | 'remove' | 'clear'>
 {
   private servers?: ColabAssignedServer[];
 

--- a/src/test/helpers/uri.ts
+++ b/src/test/helpers/uri.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { join } from "path";
-import * as sinon from "sinon";
-import vscode from "vscode";
+import { join } from 'path';
+import * as sinon from 'sinon';
+import vscode from 'vscode';
 
 interface UriOptions {
   scheme: string;
@@ -23,21 +23,21 @@ export class TestUri implements vscode.Uri {
   static parse(stringUri: string): TestUri {
     const url = new URL(stringUri);
     return new TestUri(
-      url.protocol.replace(/:$/, ""),
+      url.protocol.replace(/:$/, ''),
       url.hostname,
       url.pathname,
-      url.search.replace(/^\?/, ""),
-      url.hash.replace(/^#/, ""),
+      url.search.replace(/^\?/, ''),
+      url.hash.replace(/^#/, ''),
     );
   }
 
   static file(filePath: string): TestUri {
     return new TestUri(
-      "file",
-      "",
-      filePath.split("?")[0] || "",
-      filePath.split("?")[1] || "",
-      "",
+      'file',
+      '',
+      filePath.split('?')[0] || '',
+      filePath.split('?')[1] || '',
+      '',
     );
   }
 
@@ -123,7 +123,7 @@ export class TestUri implements vscode.Uri {
  * @returns A Sinon matcher for the URI.
  */
 export function matchUri(regExp: RegExp | string): sinon.SinonMatcher {
-  if (typeof regExp === "string") {
+  if (typeof regExp === 'string') {
     regExp = new RegExp(regExp);
   }
   return sinon.match((uri: vscode.Uri) => regExp.test(uri.toString()));

--- a/src/test/helpers/vscode.ts
+++ b/src/test/helpers/vscode.ts
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as sinon from "sinon";
-import vscode from "vscode";
-import { FakeAuthenticationProviderManager } from "./authentication";
-import { TestCancellationTokenSource } from "./cancellation";
-import { TestEventEmitter } from "./events";
-import { TestUri } from "./uri";
+import * as sinon from 'sinon';
+import vscode from 'vscode';
+import { FakeAuthenticationProviderManager } from './authentication';
+import { TestCancellationTokenSource } from './cancellation';
+import { TestEventEmitter } from './events';
+import { TestUri } from './uri';
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 class TestQuickInputButtons implements vscode.QuickInputButtons {
   static readonly Back: vscode.QuickInputButton = {
     iconPath: {
-      id: "back",
+      id: 'back',
     },
   };
 }
@@ -165,7 +165,7 @@ export function newVsCodeStub(): VsCodeStub {
     },
     UIKind: UIKind,
     env: {
-      uriScheme: "vscode",
+      uriScheme: 'vscode',
       uiKind: UIKind.Desktop,
       openExternal: sinon.stub(),
       asExternalUri: sinon.stub(),

--- a/src/test/integration-test-runner.ts
+++ b/src/test/integration-test-runner.ts
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { spawnSync } from "child_process";
-import * as fs from "fs";
-import * as path from "path";
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 import {
   downloadAndUnzipVSCode,
   resolveCliPathFromVSCodeExecutablePath,
   runTests,
-} from "@vscode/test-electron";
+} from '@vscode/test-electron';
 
 function getExtensionsDir(vscodeExecutablePath: string): string {
-  const extDirPath = path.resolve(vscodeExecutablePath, "../", "extensions");
+  const extDirPath = path.resolve(vscodeExecutablePath, '../', 'extensions');
   if (!fs.existsSync(extDirPath)) {
     fs.mkdirSync(extDirPath);
   }
@@ -26,51 +26,51 @@ function installExtension(
   extensionsDir: string,
   extension: string,
 ) {
-  console.info("Installing Jupyter Extension");
+  console.info('Installing Jupyter Extension');
   spawnSync(
     cliPath,
     [
-      "--install-extension",
+      '--install-extension',
       extension,
-      "--extensions-dir",
+      '--extensions-dir',
       extensionsDir,
-      "--disable-telemetry",
+      '--disable-telemetry',
     ],
     {
-      encoding: "utf-8",
-      stdio: "inherit",
+      encoding: 'utf-8',
+      stdio: 'inherit',
     },
   );
 }
 
 async function main() {
   try {
-    const extensionDevelopmentPath = path.resolve(__dirname, "../../../");
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../../');
 
-    const extensionTestsPath = path.resolve(__dirname, "../suite/index");
-    const vscodeExecutablePath = await downloadAndUnzipVSCode("insiders");
+    const extensionTestsPath = path.resolve(__dirname, '../suite/index');
+    const vscodeExecutablePath = await downloadAndUnzipVSCode('insiders');
     const cliPath =
       resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
     const extensionsDir = getExtensionsDir(vscodeExecutablePath);
 
-    installExtension(cliPath, extensionsDir, "ms-toolsai.jupyter");
+    installExtension(cliPath, extensionsDir, 'ms-toolsai.jupyter');
 
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
-      launchArgs: ["--extensions-dir", extensionsDir]
-        .concat(["--skip-welcome"])
-        .concat(["--skip-release-notes"])
-        .concat(["--timeout", "5000"]),
-      version: "insiders",
+      launchArgs: ['--extensions-dir', extensionsDir]
+        .concat(['--skip-welcome'])
+        .concat(['--skip-release-notes'])
+        .concat(['--timeout', '5000']),
+      version: 'insiders',
     });
   } catch (err) {
-    console.error("Failed to run tests", err);
+    console.error('Failed to run tests', err);
     process.exit(1);
   }
 }
 
 main().catch((error: unknown) => {
-  console.error("Unhandled error in main function", error);
+  console.error('Unhandled error in main function', error);
   process.exit(1);
 });

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as path from "path";
-import { Glob } from "glob";
-import Mocha from "mocha";
+import * as path from 'path';
+import { Glob } from 'glob';
+import Mocha from 'mocha';
 
 export function run(): Promise<void> {
   const mocha = new Mocha({
-    ui: "bdd",
+    ui: 'bdd',
   });
 
-  const testsRoot = path.resolve(__dirname, "..");
+  const testsRoot = path.resolve(__dirname, '..');
 
   return new Promise((c, e) => {
-    const files = new Glob("**/**vscode.test.js", { cwd: testsRoot });
+    const files = new Glob('**/**vscode.test.js', { cwd: testsRoot });
 
     for (const file of files) {
       mocha.addFile(path.resolve(testsRoot, file));

--- a/src/test/unit-test-setup.ts
+++ b/src/test/unit-test-setup.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as chai from "chai";
-import chaiAsPromised from "chai-as-promised";
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
 chai.use(chaiAsPromised);

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { UUID } from "crypto";
+import { UUID } from 'crypto';
 
 /**
  * Type guard to check if a value is a valid UUID. Ensures the string follows
@@ -29,5 +29,5 @@ export function isUUID(value: string): value is UUID {
  */
 export function uuidToWebSafeBase64(uuid: UUID): string {
   // Ensure 44-character length by adding the necessary padding.
-  return uuid.replace(/-/g, "_") + ".".repeat(44 - uuid.length);
+  return uuid.replace(/-/g, '_') + '.'.repeat(44 - uuid.length);
 }


### PR DESCRIPTION
* **Why**? This is to conform with https://google.github.io/styleguide/tsguide.html#string-literals.
* Also, it looks like people externally tend to use single quotes too: [example 1](https://github.com/microsoft/vscode-jupyter/blob/main/.prettierrc.js#L2) and [example 2](https://github.com/microsoft/vscode-extension-samples/blob/main/.prettierrc.json#L3).