### PR TITLE
feat: converters between Jupyter and VS files

### DIFF
--- a/src/jupyter/client/converters.ts
+++ b/src/jupyter/client/converters.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vscode, { FileStat, FileType } from 'vscode';
+import { Contents, ContentsTypeEnum } from './generated';
+
+/**
+ * Convert from a Jupyter contents type to the VS Code {@link FileType}.
+ *
+ * @param vs - The vscode module.
+ * @param type - the Jupyter contents type to convert.
+ * @returns A {@link FileType.Directory} for a Jupyter 'directory', otherwise a
+ * {@link FileType.File}.
+ */
+export function toFileType(
+  vs: typeof vscode,
+  type: ContentsTypeEnum,
+): FileType {
+  switch (type) {
+    case 'directory':
+      return vs.FileType.Directory;
+    case 'notebook':
+    case 'file':
+    default:
+      return vs.FileType.File;
+  }
+}
+
+/**
+ * Convert from Jupyter {@link Contents} to a VS Code {@link FileStat}.
+ *
+ * @param vs - The vscode module.
+ * @param contents - the Jupyter contents to convert.
+ * @returns A {@link FileStat} for the {@link Contents}, with missing values
+ * converted to their equivalent defaults.
+ */
+export function toFileStat(vs: typeof vscode, contents: Contents): FileStat {
+  return {
+    type: toFileType(vs, contents.type),
+    ctime: contents.created ? new Date(contents.created).getTime() : 0,
+    mtime: contents.lastModified
+      ? new Date(contents.lastModified).getTime()
+      : 0,
+    size: contents.size ?? 0,
+  };
+}
+
+/**
+ * A subtype of {@link Contents} which represents a directory. Has the `type` of
+ * 'directory' and `contents` is an array of {@link Contents}.
+ */
+export type DirectoryContents = Omit<Contents, 'content' | 'type'> & {
+  content: Contents[];
+  type: 'directory';
+};
+
+/**
+ * A type-guard to determine if the provided contents represent a directory.
+ *
+ * @param contents - the Jupyter contents to evaluate.
+ * @returns a type-guard asserting the provided {@link Contents} are
+ * {@link DirectoryContents}.
+ */
+export function isDirectoryContents(
+  contents: Contents,
+): contents is DirectoryContents {
+  return (
+    contents.type === ContentsTypeEnum.Directory &&
+    Array.isArray(contents.content)
+  );
+}

