### PR TITLE
refactor: use the generated jupyter client

### DIFF
--- a/src/colab/api.ts
+++ b/src/colab/api.ts
@@ -24,6 +24,10 @@
  */
 
 import { z } from 'zod';
+import {
+  Session as GeneratedSession,
+  Kernel as GeneratedKernel,
+} from '../jupyter/client/generated';
 
 export enum SubscriptionState {
   UNSUBSCRIBED = 1,
@@ -337,7 +341,7 @@ export type Assignment = z.infer<typeof AssignmentSchema>;
 /** A Colab Jupyter kernel returned from the Colab API. */
 // This can be obtained by querying the Jupyter REST API's /api/spec.yaml
 // endpoint.
-export const KernelSchema = z
+export const KernelSchema: z.ZodType<GeneratedKernel> = z
   .object({
     /** The UUID of the kernel. */
     id: z.string(),
@@ -361,7 +365,7 @@ export const KernelSchema = z
 export type Kernel = z.infer<typeof KernelSchema>;
 
 /** A session to a Colab Jupyter kernel returned from the Colab API. */
-export const SessionSchema = z.object({
+export const SessionSchema: z.ZodType<GeneratedSession> = z.object({
   /** The UUID of the session. */
   id: z.string(),
   /** The kernel associated with the session. */

--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -9,7 +9,8 @@ import * as https from 'https';
 import fetch, { Request, RequestInit, Headers } from 'node-fetch';
 import { z } from 'zod';
 import { traceMethod } from '../common/logging/decorators';
-import { ColabAssignedServer } from '../jupyter/servers';
+import { JupyterClient } from '../jupyter/client';
+import { Session } from '../jupyter/client/generated';
 import { uuidToWebSafeBase64 } from '../utils/uuid';
 import {
   Assignment,
@@ -19,10 +20,6 @@ import {
   CcuInfoSchema,
   AssignmentSchema,
   GetAssignmentResponseSchema,
-  KernelSchema,
-  Kernel,
-  SessionSchema,
-  Session,
   UserInfoSchema,
   SubscriptionTier,
   PostAssignmentResponse,
@@ -33,12 +30,12 @@ import {
   RuntimeProxyInfo,
   RuntimeProxyInfoSchema,
   Shape,
+  SessionSchema,
 } from './api';
 import {
   ACCEPT_JSON_HEADER,
   AUTHORIZATION_HEADER,
   COLAB_CLIENT_AGENT_HEADER,
-  COLAB_RUNTIME_PROXY_TOKEN_HEADER,
   COLAB_TUNNEL_HEADER,
   COLAB_XSRF_TOKEN_HEADER,
 } from './headers';
@@ -251,61 +248,22 @@ export class ColabClient {
   }
 
   /**
-   * Lists all kernels for a given server.
+   * Lists all sessions for a given server by its endpoint.
    *
-   * @param server - The server to list kernels for.
-   * @param signal - Optional {@link AbortSignal} to cancel the request.
-   * @returns The list of kernels.
-   */
-  async listKernels(
-    server: ColabAssignedServer,
-    signal?: AbortSignal,
-  ): Promise<Kernel[]> {
-    const url = new URL(
-      'api/kernels',
-      server.connectionInformation.baseUrl.toString(),
-    );
-    return await this.issueRequest(
-      url,
-      {
-        method: 'GET',
-        headers: {
-          [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
-            server.connectionInformation.token,
-        },
-        signal,
-      },
-      z.array(KernelSchema),
-    );
-  }
-
-  /**
-   * Lists all sessions for a given server or assignment endpoint.
-   *
-   * @param serverOrEndpoint - The server or assignment endpoint to list
-   *   sessions for.
+   * @param endpoint - The assignment endpoint to list sessions for.
    * @param signal - Optional {@link AbortSignal} to cancel the request.
    * @returns The list of sessions.
    */
   async listSessions(
-    serverOrEndpoint: ColabAssignedServer | string,
+    endpoint: string,
     signal?: AbortSignal,
   ): Promise<Session[]> {
-    let url: URL;
-    let headers: fetch.HeadersInit;
-    if (typeof serverOrEndpoint === 'string') {
-      url = new URL(
-        `${TUN_ENDPOINT}/${serverOrEndpoint}/api/sessions`,
-        this.colabDomain,
-      );
-      headers = { [COLAB_TUNNEL_HEADER.key]: COLAB_TUNNEL_HEADER.value };
-    } else {
-      const connectionInfo = serverOrEndpoint.connectionInformation;
-      url = new URL('api/sessions', connectionInfo.baseUrl.toString());
-      headers = {
-        [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: connectionInfo.token,
-      };
-    }
+    const url = new URL(
+      `${TUN_ENDPOINT}/${endpoint}/api/sessions`,
+      this.colabDomain,
+    );
+    const headers = { [COLAB_TUNNEL_HEADER.key]: COLAB_TUNNEL_HEADER.value };
+
     return await this.issueRequest(
       url,
       {
@@ -315,32 +273,6 @@ export class ColabClient {
       },
       z.array(SessionSchema),
     );
-  }
-
-  /**
-   * Deletes the given session
-   *
-   * @param server - The server with the session to delete.
-   * @param sessionId - The ID of the session to delete.
-   * @param signal - Optional {@link AbortSignal} to cancel the request.
-   */
-  async deleteSession(
-    server: ColabAssignedServer,
-    sessionId: string,
-    signal?: AbortSignal,
-  ) {
-    const url = new URL(
-      `api/sessions/${sessionId}`,
-      server.connectionInformation.baseUrl.toString(),
-    );
-    await this.issueRequest(url, {
-      method: 'DELETE',
-      headers: {
-        [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
-          server.connectionInformation.token,
-      },
-      signal,
-    });
   }
 
   /**
@@ -493,6 +425,8 @@ export class ColabClient {
     return schema.parse(JSON.parse(stripXssiPrefix(body)));
   }
 }
+
+export interface PersistentJupyterClient extends JupyterClient, Disposable {}
 
 /** Error thrown when the user has too many assignments. */
 export class TooManyAssignmentsError extends Error {}

--- a/src/colab/keep-alive.unit.test.ts
+++ b/src/colab/keep-alive.unit.test.ts
@@ -8,10 +8,17 @@ import { randomUUID } from 'crypto';
 import { expect } from 'chai';
 import sinon, { SinonFakeTimers, SinonStubbedInstance } from 'sinon';
 import { AssignmentManager } from '../jupyter/assignments';
+import { JupyterClient, ProxiedJupyterClient } from '../jupyter/client';
+import { Kernel } from '../jupyter/client/generated';
 import { ColabAssignedServer } from '../jupyter/servers';
 import { TestCancellationTokenSource } from '../test/helpers/cancellation';
+import {
+  createJupyterClientStub,
+  JupyterClientStub,
+} from '../test/helpers/jupyter';
+import { TestUri } from '../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
-import { Kernel, Variant } from './api';
+import { Variant } from './api';
 import { ColabClient } from './client';
 import {
   COLAB_CLIENT_AGENT_HEADER,
@@ -47,12 +54,34 @@ const DEFAULT_KERNEL: Kernel = {
   connections: 1,
 };
 
+const DEFAULT_SERVER = {
+  id: randomUUID(),
+  label: 'Colab GPU A100',
+  variant: Variant.GPU,
+  accelerator: 'A100',
+  endpoint: 'm-s-foo',
+  connectionInformation: {
+    baseUrl: TestUri.parse('https://example.com'),
+    token: '123',
+    tokenExpiry: new Date(Date.now() + 1000 * 60 * 60),
+    headers: {
+      [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: '123',
+      [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
+    },
+  },
+  dateAssigned: new Date(),
+};
+
 describe('ServerKeepAliveController', () => {
   let clock: SinonFakeTimers;
   let vsCodeStub: VsCodeStub;
   let colabClientStub: SinonStubbedInstance<ColabClient>;
+  let jupyterClientFactoryStub: sinon.SinonStub<
+    [server: ColabAssignedServer],
+    JupyterClient
+  >;
+  let defaultServerJupyterStub: JupyterClientStub;
   let assignmentStub: SinonStubbedInstance<AssignmentManager>;
-  let defaultServer: ColabAssignedServer;
   let keepAlive: ServerKeepAliveController;
 
   async function tickPast(ms: number) {
@@ -66,24 +95,15 @@ describe('ServerKeepAliveController', () => {
     clock.setSystemTime(NOW);
     vsCodeStub = newVsCodeStub();
     colabClientStub = sinon.createStubInstance(ColabClient);
+    jupyterClientFactoryStub = sinon.stub(
+      ProxiedJupyterClient,
+      'withStaticConnection',
+    );
+    defaultServerJupyterStub = createJupyterClientStub();
+    jupyterClientFactoryStub
+      .withArgs(DEFAULT_SERVER)
+      .returns(defaultServerJupyterStub);
     assignmentStub = sinon.createStubInstance(AssignmentManager);
-    defaultServer = {
-      id: randomUUID(),
-      label: 'Colab GPU A100',
-      variant: Variant.GPU,
-      accelerator: 'A100',
-      endpoint: 'm-s-foo',
-      connectionInformation: {
-        baseUrl: vsCodeStub.Uri.parse('https://example.com'),
-        token: '123',
-        tokenExpiry: new Date(Date.now() + 1000 * 60 * 60),
-        headers: {
-          [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: '123',
-          [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
-        },
-      },
-      dateAssigned: new Date(),
-    };
     keepAlive = new ServerKeepAliveController(
       vsCodeStub.asVsCode(),
       colabClientStub,
@@ -128,10 +148,8 @@ describe('ServerKeepAliveController', () => {
       // Type assertion needed due to overloading on getServers
       (assignmentStub.getServers as sinon.SinonStub)
         .withArgs('extension')
-        .resolves([defaultServer]);
-      colabClientStub.listKernels
-        .withArgs(defaultServer)
-        .resolves([DEFAULT_KERNEL]);
+        .resolves([DEFAULT_SERVER]);
+      defaultServerJupyterStub.kernels.list.resolves([DEFAULT_KERNEL]);
       colabClientStub.sendKeepAlive.callsFake(ABORTING_KEEP_ALIVE);
       keepAlive = new ServerKeepAliveController(
         vsCodeStub.asVsCode(),
@@ -156,10 +174,8 @@ describe('ServerKeepAliveController', () => {
       // Type assertion needed due to overloading on getServers
       (assignmentStub.getServers as sinon.SinonStub)
         .withArgs('extension')
-        .resolves([defaultServer]);
-      colabClientStub.listKernels
-        .withArgs(defaultServer)
-        .resolves([DEFAULT_KERNEL]);
+        .resolves([DEFAULT_SERVER]);
+      defaultServerJupyterStub.kernels.list.resolves([DEFAULT_KERNEL]);
 
       // On
       keepAlive.on();
@@ -187,10 +203,8 @@ describe('ServerKeepAliveController', () => {
       // Type assertion needed due to overloading on getServers
       (assignmentStub.getServers as sinon.SinonStub)
         .withArgs('extension')
-        .resolves([defaultServer]);
-      colabClientStub.listKernels
-        .withArgs(defaultServer)
-        .resolves([DEFAULT_KERNEL]);
+        .resolves([DEFAULT_SERVER]);
+      defaultServerJupyterStub.kernels.list.resolves([DEFAULT_KERNEL]);
       colabClientStub.sendKeepAlive
         .onFirstCall()
         .callsFake(ABORTING_KEEP_ALIVE);
@@ -214,7 +228,7 @@ describe('ServerKeepAliveController', () => {
         await tickPast(CONFIG.keepAliveIntervalMs);
 
         sinon.assert.calledOnce(assignmentStub.getServers);
-        sinon.assert.notCalled(colabClientStub.listKernels);
+        sinon.assert.notCalled(jupyterClientFactoryStub);
         sinon.assert.notCalled(colabClientStub.sendKeepAlive);
       });
     });
@@ -224,20 +238,18 @@ describe('ServerKeepAliveController', () => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
           .withArgs('extension')
-          .resolves([defaultServer]);
+          .resolves([DEFAULT_SERVER]);
       });
 
       it('sends a keep-alive request for a server with recent activity', async () => {
-        colabClientStub.listKernels
-          .withArgs(defaultServer)
-          .resolves([DEFAULT_KERNEL]);
+        defaultServerJupyterStub.kernels.list.resolves([DEFAULT_KERNEL]);
 
         await tickPast(CONFIG.keepAliveIntervalMs);
 
         sinon.assert.calledOnce(colabClientStub.sendKeepAlive);
         sinon.assert.calledWith(
           colabClientStub.sendKeepAlive,
-          defaultServer.endpoint,
+          DEFAULT_SERVER.endpoint,
         );
       });
 
@@ -254,16 +266,14 @@ describe('ServerKeepAliveController', () => {
               NOW.getTime() - CONFIG.inactivityThresholdMs - 1,
             ).toString(),
           };
-          colabClientStub.listKernels
-            .withArgs(defaultServer)
-            .resolves([busyKernel]);
+          defaultServerJupyterStub.kernels.list.resolves([busyKernel]);
 
           await tickPast(CONFIG.keepAliveIntervalMs);
 
           sinon.assert.calledOnce(colabClientStub.sendKeepAlive);
           sinon.assert.calledWith(
             colabClientStub.sendKeepAlive,
-            defaultServer.endpoint,
+            DEFAULT_SERVER.endpoint,
           );
         });
       }
@@ -291,10 +301,8 @@ describe('ServerKeepAliveController', () => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
           .withArgs('extension')
-          .resolves([defaultServer]);
-        colabClientStub.listKernels
-          .withArgs(defaultServer)
-          .resolves([idleKernel]);
+          .resolves([DEFAULT_SERVER]);
+        defaultServerJupyterStub.kernels.list.resolves([idleKernel]);
         cancellationSource = new vsCodeStub.CancellationTokenSource();
         reportStub = sinon.stub();
         vsCodeStub.window.withProgress
@@ -368,9 +376,7 @@ describe('ServerKeepAliveController', () => {
             ...idleKernel,
             lastActivity: NOW.toString(),
           };
-          colabClientStub.listKernels
-            .withArgs(defaultServer)
-            .resolves([activeKernel]);
+          defaultServerJupyterStub.kernels.list.resolves([activeKernel]);
 
           await tickPast(CONFIG.keepAliveIntervalMs);
 
@@ -398,9 +404,7 @@ describe('ServerKeepAliveController', () => {
               ...idleKernel,
               lastActivity: NOW.toString(),
             };
-            colabClientStub.listKernels
-              .withArgs(defaultServer)
-              .resolves([activeKernel]);
+            defaultServerJupyterStub.kernels.list.resolves([activeKernel]);
             await tickPast(CONFIG.keepAliveIntervalMs);
           });
 
@@ -424,7 +428,7 @@ describe('ServerKeepAliveController', () => {
         activity: 'idle' | 'active',
       ): { server: ColabAssignedServer; kernel: Kernel } {
         const server = {
-          ...defaultServer,
+          ...DEFAULT_SERVER,
           id: randomUUID(),
           endpoint: `m-s-${n.toString()}`,
         };
@@ -458,7 +462,9 @@ describe('ServerKeepAliveController', () => {
         idle2 = createServerWithKernel(4, 'idle');
         const servers = [active1, active2, idle1, idle2];
         for (const { server, kernel } of servers) {
-          colabClientStub.listKernels.withArgs(server).resolves([kernel]);
+          const jupyterStub = createJupyterClientStub();
+          jupyterClientFactoryStub.withArgs(server).returns(jupyterStub);
+          jupyterStub.kernels.list.resolves([kernel]);
         }
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
@@ -547,7 +553,7 @@ describe('ServerKeepAliveController', () => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
           .withArgs('extension')
-          .resolves([defaultServer]);
+          .resolves([DEFAULT_SERVER]);
         const kernels: Kernel[] = [
           DEFAULT_KERNEL,
           // An "idle" kernel.
@@ -557,14 +563,14 @@ describe('ServerKeepAliveController', () => {
             lastActivity: new Date(42).toString(),
           },
         ];
-        colabClientStub.listKernels.withArgs(defaultServer).resolves(kernels);
+        defaultServerJupyterStub.kernels.list.resolves(kernels);
 
         await tickPast(CONFIG.keepAliveIntervalMs);
 
         sinon.assert.calledOnce(colabClientStub.sendKeepAlive);
         sinon.assert.calledWith(
           colabClientStub.sendKeepAlive,
-          defaultServer.endpoint,
+          DEFAULT_SERVER.endpoint,
         );
       });
 
@@ -572,7 +578,7 @@ describe('ServerKeepAliveController', () => {
         // Type assertion needed due to overloading on getServers
         (assignmentStub.getServers as sinon.SinonStub)
           .withArgs('extension')
-          .resolves([defaultServer]);
+          .resolves([DEFAULT_SERVER]);
         const kernels: Kernel[] = [
           {
             ...DEFAULT_KERNEL,
@@ -585,7 +591,7 @@ describe('ServerKeepAliveController', () => {
             lastActivity: new Date(43).toString(),
           },
         ];
-        colabClientStub.listKernels.withArgs(defaultServer).resolves(kernels);
+        defaultServerJupyterStub.kernels.list.resolves(kernels);
         await tickPast(CONFIG.keepAliveIntervalMs);
 
         sinon.assert.notCalled(colabClientStub.sendKeepAlive);

--- a/src/test/helpers/jupyter.ts
+++ b/src/test/helpers/jupyter.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import sinon from 'sinon';
+import { JupyterClient } from '../../jupyter/client';
+import {
+  ConfigApi,
+  ContentsApi,
+  IdentityApi,
+  KernelsApi,
+  KernelspecsApi,
+  SessionsApi,
+  StatusApi,
+  TerminalsApi,
+} from '../../jupyter/client/generated';
+
+/**
+ * A stub of a JupyterClient.
+ */
+export interface JupyterClientStub extends JupyterClient {
+  readonly config: sinon.SinonStubbedInstance<JupyterClient['config']>;
+  readonly contents: sinon.SinonStubbedInstance<JupyterClient['contents']>;
+  readonly identity: sinon.SinonStubbedInstance<JupyterClient['identity']>;
+  readonly kernels: sinon.SinonStubbedInstance<JupyterClient['kernels']>;
+  readonly kernelspecs: sinon.SinonStubbedInstance<
+    JupyterClient['kernelspecs']
+  >;
+  readonly sessions: sinon.SinonStubbedInstance<JupyterClient['sessions']>;
+  readonly status: sinon.SinonStubbedInstance<JupyterClient['status']>;
+  readonly terminals: sinon.SinonStubbedInstance<JupyterClient['terminals']>;
+}
+
+/**
+ * Creates a stub of a JupyterClient.
+ */
+export function createJupyterClientStub(): JupyterClientStub {
+  return {
+    config: sinon.createStubInstance(ConfigApi),
+    contents: sinon.createStubInstance(ContentsApi),
+    identity: sinon.createStubInstance(IdentityApi),
+    kernels: sinon.createStubInstance(KernelsApi),
+    kernelspecs: sinon.createStubInstance(KernelspecsApi),
+    sessions: sinon.createStubInstance(SessionsApi),
+    status: sinon.createStubInstance(StatusApi),
+    terminals: sinon.createStubInstance(TerminalsApi),
+  };
+}


### PR DESCRIPTION
This effectively migrates all `/api` requests to the generated Jupyter client.

Added `src/test/helpers/jupyter.ts` to facilitate stubbing.

Since we still need to be able to `listSession` on the `tun/m` endpoint (to get the non-VS servers) we still need to Zod definition. Added `z.ZodType` annotations to ensure consistency.