### PR TITLE
feat: enable the Colab activity bar for local dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,31 @@
         }
       }
     },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "colab-extension",
+          "title": "Colab",
+          "icon": "$(colab-logo)"
+        }
+      ]
+    },
+    "views": {
+      "colab-extension": [
+        {
+          "id": "colab-servers-view",
+          "icon": "$(remote-explorer)",
+          "name": "Colab",
+          "when": "colab.extensionMode == Development"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "colab-servers-view",
+        "contents": "No assigned Colab servers."
+      }
+    ],
     "menus": {
       "notebook/toolbar": [
         {


### PR DESCRIPTION
Here we set the `colab.extensionMode` context and enable the Colab activity bar view `"when": "colab.extensionMode == Development"`.

This enables me to break up the subsequent PRs which will enable it behind an experimental setting and add context menu support for New File..., New Folder..., Cut, Copy, Paste, Download..., Copy Path, Copy Relative Path, Rename and Delete.