### PR TITLE
feat: Auto-configure Plotly renderer for Colab compatibility

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -21,9 +21,12 @@ milli
 mocharc
 openapitools
 pkce
+plotly
+Plotly
 Pyright
 quickpick
 refreshable
+sess
 toggleable
 tombstoned
 toolsai

--- a/src/jupyter/colab-proxy-web-socket.ts
+++ b/src/jupyter/colab-proxy-web-socket.ts
@@ -11,11 +11,12 @@ import {
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../colab/headers';
 import { warnOnDriveMount } from './drive-mount-warning';
+import { injectPlotlyConfig } from './plotly-config';
 
 /**
  * Returns a class which extends {@link WebSocket}, adds Colab's custom headers,
- * and intercepts {@link WebSocket.send} to warn users when on `drive.mount`
- * execution.
+ * intercepts {@link WebSocket.send} to warn users when on `drive.mount`
+ * execution, and auto-configures Plotly renderer for Colab compatibility.
  */
 export function colabProxyWebSocket(
   vs: typeof vscode,
@@ -67,11 +68,14 @@ export function colabProxyWebSocket(
     ) {
       warnOnDriveMount(vs, data);
 
+      // Auto-configure Plotly renderer for Colab compatibility
+      const modifiedData = injectPlotlyConfig(data);
+
       if (options === undefined || typeof options === 'function') {
         cb = options;
         options = {};
       }
-      super.send(data, options, cb);
+      super.send(modifiedData, options, cb);
     }
   };
 }

--- a/src/jupyter/plotly-config.ts
+++ b/src/jupyter/plotly-config.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod';
+
+/**
+ * Python code to configure Plotly to use the 'plotly_mimetype' renderer.
+ * This makes Plotly visualizations work correctly in VS Code when connected
+ * to a Colab runtime. The code is wrapped in a try/except to gracefully
+ * handle cases where Plotly is not installed.
+ */
+const PLOTLY_CONFIG_CODE = `
+try:
+    import plotly.io as pio
+    if pio.renderers.default != 'plotly_mimetype':
+        pio.renderers.default = 'plotly_mimetype'
+except ImportError:
+    pass
+`.trim();
+
+/**
+ * Tracks kernel sessions that have already been configured.
+ * Uses session ID as key to ensure config runs once per kernel session.
+ */
+const configuredSessions = new Set<string>();
+
+/**
+ * Clears the set of configured sessions.
+ * Useful for testing and when kernel sessions are restarted.
+ */
+export function resetConfiguredSessions(): void {
+  configuredSessions.clear();
+}
+
+/**
+ * Returns the number of currently configured sessions.
+ * Useful for testing.
+ */
+export function getConfiguredSessionCount(): number {
+  return configuredSessions.size;
+}
+
+/**
+ * Interface representing a Jupyter execute request message.
+ */
+interface JupyterExecuteRequestMessage {
+  header: {
+    msg_type: 'execute_request';
+    session: string;
+  };
+  content: {
+    code: string;
+  };
+}
+
+/**
+ * Zod schema for validating Jupyter execute request messages.
+ */
+const ExecuteRequestSchema = z.object({
+  header: z.object({
+    msg_type: z.literal('execute_request'),
+    session: z.string(),
+  }),
+  content: z.object({
+    code: z.string(),
+  }),
+});
+
+/**
+ * Type guard to check if a message is a Jupyter execute request.
+ */
+function isExecuteRequest(
+  message: unknown,
+): message is JupyterExecuteRequestMessage {
+  return ExecuteRequestSchema.safeParse(message).success;
+}
+
+/**
+ * Injects Plotly configuration code into the first execute request for each
+ * kernel session. This ensures Plotly uses the 'plotly_mimetype' renderer
+ * which is compatible with VS Code's notebook rendering when connected to
+ * Colab runtimes.
+ *
+ * The injection is:
+ * - Idempotent: Only runs once per session
+ * - Safe: Wrapped in try/except, no-op if Plotly isn't installed
+ * - Non-invasive: Prepended to user code, doesn't affect execution
+ *
+ * @param rawJupyterMessage - The raw JSON string of a Jupyter kernel message
+ * @returns The potentially modified message string with Plotly config prepended
+ */
+export function injectPlotlyConfig(rawJupyterMessage: string): string {
+  if (!rawJupyterMessage) {
+    return rawJupyterMessage;
+  }
+
+  let parsedMessage: unknown;
+  try {
+    parsedMessage = JSON.parse(rawJupyterMessage) as unknown;
+  } catch {
+    // Not valid JSON, return as-is
+    return rawJupyterMessage;
+  }
+
+  if (!isExecuteRequest(parsedMessage)) {
+    return rawJupyterMessage;
+  }
+
+  const sessionId = parsedMessage.header.session;
+  if (configuredSessions.has(sessionId)) {
+    // Already configured this session
+    return rawJupyterMessage;
+  }
+
+  // Mark session as configured
+  configuredSessions.add(sessionId);
+
+  // Prepend Plotly configuration to user's code
+  const modifiedMessage = {
+    ...parsedMessage,
+    content: {
+      ...parsedMessage.content,
+      code: PLOTLY_CONFIG_CODE + '\n' + parsedMessage.content.code,
+    },
+  };
+
+  return JSON.stringify(modifiedMessage);
+}

