### PR TITLE
test: add e2e test cases to verify df display and plot

### DIFF
--- a/src/test/extension.e2e.test.ts
+++ b/src/test/extension.e2e.test.ts
@@ -25,7 +25,7 @@ import {
 import { CONFIG } from '../colab-config';
 
 const ELEMENT_WAIT_MS = 10000;
-const CELL_EXECUTION_WAIT_MS = 45000;
+const CELL_EXECUTION_WAIT_MS = 30000;
 
 describe('Colab Extension', function () {
   dotenv.config();


### PR DESCRIPTION
**Why**? This is to add more Kernel related test coverage to increase confidence of our custom `WebSocket` override in https://github.com/googlecolab/colab-vscode/pull/297.