### PR TITLE
fix: add trash icon to remove server

### DIFF
--- a/src/colab/commands/constants.ts
+++ b/src/colab/commands/constants.ts
@@ -57,7 +57,7 @@ export const OPEN_COLAB_WEB: Command = {
 /** Command to remove a server. */
 export const REMOVE_SERVER: RegisteredCommand = {
   id: 'colab.removeServer',
-  label: 'Remove Server',
+  label: '$(trash)  Remove Server',
 };
 
 /** Command to rename a server alias. */


### PR DESCRIPTION
<img width="1025" height="206" alt="image" src="https://github.com/user-attachments/assets/aaf260b5-6546-4d8c-b128-d10c091e29d1" />

I've got a downstream PR which adds another command to the toolbar. The icons make disambiguating easier.