--- a/src/jupyter/plotly-config.unit.test.ts
+++ b/src/jupyter/plotly-config.unit.test.ts
@@ -1,0 +1,314 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import {
+  getConfiguredSessionCount,
+  injectPlotlyConfig,
+  resetConfiguredSessions,
+} from './plotly-config';
+
+/**
+ * Type for parsed Jupyter kernel messages in tests.
+ */
+interface ParsedMessage {
+  header: {
+    msg_type: string;
+    session?: string;
+    msg_id?: string;
+    username?: string;
+  };
+  content?: {
+    code?: string;
+    silent?: boolean;
+    store_history?: boolean;
+    cursor_pos?: number;
+  };
+  parent_header?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+describe('injectPlotlyConfig', () => {
+  beforeEach(() => {
+    resetConfiguredSessions();
+  });
+
+  describe('when receiving a valid execute_request', () => {
+    it('injects Plotly config on the first request for a session', () => {
+      const rawMessage = JSON.stringify({
+        header: { msg_type: 'execute_request', session: 'session-123' },
+        content: { code: 'print("hello")' },
+      });
+
+      const result = injectPlotlyConfig(rawMessage);
+      const parsed = JSON.parse(result) as ParsedMessage;
+
+      expect(parsed.content?.code).to.include('plotly.io');
+      expect(parsed.content?.code).to.include('plotly_mimetype');
+      expect(parsed.content?.code).to.include('print("hello")');
+    });
+
+    it('does not inject Plotly config on subsequent requests for the same session', () => {
+      const rawMessage1 = JSON.stringify({
+        header: { msg_type: 'execute_request', session: 'session-456' },
+        content: { code: 'x = 1' },
+      });
+      const rawMessage2 = JSON.stringify({
+        header: { msg_type: 'execute_request', session: 'session-456' },
+        content: { code: 'y = 2' },
+      });
+
+      // First request should be modified
+      const result1 = injectPlotlyConfig(rawMessage1);
+      expect((JSON.parse(result1) as ParsedMessage).content?.code).to.include(
+        'plotly.io',
+      );
+
+      // Second request should NOT be modified
+      const result2 = injectPlotlyConfig(rawMessage2);
+      const parsed2 = JSON.parse(result2) as ParsedMessage;
+      expect(parsed2.content?.code).to.equal('y = 2');
+      expect(parsed2.content?.code).to.not.include('plotly.io');
+    });
+
+    it('injects Plotly config for different sessions independently', () => {
+      const rawMessage1 = JSON.stringify({
+        header: { msg_type: 'execute_request', session: 'session-A' },
+        content: { code: 'code_A' },
+      });
+      const rawMessage2 = JSON.stringify({
+        header: { msg_type: 'execute_request', session: 'session-B' },
+        content: { code: 'code_B' },
+      });
+
+      const result1 = injectPlotlyConfig(rawMessage1);
+      const result2 = injectPlotlyConfig(rawMessage2);
+
+      // Both should have Plotly config injected
+      expect((JSON.parse(result1) as ParsedMessage).content?.code).to.include(
+        'plotly.io',
+      );
+      expect((JSON.parse(result2) as ParsedMessage).content?.code).to.include(
+        'plotly.io',
+      );
+    });
+
+    it('preserves all other message properties', () => {
+      const rawMessage = JSON.stringify({
+        header: {
+          msg_type: 'execute_request',
+          session: 'session-789',
+          msg_id: 'abc-123',
+          username: 'user',
+        },
+        content: {
+          code: 'x = 1',
+          silent: false,
+          store_history: true,
+        },
+        parent_header: {},
+        metadata: { custom: 'data' },
+      });
+
+      const result = injectPlotlyConfig(rawMessage);
+      const parsed = JSON.parse(result) as ParsedMessage;
+
+      expect(parsed.header.msg_id).to.equal('abc-123');
+      expect(parsed.header.username).to.equal('user');
+      expect(parsed.content?.silent).to.equal(false);
+      expect(parsed.content?.store_history).to.equal(true);
+      expect(parsed.parent_header).to.deep.equal({});
+      expect(parsed.metadata).to.deep.equal({ custom: 'data' });
+    });
+  });
+
+  describe('when receiving non-execute_request messages', () => {
+    it('does not modify kernel_info_request messages', () => {
+      const rawMessage = JSON.stringify({
+        header: { msg_type: 'kernel_info_request', session: 'session-123' },
+      });
+
+      const result = injectPlotlyConfig(rawMessage);
+
+      expect(result).to.equal(rawMessage);
+    });
+
+    it('does not modify inspect_request messages', () => {
+      const rawMessage = JSON.stringify({
+        header: { msg_type: 'inspect_request', session: 'session-123' },
+        content: { code: 'some_variable', cursor_pos: 5 },
+      });
+
+      const result = injectPlotlyConfig(rawMessage);
+
+      expect(result).to.equal(rawMessage);
+    });
+
+    it('does not modify complete_request messages', () => {
+      const rawMessage = JSON.stringify({
+        header: { msg_type: 'complete_request', session: 'session-123' },
+        content: { code: 'import nu', cursor_pos: 9 },
+      });
+
+      const result = injectPlotlyConfig(rawMessage);
+
+      expect(result).to.equal(rawMessage);
+    });
+  });
+
+  describe('when receiving invalid input', () => {
+    it('returns empty string unchanged', () => {
+      const result = injectPlotlyConfig('');
+
+      expect(result).to.equal('');
+    });
+
+    it('returns invalid JSON unchanged', () => {
+      const invalidJson = 'not valid json {{{';
+
+      const result = injectPlotlyConfig(invalidJson);
+
+      expect(result).to.equal(invalidJson);
+    });
+
+    it('returns non-Jupyter format messages unchanged', () => {
+      const rawMessage = JSON.stringify({
+        random_field: 'random_value',
+      });
+
+      const result = injectPlotlyConfig(rawMessage);
+
+      expect(result).to.equal(rawMessage);
+    });
+
+    it('returns execute_request without session unchanged', () => {
+      const rawMessage = JSON.stringify({
+        header: { msg_type: 'execute_request' },
+        content: { code: 'print("test")' },
+      });
+
+      const result = injectPlotlyConfig(rawMessage);
+
+      expect(result).to.equal(rawMessage);
+    });
+  });
+
+  describe('session tracking', () => {
+    it('tracks configured sessions correctly', () => {
+      expect(getConfiguredSessionCount()).to.equal(0);
+
+      injectPlotlyConfig(
+        JSON.stringify({
+          header: { msg_type: 'execute_request', session: 'sess-1' },
+          content: { code: 'x = 1' },
+        }),
+      );
+      expect(getConfiguredSessionCount()).to.equal(1);
+
+      injectPlotlyConfig(
+        JSON.stringify({
+          header: { msg_type: 'execute_request', session: 'sess-2' },
+          content: { code: 'x = 2' },
+        }),
+      );
+      expect(getConfiguredSessionCount()).to.equal(2);
+
+      // Same session shouldn't increase count
+      injectPlotlyConfig(
+        JSON.stringify({
+          header: { msg_type: 'execute_request', session: 'sess-1' },
+          content: { code: 'x = 3' },
+        }),
+      );
+      expect(getConfiguredSessionCount()).to.equal(2);
+    });
+
+    it('resets tracked sessions correctly', () => {
+      injectPlotlyConfig(
+        JSON.stringify({
+          header: { msg_type: 'execute_request', session: 'sess-1' },
+          content: { code: 'x = 1' },
+        }),
+      );
+      expect(getConfiguredSessionCount()).to.equal(1);
+
+      resetConfiguredSessions();
+
+      expect(getConfiguredSessionCount()).to.equal(0);
+
+      // After reset, same session should get configured again
+      const result = injectPlotlyConfig(
+        JSON.stringify({
+          header: { msg_type: 'execute_request', session: 'sess-1' },
+          content: { code: 'y = 2' },
+        }),
+      );
+      expect((JSON.parse(result) as ParsedMessage).content?.code).to.include(
+        'plotly.io',
+      );
+    });
+  });
+
+  describe('injected code properties', () => {
+    it('uses try/except to handle missing Plotly gracefully', () => {
+      const rawMessage = JSON.stringify({
+        header: { msg_type: 'execute_request', session: 'session-test' },
+        content: { code: 'x = 1' },
+      });
+
+      const result = injectPlotlyConfig(rawMessage);
+      const parsed = JSON.parse(result) as ParsedMessage;
+
+      expect(parsed.content?.code).to.include('try:');
+      expect(parsed.content?.code).to.include('except ImportError:');
+      expect(parsed.content?.code).to.include('pass');
+    });
+
+    it('sets renderer to plotly_mimetype', () => {
+      const rawMessage = JSON.stringify({
+        header: { msg_type: 'execute_request', session: 'session-test2' },
+        content: { code: 'fig.show()' },
+      });
+
+      const result = injectPlotlyConfig(rawMessage);
+      const parsed = JSON.parse(result) as ParsedMessage;
+
+      expect(parsed.content?.code).to.include("'plotly_mimetype'");
+      expect(parsed.content?.code).to.include('pio.renderers.default');
+    });
+
+    it('only sets renderer if not already set to plotly_mimetype', () => {
+      const rawMessage = JSON.stringify({
+        header: { msg_type: 'execute_request', session: 'session-test3' },
+        content: { code: 'x = 1' },
+      });
+
+      const result = injectPlotlyConfig(rawMessage);
+      const parsed = JSON.parse(result) as ParsedMessage;
+
+      // Should check before setting
+      expect(parsed.content?.code).to.include(
+        "if pio.renderers.default != 'plotly_mimetype'",
+      );
+    });
+
+    it('prepends config code before user code', () => {
+      const rawMessage = JSON.stringify({
+        header: { msg_type: 'execute_request', session: 'session-order' },
+        content: { code: 'user_code_here()' },
+      });
+
+      const result = injectPlotlyConfig(rawMessage);
+      const parsed = JSON.parse(result) as ParsedMessage;
+      const code = parsed.content?.code ?? '';
+
+      const plotlyIndex = code.indexOf('plotly.io');
+      const userCodeIndex = code.indexOf('user_code_here()');
+
+      expect(plotlyIndex).to.be.lessThan(userCodeIndex);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #339: Interactive Plotly figures fail to render with ipywidget error.

Automatically sets the Plotly renderer to 'plotly_mimetype' on first code execution per kernel session, enabling interactive Plotly charts to render correctly in VS Code when connected to a Colab runtime.

Implementation:
- Created plotly-config.ts module to inject Plotly config code
- Modified colab-proxy-web-socket.ts to intercept execute_request messages
- Uses try/except to gracefully handle cases where Plotly is not installed
- Only configures on first execute_request per session (idempotent)
- Follows existing pattern from drive-mount-warning.ts