### PR TITLE
chore: add missing `sinon.restore()` in 2 recently added test files

### DIFF
--- a/src/auth/drive.unit.test.ts
+++ b/src/auth/drive.unit.test.ts
@@ -35,6 +35,10 @@ describe('handleDriveFsAuth', () => {
       });
   });
 
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('throws an error if credentials propagation dry run failed', async () => {
     const errMsg = 'Credentials propagation dry run failed';
     colabClientStub.propagateDriveCredentials

--- a/src/jupyter/colab-proxy-web-socket.unit.test.ts
+++ b/src/jupyter/colab-proxy-web-socket.unit.test.ts
@@ -53,6 +53,10 @@ describe('colabProxyWebSocket', () => {
     handleDriveFsAuthStub = sinon.stub();
   });
 
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe('constructor', () => {
     const tests = [
       {


### PR DESCRIPTION
As mentioned in https://sinonjs.org/releases/latest/general-setup, it's recommended to invoke `sinon.restore()` in `afterEach` block of all test files at the root level.

I missed this in my 2 recently added test files:
* `/auth/drive.unit.test.ts`
* `/jupyter/colab-proxy-web-socket.unit.test.ts`