### PR TITLE
feat: add new `colab.mountDrive` to VS Code command palette and Colab toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,13 @@
     "commands": [
       {
         "category": "Colab",
+        "command": "colab.mountDrive",
+        "enablement": "colab.hasAssignedServer",
+        "when": "config.colab.driveMounting",
+        "title": "Mount Google Drive to Server..."
+      },
+      {
+        "category": "Colab",
         "command": "colab.mountServer",
         "enablement": "colab.hasAssignedServer",
         "when": "config.colab.serverMounting",

--- a/src/colab/commands/constants.ts
+++ b/src/colab/commands/constants.ts
@@ -68,6 +68,14 @@ export const MOUNT_SERVER: RegisteredCommand = {
   description: 'Reloads VS Code if a Workspace is not already open.',
 };
 
+/** Command to add a code snippet to mount Drive. */
+export const MOUNT_DRIVE: RegisteredCommand = {
+  id: 'colab.mountDrive',
+  label: 'Mount Google Drive to Server',
+  icon: 'file-code',
+  description: 'Generates a code snippet to mount Google Drive.',
+};
+
 /** Command to remove a server. */
 export const REMOVE_SERVER: RegisteredCommand = {
   id: 'colab.removeServer',

--- a/src/colab/commands/notebook.unit.test.ts
+++ b/src/colab/commands/notebook.unit.test.ts
@@ -10,173 +10,287 @@ import { QuickPickItem, Uri, WorkspaceConfiguration } from 'vscode';
 import { InputFlowAction } from '../../common/multi-step-quickpick';
 import { AssignmentManager } from '../../jupyter/assignments';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
+import { TestWorkspaceEdit } from '../../test/helpers/workspace';
 import {
   OPEN_COLAB_WEB,
   UPGRADE_TO_PRO,
   REMOVE_SERVER,
   MOUNT_SERVER,
+  MOUNT_DRIVE,
 } from './constants';
-import { notebookToolbar } from './notebook';
+import { notebookToolbar, insertCodeCellBelow } from './notebook';
 
-describe('notebookToolbar', () => {
+describe('Notebook', () => {
   let vs: VsCodeStub;
-  let assignmentManager: SinonStubbedInstance<AssignmentManager>;
-  let serverMountingEnabled = false;
 
   beforeEach(() => {
     vs = newVsCodeStub();
-    assignmentManager = sinon.createStubInstance(AssignmentManager);
-    vs.workspace.getConfiguration.withArgs('colab').returns({
-      get: sinon
-        .stub<[string], boolean>()
-        .withArgs('serverMounting')
-        .callsFake(() => serverMountingEnabled),
-    } as Pick<WorkspaceConfiguration, 'get'> as WorkspaceConfiguration);
   });
 
-  afterEach(() => {
-    sinon.restore();
+  describe('notebookToolbar', () => {
+    let assignmentManager: SinonStubbedInstance<AssignmentManager>;
+    let serverMountingEnabled: boolean;
+    let driveMountingEnabled: boolean;
+
+    beforeEach(() => {
+      serverMountingEnabled = false;
+      driveMountingEnabled = false;
+      assignmentManager = sinon.createStubInstance(AssignmentManager);
+      vs.workspace.getConfiguration.withArgs('colab').returns({
+        get: sinon.stub<[string], boolean>().callsFake((name: string) => {
+          switch (name) {
+            case 'serverMounting':
+              return serverMountingEnabled;
+            case 'driveMounting':
+              return driveMountingEnabled;
+            default:
+              return false;
+          }
+        }),
+      } as Pick<WorkspaceConfiguration, 'get'> as WorkspaceConfiguration);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('does nothing when no command is selected', async () => {
+      vs.window.showQuickPick.resolves(undefined);
+
+      await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
+        .eventually.be.fulfilled;
+    });
+
+    it('re-invokes the notebook toolbar when a command flows back', async () => {
+      assignmentManager.hasAssignedServer.resolves(true);
+      vs.commands.executeCommand
+        .withArgs(REMOVE_SERVER.id)
+        .onFirstCall()
+        .rejects(InputFlowAction.back);
+      vs.window.showQuickPick
+        .onFirstCall()
+        .callsFake(findCommand(REMOVE_SERVER.label))
+        .onSecondCall()
+        .callsFake(findCommand(REMOVE_SERVER.label));
+
+      await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
+        .eventually.be.fulfilled;
+
+      sinon.assert.calledTwice(vs.window.showQuickPick);
+    });
+
+    it('excludes server specific commands when there are non assigned', async () => {
+      vs.window.showQuickPick
+        .onFirstCall()
+        // Arbitrarily select the first command.
+        .callsFake(findCommand(OPEN_COLAB_WEB.label));
+
+      await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
+        .eventually.be.fulfilled;
+
+      sinon.assert.calledOnceWithMatch(
+        vs.window.showQuickPick,
+        commandsLabeled([OPEN_COLAB_WEB.label, UPGRADE_TO_PRO.label]),
+      );
+    });
+
+    it('includes all commands when there is a server assigned', async () => {
+      assignmentManager.hasAssignedServer.resolves(true);
+      vs.window.showQuickPick
+        .onFirstCall()
+        // Arbitrarily select the first command.
+        .callsFake(findCommand(OPEN_COLAB_WEB.label));
+
+      await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
+        .eventually.be.fulfilled;
+
+      sinon.assert.calledOnceWithMatch(
+        vs.window.showQuickPick,
+        commandsLabeled([
+          REMOVE_SERVER.label,
+          /* separator */ '',
+          OPEN_COLAB_WEB.label,
+          UPGRADE_TO_PRO.label,
+        ]),
+      );
+    });
+
+    it('includes server mounting when there is a server assigned and the setting is enabled', async () => {
+      assignmentManager.hasAssignedServer.resolves(true);
+      serverMountingEnabled = true;
+      vs.window.showQuickPick
+        .onFirstCall()
+        // Arbitrarily select the first command.
+        .callsFake(findCommand(OPEN_COLAB_WEB.label));
+
+      await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
+        .eventually.be.fulfilled;
+
+      sinon.assert.calledOnceWithMatch(
+        vs.window.showQuickPick,
+        commandsLabeled([
+          MOUNT_SERVER.label,
+          REMOVE_SERVER.label,
+          /* separator */ '',
+          OPEN_COLAB_WEB.label,
+          UPGRADE_TO_PRO.label,
+        ]),
+      );
+    });
+
+    it('includes drive mounting when there is a server assigned and the setting is enabled', async () => {
+      assignmentManager.hasAssignedServer.resolves(true);
+      driveMountingEnabled = true;
+      vs.window.showQuickPick
+        .onFirstCall()
+        // Arbitrarily select the first command.
+        .callsFake(findCommand(OPEN_COLAB_WEB.label));
+
+      await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
+        .eventually.be.fulfilled;
+
+      sinon.assert.calledOnceWithMatch(
+        vs.window.showQuickPick,
+        commandsLabeled([
+          MOUNT_DRIVE.label,
+          REMOVE_SERVER.label,
+          /* separator */ '',
+          OPEN_COLAB_WEB.label,
+          UPGRADE_TO_PRO.label,
+        ]),
+      );
+    });
+
+    it('opens Colab in web', async () => {
+      vs.window.showQuickPick.callsFake(findCommand(OPEN_COLAB_WEB.label));
+
+      await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
+        .eventually.be.fulfilled;
+
+      sinon.assert.calledOnceWithMatch(
+        vs.env.openExternal,
+        sinon.match(
+          (u: Uri) =>
+            u.authority === 'colab.research.google.com' && u.path === '/',
+        ),
+      );
+    });
+
+    it('opens the Colab signup page', async () => {
+      vs.window.showQuickPick.callsFake(findCommand(UPGRADE_TO_PRO.label));
+
+      await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
+        .eventually.be.fulfilled;
+
+      sinon.assert.calledOnceWithMatch(
+        vs.env.openExternal,
+        sinon.match(
+          (u: Uri) =>
+            u.authority === 'colab.research.google.com' && u.path === '/signup',
+        ),
+      );
+    });
+
+    it('mounts Drive', async () => {
+      assignmentManager.hasAssignedServer.resolves(true);
+      driveMountingEnabled = true;
+      vs.window.showQuickPick.callsFake(findCommand(MOUNT_DRIVE.label));
+
+      await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
+        .eventually.be.fulfilled;
+
+      sinon.assert.calledOnceWithMatch(
+        vs.commands.executeCommand,
+        MOUNT_DRIVE.id,
+      );
+    });
+
+    it('mounts a server', async () => {
+      assignmentManager.hasAssignedServer.resolves(true);
+      serverMountingEnabled = true;
+      vs.window.showQuickPick.callsFake(findCommand(MOUNT_SERVER.label));
+
+      await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
+        .eventually.be.fulfilled;
+
+      sinon.assert.calledOnceWithMatch(
+        vs.commands.executeCommand,
+        MOUNT_SERVER.id,
+      );
+    });
+
+    it('removes a server', async () => {
+      assignmentManager.hasAssignedServer.resolves(true);
+      vs.window.showQuickPick.callsFake(findCommand(REMOVE_SERVER.label));
+
+      await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
+        .eventually.be.fulfilled;
+
+      sinon.assert.calledOnceWithMatch(
+        vs.commands.executeCommand,
+        REMOVE_SERVER.id,
+      );
+    });
   });
 
-  it('does nothing when no command is selected', async () => {
-    vs.window.showQuickPick.resolves(undefined);
+  describe('insertCodeCellBelow', () => {
+    it('returns false if no active notebook editor', async () => {
+      const result = await insertCodeCellBelow(vs.asVsCode(), '', '');
 
-    await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
-      .eventually.be.fulfilled;
-  });
+      expect(result).to.be.false;
+      sinon.assert.notCalled(vs.workspace.applyEdit);
+    });
 
-  it('re-invokes the notebook toolbar when a command flows back', async () => {
-    assignmentManager.hasAssignedServer.resolves(true);
-    vs.commands.executeCommand
-      .withArgs(REMOVE_SERVER.id)
-      .onFirstCall()
-      .rejects(InputFlowAction.back);
-    vs.window.showQuickPick
-      .onFirstCall()
-      .callsFake(findCommand(REMOVE_SERVER.label))
-      .onSecondCall()
-      .callsFake(findCommand(REMOVE_SERVER.label));
+    describe('with an active notebook editor', () => {
+      const testNotebookUri = 'test-notebook-uri';
+      const selectedCellIndex = 2;
 
-    await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
-      .eventually.be.fulfilled;
+      beforeEach(() => {
+        vs.window.activeNotebookEditor = {
+          notebook: {
+            uri: vs.Uri.from({
+              scheme: '',
+              path: testNotebookUri,
+            }),
+          },
+          selection: sinon.createStubInstance(vs.NotebookRange),
+        };
+        vs.window.activeNotebookEditor.selection.start = selectedCellIndex;
+      });
 
-    sinon.assert.calledTwice(vs.window.showQuickPick);
-  });
+      const tests = [
+        { name: 'succeeds', success: true },
+        { name: 'fails', success: false },
+      ];
+      tests.forEach(({ name, success }) => {
+        it(`inserts code in language below selection and returns ${String(success)} if applyEdit ${name}`, async () => {
+          vs.workspace.applyEdit.resolves(success);
+          const code = 'print("Hello World")';
+          const language = 'python';
 
-  it('excludes server specific commands when there are non assigned', async () => {
-    vs.window.showQuickPick
-      .onFirstCall()
-      // Arbitrarily select the first command.
-      .callsFake(findCommand(OPEN_COLAB_WEB.label));
+          const result = await insertCodeCellBelow(
+            vs.asVsCode(),
+            code,
+            language,
+          );
 
-    await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
-      .eventually.be.fulfilled;
-
-    sinon.assert.calledOnceWithMatch(
-      vs.window.showQuickPick,
-      commandsLabeled([OPEN_COLAB_WEB.label, UPGRADE_TO_PRO.label]),
-    );
-  });
-
-  it('includes all commands when there is a server assigned', async () => {
-    assignmentManager.hasAssignedServer.resolves(true);
-    vs.window.showQuickPick
-      .onFirstCall()
-      // Arbitrarily select the first command.
-      .callsFake(findCommand(OPEN_COLAB_WEB.label));
-
-    await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
-      .eventually.be.fulfilled;
-
-    sinon.assert.calledOnceWithMatch(
-      vs.window.showQuickPick,
-      commandsLabeled([
-        REMOVE_SERVER.label,
-        /* separator */ '',
-        OPEN_COLAB_WEB.label,
-        UPGRADE_TO_PRO.label,
-      ]),
-    );
-  });
-
-  it('includes server mounting when there is a server assigned and the setting is enabled', async () => {
-    assignmentManager.hasAssignedServer.resolves(true);
-    serverMountingEnabled = true;
-    vs.window.showQuickPick
-      .onFirstCall()
-      // Arbitrarily select the first command.
-      .callsFake(findCommand(OPEN_COLAB_WEB.label));
-
-    await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
-      .eventually.be.fulfilled;
-
-    sinon.assert.calledOnceWithMatch(
-      vs.window.showQuickPick,
-      commandsLabeled([
-        MOUNT_SERVER.label,
-        REMOVE_SERVER.label,
-        /* separator */ '',
-        OPEN_COLAB_WEB.label,
-        UPGRADE_TO_PRO.label,
-      ]),
-    );
-  });
-
-  it('opens Colab in web', async () => {
-    vs.window.showQuickPick.callsFake(findCommand(OPEN_COLAB_WEB.label));
-
-    await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
-      .eventually.be.fulfilled;
-
-    sinon.assert.calledOnceWithMatch(
-      vs.env.openExternal,
-      sinon.match(
-        (u: Uri) =>
-          u.authority === 'colab.research.google.com' && u.path === '/',
-      ),
-    );
-  });
-
-  it('opens the Colab signup page', async () => {
-    vs.window.showQuickPick.callsFake(findCommand(UPGRADE_TO_PRO.label));
-
-    await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
-      .eventually.be.fulfilled;
-
-    sinon.assert.calledOnceWithMatch(
-      vs.env.openExternal,
-      sinon.match(
-        (u: Uri) =>
-          u.authority === 'colab.research.google.com' && u.path === '/signup',
-      ),
-    );
-  });
-
-  it('mounts a server', async () => {
-    assignmentManager.hasAssignedServer.resolves(true);
-    serverMountingEnabled = true;
-    vs.window.showQuickPick.callsFake(findCommand(MOUNT_SERVER.label));
-
-    await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
-      .eventually.be.fulfilled;
-
-    sinon.assert.calledOnceWithMatch(
-      vs.commands.executeCommand,
-      MOUNT_SERVER.id,
-    );
-  });
-
-  it('removes a server', async () => {
-    assignmentManager.hasAssignedServer.resolves(true);
-    vs.window.showQuickPick.callsFake(findCommand(REMOVE_SERVER.label));
-
-    await expect(notebookToolbar(vs.asVsCode(), assignmentManager)).to
-      .eventually.be.fulfilled;
-
-    sinon.assert.calledOnceWithMatch(
-      vs.commands.executeCommand,
-      REMOVE_SERVER.id,
-    );
+          expect(result).to.equals(success);
+          sinon.assert.calledOnceWithMatch(
+            vs.workspace.applyEdit,
+            sinon.match((edit: TestWorkspaceEdit) => {
+              const notebookEdit = edit.edits[0];
+              const newCellData = notebookEdit.newCells[0];
+              return (
+                edit.uri.path === testNotebookUri &&
+                notebookEdit.range.start === selectedCellIndex + 1 &&
+                newCellData.value === code &&
+                newCellData.languageId === language
+              );
+            }),
+          );
+        });
+      });
+    });
   });
 });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,12 +15,16 @@ import { ColabClient } from './colab/client';
 import {
   COLAB_TOOLBAR,
   UPLOAD,
+  MOUNT_DRIVE,
   MOUNT_SERVER,
   REMOVE_SERVER,
   SIGN_OUT,
 } from './colab/commands/constants';
 import { upload } from './colab/commands/files';
-import { notebookToolbar } from './colab/commands/notebook';
+import {
+  notebookToolbar,
+  insertCodeCellBelow,
+} from './colab/commands/notebook';
 import { mountServer, removeServer } from './colab/commands/server';
 import { ConnectionRefreshController } from './colab/connection-refresher';
 import { ConsumptionNotifier } from './colab/consumption/notifier';
@@ -195,6 +199,14 @@ function registerCommands(
         await mountServer(vscode, assignmentManager, fs, withBackButton);
       },
     ),
+    vscode.commands.registerCommand(MOUNT_DRIVE.id, async () => {
+      await insertCodeCellBelow(
+        vscode,
+        `from google.colab import drive
+drive.mount('/content/drive')`,
+        'python',
+      );
+    }),
     vscode.commands.registerCommand(
       REMOVE_SERVER.id,
       async (withBackButton?: boolean) => {

--- a/src/test/helpers/notebook.ts
+++ b/src/test/helpers/notebook.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NotebookCellData, NotebookEdit, NotebookRange } from 'vscode';
+
+export enum NotebookCellKind {
+  Markup = 1,
+  Code = 2,
+}
+
+export class TestNotebookCellData implements NotebookCellData {
+  kind: NotebookCellKind;
+  value: string;
+  languageId: string;
+
+  constructor(kind: NotebookCellKind, value: string, languageId: string) {
+    this.kind = kind;
+    this.value = value;
+    this.languageId = languageId;
+  }
+}
+
+export class TestNotebookEdit implements NotebookEdit {
+  range: TestNotebookRange;
+  newCells: TestNotebookCellData[];
+
+  constructor(range: TestNotebookRange, newCells: TestNotebookCellData[]) {
+    this.range = range;
+    this.newCells = newCells;
+  }
+}
+
+export class TestNotebookRange implements NotebookRange {
+  start: number;
+  end: number;
+
+  get isEmpty(): boolean {
+    return this.start === this.end;
+  }
+
+  constructor(start: number, end: number) {
+    this.start = start;
+    this.end = end;
+  }
+
+  with(change: { start?: number; end?: number }): NotebookRange {
+    return new TestNotebookRange(
+      change.start ?? this.start,
+      change.end ?? this.end,
+    );
+  }
+}

--- a/src/test/helpers/vscode.ts
+++ b/src/test/helpers/vscode.ts
@@ -10,8 +10,15 @@ import { FakeAuthenticationProviderManager } from './authentication';
 import { TestCancellationTokenSource } from './cancellation';
 import { TestFileSystemError } from './errors';
 import { TestEventEmitter } from './events';
+import {
+  NotebookCellKind,
+  TestNotebookCellData,
+  TestNotebookEdit,
+  TestNotebookRange,
+} from './notebook';
 import { TestThemeIcon } from './theme';
 import { TestUri } from './uri';
+import { TestWorkspaceEdit } from './workspace';
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 class TestQuickInputButtons implements vscode.QuickInputButtons {
@@ -74,6 +81,11 @@ export interface VsCodeStub {
   CancellationTokenSource: typeof TestCancellationTokenSource;
   EventEmitter: typeof TestEventEmitter;
   QuickPickItemKind: typeof QuickPickItemKind;
+  NotebookCellKind: typeof NotebookCellKind;
+  NotebookCellData: typeof TestNotebookCellData;
+  NotebookEdit: typeof TestNotebookEdit;
+  NotebookRange: typeof TestNotebookRange;
+  WorkspaceEdit: typeof TestWorkspaceEdit;
   DiagnosticSeverity: typeof DiagnosticSeverity;
   FileSystemError: typeof FileSystemError;
   commands: {
@@ -113,6 +125,12 @@ export interface VsCodeStub {
     createQuickPick: sinon.SinonStubbedMember<
       typeof vscode.window.createQuickPick
     >;
+    activeNotebookEditor?: {
+      notebook: {
+        uri: TestUri;
+      };
+      selection: sinon.SinonStubbedMember<TestNotebookRange>;
+    };
   };
   workspace: {
     getConfiguration: sinon.SinonStubbedMember<
@@ -130,6 +148,7 @@ export interface VsCodeStub {
     onDidChangeWorkspaceFolders: sinon.SinonStubbedMember<
       typeof vscode.workspace.onDidChangeWorkspaceFolders
     >;
+    applyEdit: sinon.SinonStubbedMember<typeof vscode.workspace.applyEdit>;
     workspaceFolders: sinon.SinonStubbedMember<
       typeof vscode.workspace.workspaceFolders
     >;
@@ -205,13 +224,18 @@ export function newVsCodeStub(): VsCodeStub {
         authentication: { ...this.authentication } as Partial<
           typeof vscode.authentication
         > as typeof vscode.authentication,
-      } as Partial<typeof vscode> as typeof vscode;
+      } as unknown as Partial<typeof vscode> as typeof vscode;
     },
     ThemeIcon: TestThemeIcon,
     Uri: TestUri,
     CancellationTokenSource: TestCancellationTokenSource,
     EventEmitter: TestEventEmitter,
     QuickPickItemKind: QuickPickItemKind,
+    NotebookCellKind: NotebookCellKind,
+    NotebookCellData: TestNotebookCellData,
+    NotebookEdit: TestNotebookEdit,
+    NotebookRange: TestNotebookRange,
+    WorkspaceEdit: TestWorkspaceEdit,
     DiagnosticSeverity: DiagnosticSeverity,
     FileSystemError: TestFileSystemError,
     commands: {
@@ -242,6 +266,7 @@ export function newVsCodeStub(): VsCodeStub {
       updateWorkspaceFolders: sinon.stub(),
       onDidChangeConfiguration: sinon.stub(),
       onDidChangeWorkspaceFolders: sinon.stub(),
+      applyEdit: sinon.stub(),
       workspaceFolders: undefined,
       textDocuments: [],
       fs: {

--- a/src/test/helpers/workspace.ts
+++ b/src/test/helpers/workspace.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TestNotebookEdit } from './notebook';
+import { TestUri } from './uri';
+
+export class TestWorkspaceEdit {
+  uri: TestUri;
+  edits: readonly TestNotebookEdit[] = [];
+
+  set(uri: TestUri, edits: readonly TestNotebookEdit[]): void {
+    this.uri = uri;
+    this.edits = edits;
+  }
+}


### PR DESCRIPTION
As a MVP, this new command only adds a new cell with code snippet to execute `drive.mount()`. New command is also protected behind the `colab.driveMounting` experimental config, and only shows up if there is a Colab server assigned.

## Preview

Command palette:
<img width="902" height="447" alt="MountDrive_VSCodeCommand" src="https://github.com/user-attachments/assets/d91fed76-f090-4a5e-a985-fea14c8e8107" />

Colab toolbar:
<img width="908" height="385" alt="MountDrive_ColabToobar" src="https://github.com/user-attachments/assets/dc8d63b2-25ce-4234-b309-781e64cce247" />

[Demo screencast](https://screencast.googleplex.com/cast/NTg1Nzc4MDYyNjg4MjU2MHwzZWEyNzJjZC1hMw)

---

Related GitHub Issue: https://github.com/googlecolab/colab-vscode/issues/256
Internal tracking bug: b/479193465
