### PR TITLE
feat: mount server quick pick

### DIFF
--- a/src/colab/commands/constants.ts
+++ b/src/colab/commands/constants.ts
@@ -60,6 +60,14 @@ export const OPEN_COLAB_WEB: Command = {
   description: 'Open Colab web.',
 };
 
+/** Command to mount a server's file-system. */
+export const MOUNT_SERVER: RegisteredCommand = {
+  id: 'colab.mountServer',
+  label: 'Mount Server to Workspace',
+  icon: 'remote',
+  description: 'Reloads VS Code if a Workspace is not already open.',
+};
+
 /** Command to remove a server. */
 export const REMOVE_SERVER: RegisteredCommand = {
   id: 'colab.removeServer',


### PR DESCRIPTION
This still is not wired up (called anywhere), but when called will mount the user-selected server. When there's no server, it does nothing. When there's one server, it mounts it directly. When there's multiple servers, it shows a quick pick.