--- a/src/jupyter/client/converters.unit.test.ts
+++ b/src/jupyter/client/converters.unit.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import { FileType, newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
+import { isDirectoryContents, toFileStat, toFileType } from './converters';
+import { Contents, ContentsTypeEnum } from './generated';
+
+describe('converters', () => {
+  let vs: VsCodeStub;
+
+  beforeEach(() => {
+    vs = newVsCodeStub();
+  });
+
+  describe('toFileType', () => {
+    it('converts directory type', () => {
+      expect(toFileType(vs.asVsCode(), 'directory')).to.equal(
+        FileType.Directory,
+      );
+    });
+
+    it('converts file type', () => {
+      expect(toFileType(vs.asVsCode(), 'file')).to.equal(FileType.File);
+    });
+
+    it('converts notebook type to file', () => {
+      expect(toFileType(vs.asVsCode(), 'notebook')).to.equal(FileType.File);
+    });
+  });
+
+  describe('toFileStat', () => {
+    it('converts contents to file stat', () => {
+      const created = '2025-12-16T14:30:53.932129Z';
+      const lastModified = '2025-12-11T14:34:40Z';
+      const contents: Contents = {
+        name: 'foo.txt',
+        path: 'foo.txt',
+        type: ContentsTypeEnum.File,
+        writable: true,
+        created,
+        lastModified,
+        size: 123,
+        mimetype: 'text/plain',
+        content: '',
+        format: 'text',
+      };
+
+      const stat = toFileStat(vs.asVsCode(), contents);
+
+      expect(stat.type).to.equal(FileType.File);
+      expect(stat.ctime).to.equal(new Date(created).getTime());
+      expect(stat.mtime).to.equal(new Date(lastModified).getTime());
+      expect(stat.size).to.equal(123);
+    });
+
+    it('handles missing size by defaulting to 0', () => {
+      const contents: Contents = {
+        name: 'foo.txt',
+        path: 'foo.txt',
+        type: ContentsTypeEnum.File,
+        writable: true,
+        created: '2025-12-16T14:30:53.932129Z',
+        lastModified: '2025-12-11T14:34:40Z',
+        mimetype: 'text/plain',
+        content: '',
+        format: 'text',
+      };
+
+      const stat = toFileStat(vs.asVsCode(), contents);
+
+      expect(stat.size).to.equal(0);
+    });
+
+    it('handles missing timestamps by defaulting to 0', () => {
+      const contents: Contents = {
+        name: 'foo.txt',
+        path: 'foo.txt',
+        type: ContentsTypeEnum.File,
+        writable: true,
+        created: '',
+        lastModified: '',
+        size: 123,
+        mimetype: 'text/plain',
+        content: '',
+        format: 'text',
+      };
+
+      const stat = toFileStat(vs.asVsCode(), contents);
+
+      expect(stat.ctime).to.equal(0);
+      expect(stat.mtime).to.equal(0);
+    });
+  });
+
+  describe('isDirectoryContents', () => {
+    it('returns true for a directory with contents', () => {
+      const contents: Contents = {
+        name: 'dir',
+        path: 'dir',
+        type: ContentsTypeEnum.Directory,
+        content: [],
+        writable: true,
+        created: '',
+        lastModified: '',
+        mimetype: '',
+        format: '',
+      };
+
+      expect(isDirectoryContents(contents)).to.be.true;
+    });
+
+    it('returns false for a file', () => {
+      const contents: Contents = {
+        name: 'foo.txt',
+        path: 'foo.txt',
+        type: ContentsTypeEnum.File,
+        content: '',
+        writable: true,
+        created: '',
+        lastModified: '',
+        mimetype: '',
+        format: '',
+      };
+
+      expect(isDirectoryContents(contents)).to.be.false;
+    });
+
+    it('returns false for directory without contents', () => {
+      const contents: Contents = {
+        name: 'dir',
+        path: 'dir',
+        type: ContentsTypeEnum.Directory,
+        content: '',
+        writable: true,
+        created: '',
+        lastModified: '',
+        mimetype: '',
+        format: '',
+      };
+
+      expect(isDirectoryContents(contents)).to.be.false;
+    });
+  });
+});

--- a/src/test/helpers/vscode.ts
+++ b/src/test/helpers/vscode.ts
@@ -32,6 +32,13 @@ export enum ExtensionMode {
   Test = 3,
 }
 
+export enum FileType {
+  Unknown = 0,
+  File = 1,
+  Directory = 2,
+  SymbolicLink = 64,
+}
+
 enum ProgressLocation {
   SourceControl = 1,
   Window = 10,
@@ -105,6 +112,7 @@ export interface VsCodeStub {
     textDocuments: vscode.TextDocument[];
   };
   ExtensionMode: typeof vscode.ExtensionMode;
+  FileType: typeof vscode.FileType;
   ProgressLocation: typeof ProgressLocation;
   QuickInputButtons: typeof TestQuickInputButtons;
   extensions: {
@@ -189,6 +197,7 @@ export function newVsCodeStub(): VsCodeStub {
       textDocuments: [],
     },
     ExtensionMode: ExtensionMode,
+    FileType: FileType,
     ProgressLocation: ProgressLocation,
     QuickInputButtons: TestQuickInputButtons,
     extensions: {


### PR DESCRIPTION
These are used in a downstream PR which adds a Jupyter Server `contents/` file system that can be mounted to VS Code.