### PR TITLE
fix: atomic Colab server VFS removal

### DIFF
--- a/src/jupyter/contents/file-system.unit.test.ts
+++ b/src/jupyter/contents/file-system.unit.test.ts
@@ -120,7 +120,7 @@ describe('ContentsFileSystemProvider', () => {
   let vs: VsCodeStub;
   let jupyterStub: sinon.SinonStubbedInstance<JupyterConnectionManager>;
   let workspaceEmitter: TestEventEmitter<WorkspaceFoldersChangeEvent>;
-  let connectionEmitter: TestEventEmitter<string>;
+  let connectionEmitter: TestEventEmitter<string[]>;
   let fs: ContentsFileSystemProvider;
   let listener: sinon.SinonStub<[FileChangeEvent[]]>;
 
@@ -139,10 +139,10 @@ describe('ContentsFileSystemProvider', () => {
     jupyterStub = sinon.createStubInstance(JupyterConnectionManager);
     connectionEmitter = new TestEventEmitter();
     // Needed to work around the property being readonly.
-    Object.defineProperty(jupyterStub, 'onDidRevokeConnection', {
+    Object.defineProperty(jupyterStub, 'onDidRevokeConnections', {
       value: sinon.stub(),
     });
-    jupyterStub.onDidRevokeConnection.callsFake(connectionEmitter.event);
+    jupyterStub.onDidRevokeConnections.callsFake(connectionEmitter.event);
     fs = new ContentsFileSystemProvider(vs.asVsCode(), jupyterStub);
     listener = sinon.stub();
     fs.onDidChangeFile(listener);
@@ -207,7 +207,7 @@ describe('ContentsFileSystemProvider', () => {
         },
       ];
 
-      connectionEmitter.fire('m-s-foo');
+      connectionEmitter.fire(['m-s-foo']);
 
       sinon.assert.calledWith(vs.workspace.updateWorkspaceFolders, 0, 1);
     });
@@ -226,9 +226,39 @@ describe('ContentsFileSystemProvider', () => {
         },
       ];
 
-      connectionEmitter.fire('m-s-bar');
+      connectionEmitter.fire(['m-s-bar']);
 
-      sinon.assert.calledWith(vs.workspace.updateWorkspaceFolders, 1, 1);
+      sinon.assert.calledWith(vs.workspace.updateWorkspaceFolders, 0, 2, {
+        uri: TestUri.parse('colab://m-s-foo/'),
+        name: 'Colab CPU',
+      });
+    });
+
+    it("removes matching workspace folder when it's one of many including other folders", () => {
+      vs.workspace.workspaceFolders = [
+        {
+          uri: TestUri.parse('colab://m-s-foo/'),
+          name: 'Colab CPU',
+          index: 0,
+        },
+        {
+          uri: TestUri.parse('file://usr/home/'),
+          name: 'Not Colab',
+          index: 1,
+        },
+        {
+          uri: TestUri.parse('colab://m-s-bar/'),
+          name: 'Colab GPU',
+          index: 2,
+        },
+      ];
+
+      connectionEmitter.fire(['m-s-foo', 'm-s-bar']);
+
+      sinon.assert.calledWith(vs.workspace.updateWorkspaceFolders, 0, 3, {
+        uri: TestUri.parse('file://usr/home/'),
+        name: 'Not Colab',
+      });
     });
 
     it("no-ops when the removed server doesn't map to a workspace folder", () => {
@@ -240,7 +270,7 @@ describe('ContentsFileSystemProvider', () => {
         },
       ];
 
-      connectionEmitter.fire('m-s-bar');
+      connectionEmitter.fire(['m-s-bar']);
 
       sinon.assert.notCalled(vs.workspace.updateWorkspaceFolders);
     });

--- a/src/jupyter/contents/sessions.ts
+++ b/src/jupyter/contents/sessions.ts
@@ -28,26 +28,26 @@ export class ServerNotFound extends Error {
  */
 export class JupyterConnectionManager implements Disposable {
   private readonly connections = new Map<string, Promise<ServerConnection>>();
-  private readonly revokeConnectionEmitter: EventEmitter<string>;
+  private readonly revokeConnectionEmitter: EventEmitter<string[]>;
   private isAuthorized = false;
   private isDisposed = false;
   private disposables: Disposable[] = [];
 
   /**
-   * Fires when a server connection is revoked.
+   * Fires with the endpoints of server connections which are revoked.
    *
-   * A server connection is revoked when a an assignment is removed, or the user
+   * A server connection is revoked when an assignment is removed or the user
    * logs out.
    */
-  readonly onDidRevokeConnection: Event<string>;
+  readonly onDidRevokeConnections: Event<string[]>;
 
   constructor(
     vs: typeof vscode,
     authEvent: Event<AuthChangeEvent>,
     private readonly assignments: AssignmentManager,
   ) {
-    this.revokeConnectionEmitter = new vs.EventEmitter<string>();
-    this.onDidRevokeConnection = this.revokeConnectionEmitter.event;
+    this.revokeConnectionEmitter = new vs.EventEmitter<string[]>();
+    this.onDidRevokeConnections = this.revokeConnectionEmitter.event;
     const authChanges = authEvent(this.handleAuthChange.bind(this));
     const assignmentChanges = assignments.onDidAssignmentsChange(
       this.handleAssignmentChange.bind(this),
@@ -130,8 +130,8 @@ export class JupyterConnectionManager implements Disposable {
    *
    * @param endpoint - The endpoint of the server to remove the client of.
    * @param silent - When true, suppresses firing the
-   * {@link JupyterConnectionManager.onDidRevokeConnection} event. Useful if the
-   * caller has already updated the UI and does not need the event to fire
+   * {@link JupyterConnectionManager.onDidRevokeConnections} event. Useful if
+   * the caller has already updated the UI and does not need the event to fire
    * again.
    * @returns true if there was a connection which was removed, otherwise false.
    */
@@ -140,7 +140,7 @@ export class JupyterConnectionManager implements Disposable {
     if (!this.connections.has(endpoint)) {
       return false;
     }
-    this.revoke(endpoint, silent);
+    this.revoke([endpoint], silent);
     return true;
   }
 
@@ -186,26 +186,27 @@ export class JupyterConnectionManager implements Disposable {
   }
 
   private handleAssignmentChange(e: AssignmentChangeEvent) {
-    for (const s of e.removed) {
-      this.revoke(s.server.endpoint);
-    }
+    this.revoke(e.removed.map((r) => r.server.endpoint));
   }
 
   private revokeAll() {
-    for (const endpoint of this.connections.keys()) {
-      this.revoke(endpoint);
-    }
+    this.revoke(Array.from(this.connections.keys()));
   }
 
-  private revoke(endpoint: string, silent = false) {
-    const promise = this.connections.get(endpoint);
-    if (!promise) {
+  private revoke(endpoints: string[], silent = false) {
+    if (!endpoints.length) {
       return;
     }
-    bestEffortDisposeConnection(promise);
-    this.connections.delete(endpoint);
+    for (const endpoint of endpoints) {
+      const promise = this.connections.get(endpoint);
+      if (!promise) {
+        return;
+      }
+      bestEffortDisposeConnection(promise);
+      this.connections.delete(endpoint);
+    }
     if (!silent) {
-      this.revokeConnectionEmitter.fire(endpoint);
+      this.revokeConnectionEmitter.fire(endpoints);
     }
   }
 }


### PR DESCRIPTION
Prior to this change, removing multiple servers (e.g. when a user unauth's) would trigger multiple workspace updates. This put VS Code in a weird state. This change batches all VFS removals into a single workspace update, ensuring a consistent state. Since the API "splices" we remove the Colab servers and add back any of the remaining workspace folders in one go as to not stutter tree view.