### PR TITLE
build: bump version to `0.1.4`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "glob": "^11.1.0",
         "google-auth-library": "^9.15.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
User-impacting changes since last bump/release:

- Fixes auth bug where revoking OAuth credentials in Google account settings would cause refreshes to error, forcing the user to reload the extension / VS Code.
- Adds warning when users execute `drive.mount` pointing to the wiki / GH issue.

Commit log since last bump/release:

- 33ffe32 feat: state management for Jupyter content sessions (#322)
- bd7e4d7 chore: migrate Jupyter definition to Open API 3 (#321)
- 180c7d3 fix: catch access errors during token refresh and remove session (#316)
- 4e67a3c refactor: `removeServer` to use `QuickPickItemKind.Separator` instead of -1 (#318)
- 09f469d feat: show warning notification on `drive.mount` (#297)