### PR TITLE
fix: catch access errors during token refresh and remove session

### DIFF
--- a/src/auth/auth-provider.unit.test.ts
+++ b/src/auth/auth-provider.unit.test.ts
@@ -566,13 +566,13 @@ describe('GoogleAuthProvider', () => {
         });
       }
 
-      it('re-throws non handled errors when refreshing the access token', async () => {
+      it('ignores unhandled errors when refreshing the access token', async () => {
         refreshAccessTokenStub.throws(new Error('🤮'));
         fakeClock.tick(HOUR_MS * 2);
 
         const sessions = authProvider.getSessions(undefined, {});
 
-        await expect(sessions).to.eventually.be.rejectedWith(/🤮/);
+        await expect(sessions).to.eventually.deep.equal([DEFAULT_AUTH_SESSION]);
       });
     });
   });


### PR DESCRIPTION
When refreshing the access token, if certain `GaxiosErrors` occur, the session should be removed from storage correctly whether the AuthProvider is initialized or not. Added tests to verify this behavior.

This specific scenario is hard to reproduce manually so there is no screencast attached. 