### PR TITLE
build: bump version to `0.1.6`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "glob": "^11.1.0",
         "google-auth-library": "^9.15.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
User-impacting since last build/release:

- Add the ability to upload files and folders to Colab from VS Code.
- Add the ability to mount Colab servers.

Changes since last build/release (including `0.1.5` since we didn't document those in #329):

- 40c9ca3 feat: support uploading files and folders to Colab (#334)
- 5ed930f feat: enable mount commands in Colab extension (#333)
- 7100da6 feat: mount server quick pick (#332)
- 4bfa4a0 feat: remove all Colab servers when setting's disabled (#331)
- 91fcb8e fix: atomic Colab server VFS removal (#330)
- 93df9ff fix: remove websocket override (#329)
- 2ae4c8b feat: implement new `propagateDriveCredentials` call in client.ts (#320)
- ec2849c feat: Jupyter contents file system (#324)
- c719276 feat: converters between Jupyter and VS files (#323)