### PR TITLE
build: bump version to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "dependencies": {
         "glob": "^11.1.0",
         "google-auth-library": "^9.15.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
Changes since last bump:

- chore: add missing `sinon.restore()` in 2 recently added test files (#377)
- chore: npm audit fix (#376)
- feat: support `drive.mount` MVP behind experiment config (#365)
- build(deps): bump lodash from 4.17.21 to 4.17.23 (#374)
- feat: experimental setting for the activity bar (#373)
- feat: add delete support (#372)
- feat: add rename support (#371)
- feat: add download support (#370)
- feat: add new file & folder support (#369)
- feat: enable the Colab activity bar for local dev (#368)
- feat: Colab server tree data provider (#362)
- feat: add Colab server tree item (#361)
- test: remove custom integration test runner (#360)
- fix: mount content/ instead of remapping paths (#359)