### PR TITLE
build: bump version to 0.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "glob": "^11.1.0",
         "google-auth-library": "^9.15.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
Changes since last bump:

- fix: trace decorator log prefix (#350)
- fix: ArrayBuffer handling in Colab proxy WebSocket (#348)
- build(deps-dev): bump qs from 6.14.0 to 6.14.1 (#346)
- chore: fix license header check (#349)