### PR TITLE
feat: Colab server tree data provider

### DIFF
--- a/src/colab/server-browser/server-tree.ts
+++ b/src/colab/server-browser/server-tree.ts
@@ -151,17 +151,19 @@ export class ServerTreeProvider
 
       // Sort: Directories first, then alphabetical by name.
       entries.sort((a, b) => {
-        if (a[1] !== b[1]) {
-          return b[1] === FileType.Directory ? 1 : -1;
+        const [aName, aType] = a;
+        const [bName, bType] = b;
+        if (aType !== bType) {
+          return bType === FileType.Directory ? 1 : -1;
         }
-        return a[0].localeCompare(b[0]);
+        return aName.localeCompare(bName);
       });
 
       return entries.map(([name, type]) => {
         const itemUri = Uri.joinPath(uri, name);
         const uriString = itemUri.toString();
         const existing = this.serverItemsByUri.get(uriString);
-        if (existing && existing.type === type) {
+        if (existing?.type === type) {
           return existing;
         }
 
@@ -186,12 +188,11 @@ export class ServerTreeProvider
   }
 
   private guardDisposed() {
-    if (!this.isDisposed) {
-      return;
+    if (this.isDisposed) {
+      throw new Error(
+        'ServerTreeProvider cannot be used after it has been disposed.',
+      );
     }
-    throw new Error(
-      'ServerTreeProvider cannot be used after it has been disposed.',
-    );
   }
 }
 

--- a/src/colab/server-browser/server-tree.vscode.test.ts
+++ b/src/colab/server-browser/server-tree.vscode.test.ts
@@ -118,18 +118,21 @@ describe('ServerTreeProvider', () => {
         (assignmentStub.getServers as sinon.SinonStub).returns([]);
       });
 
-      it('returns no items with unauthorized', async () => {
-        await expect(tree.getChildren(undefined)).to.eventually.deep.equal([]);
+      const authStates = [AuthState.SIGNED_OUT, AuthState.SIGNED_IN] as const;
 
-        sinon.assert.notCalled(fsStub.readDirectory);
-      });
+      authStates.forEach((authState) => {
+        const state =
+          authState === AuthState.SIGNED_IN ? 'authorized' : 'unauthorized';
 
-      it('returns no items while authorized', async () => {
-        toggleAuth(AuthState.SIGNED_IN);
+        it(`returns no items while ${state}`, async () => {
+          toggleAuth(authState);
 
-        await expect(tree.getChildren(undefined)).to.eventually.deep.equal([]);
+          await expect(tree.getChildren(undefined)).to.eventually.deep.equal(
+            [],
+          );
 
-        sinon.assert.notCalled(fsStub.readDirectory);
+          sinon.assert.notCalled(fsStub.readDirectory);
+        });
       });
     });
 
@@ -140,7 +143,7 @@ describe('ServerTreeProvider', () => {
         ]);
       });
 
-      it('returns no items with unauthorized', async () => {
+      it('returns no items while unauthorized', async () => {
         await expect(tree.getChildren(undefined)).to.eventually.deep.equal([]);
 
         sinon.assert.notCalled(fsStub.readDirectory);
@@ -310,7 +313,7 @@ describe('ServerTreeProvider', () => {
         ]);
       });
 
-      it('returns no items with unauthorized', async () => {
+      it('returns no items while unauthorized', async () => {
         await expect(tree.getChildren(undefined)).to.eventually.deep.equal([]);
 
         sinon.assert.notCalled(fsStub.readDirectory);


### PR DESCRIPTION
Adds a `TreeDataProvider` for Colab servers, to effectively "mount" the `/content` directory as a tree-view.