### PR TITLE
feat: enable mount commands in Colab extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,14 @@
             "Trace logs and higher (debug, info, warning and error) are logged."
           ],
           "description": "Controls the verbosity of logs from the Colab extension. These can be found in the 'Colab' output channel."
+        },
+        "colab.serverMounting": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enables the ability to mount Colab server filesystems in your workspace.",
+          "tags": [
+            "experimental"
+          ]
         }
       }
     },
@@ -76,6 +84,12 @@
       }
     ],
     "commands": [
+      {
+        "category": "Colab",
+        "command": "colab.mountServer",
+        "enablement": "colab.hasAssignedServer && config.colab.serverMounting",
+        "title": "Mount Server to Workspace"
+      },
       {
         "category": "Colab",
         "command": "colab.removeServer",

--- a/src/colab/commands/notebook.ts
+++ b/src/colab/commands/notebook.ts
@@ -7,7 +7,12 @@
 import vscode, { QuickPickItem } from 'vscode';
 import { InputFlowAction } from '../../common/multi-step-quickpick';
 import { AssignmentManager } from '../../jupyter/assignments';
-import { OPEN_COLAB_WEB, REMOVE_SERVER, UPGRADE_TO_PRO } from './constants';
+import {
+  MOUNT_SERVER,
+  OPEN_COLAB_WEB,
+  REMOVE_SERVER,
+  UPGRADE_TO_PRO,
+} from './constants';
 import { openColabSignup, openColabWeb } from './external';
 import { commandThemeIcon } from './utils';
 
@@ -68,7 +73,24 @@ async function getAvailableCommands(
   if (!(await assignments.hasAssignedServer())) {
     return externalCommands;
   }
-  const serverCommands: NotebookCommand[] = [
+  const serverCommands: NotebookCommand[] = [];
+  const includeMountServer = vs.workspace
+    .getConfiguration('colab')
+    .get<boolean>('serverMounting', false);
+  if (includeMountServer) {
+    serverCommands.push({
+      label: MOUNT_SERVER.label,
+      iconPath: commandThemeIcon(vs, MOUNT_SERVER),
+      description: MOUNT_SERVER.description,
+      invoke: () => {
+        return vs.commands.executeCommand(
+          MOUNT_SERVER.id,
+          /* withBackButton= */ true,
+        );
+      },
+    });
+  }
+  serverCommands.push(
     // TODO: Include the rename server alias command once rename is reflected in
     // the recent kernels list. See https://github.com/microsoft/vscode-jupyter/issues/17107.
     {
@@ -81,7 +103,8 @@ async function getAvailableCommands(
         );
       },
     },
-  ];
+  );
+
   const separator: NotebookCommand = {
     label: '',
     kind: vs.QuickPickItemKind.Separator,


### PR DESCRIPTION
Configuring this as an _experimental_ config. This helps communicate to users that this feature is new, may have rough edges and encourages them to provide feedback.

Initially launching with it off by default. I'll be posting across the various GitHub issues and discussions to let users know about this feature and gather feedback.

The two entrypoints with this changes are the command palette and notebook toolbar.