### PR TITLE
build: bump version to `0.1.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "glob": "^11.1.0",
         "google-auth-library": "^9.15.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
User-impacting changes since last bump/release:

- _Remove Server_ command icon (#312 and #314)
- Added keywords and categories in the marketplace (#313)
- Auth provider lifecycle to prevent unhandled error (#311)
- Add the option to select high-ram machines when available (#294)

Commit log since last bump/release:

- 2beb98a fix: properly set command icons across uses (#314)
- 6182fa7 test: add e2e test cases to verify df display and plot (#315)
- f3f3736 fix: specify keywords and add categories (#313)
- 84296ec fix: register the auth provider on initialize (#311)
- fb25c91 fix: add trash icon to remove server (#312)
- d192db1 chore: include args in traces for promise results (#310)
- ba348ed refactor: use the generated jupyter client (#308)
- ab2e773 feat: implement the `ProxiedJupyterClient` (#307)
- c1ba560 feat: allow high-ram machine shapes for pro users (#294)
- c67b83b feat: generate Jupyter server client from API spec (#304)
- 1b29b5c chore: update prettier to use single quotes for TS/JS (#305)
- c1288ac refactor: log assignServer() error for debugging (#303)
- 70c3dd9 refactor: getAssignedServers() and getAllServers() to getServers() overloads (#292)