### PR TITLE
fix: specify keywords and add categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,15 +23,18 @@
     "ms-toolsai.jupyter"
   ],
   "categories": [
+    "Data Science",
+    "Machine Learning",
     "Notebooks"
   ],
-  "tags": [
+  "keywords": [
     "colab",
     "google",
     "interactive",
     "julia",
     "jupyter",
     "notebook",
+    "notebookKernelJupyterNotebook",
     "python",
     "r"
   ],


### PR DESCRIPTION
https://code.visualstudio.com/api/references/extension-manifest

I don't know where I got `tags` from, but `keywords` is what we need. The funky looking one, `notebookKernelJupyterNotebook`, is what's used when there are no Jupyter server providers and you click the button which brings you to the marketplace.