### PR TITLE
feat: add manual "Refresh" button in Colab Activity Bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,11 @@
       {
         "command": "colab.deleteFile",
         "title": "Delete"
+      },
+      {
+        "command": "colab.refreshServersView",
+        "title": "Refresh",
+        "icon": "$(refresh)"
       }
     ],
     "icons": {
@@ -224,6 +229,13 @@
           "command": "colab.upload",
           "group": "5b_importexport@30",
           "when": "resourceScheme == file && config.colab.uploading"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "colab.refreshServersView",
+          "when": "view == colab-servers-view",
+          "group": "navigation"
         }
       ],
       "view/item/context": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,7 +147,7 @@ export async function activate(context: vscode.ExtensionContext) {
     keepServersAlive,
     ...consumptionMonitor.disposables,
     whileAuthorizedToggle,
-    ...registerCommands(authProvider, assignmentManager, fs),
+    ...registerCommands(authProvider, assignmentManager, serverTreeView, fs),
   );
 }
 
@@ -185,6 +185,7 @@ function watchConsumption(colab: ColabClient): {
 function registerCommands(
   authProvider: GoogleAuthProvider,
   assignmentManager: AssignmentManager,
+  serverTreeProvider: ServerTreeProvider,
   fs: ContentsFileSystemProvider,
 ): Disposable[] {
   return [
@@ -221,6 +222,9 @@ drive.mount('/content/drive')`,
     ),
     vscode.commands.registerCommand(COLAB_TOOLBAR.id, async () => {
       await notebookToolbar(vscode, assignmentManager);
+    }),
+    vscode.commands.registerCommand('colab.refreshServersView', () => {
+      serverTreeProvider.refresh();
     }),
     vscode.commands.registerCommand(
       'colab.newFile',


### PR DESCRIPTION
**Why**? There is currently no automatic refresh capability in Colab Activity Bar, so file modifications outside VS Code workspace filesystems (e.g. Drive mounting) cannot be automatically reflected in the Activity Bar. Adding a manual "Refresh" button as a stop-gap solution, so users have ability to manually refresh the Activity Bar as needed.

**Preview**:

<img width="438" height="469" alt="ColabActivityBar_RefreshButton" src="https://github.com/user-attachments/assets/531f8d94-4052-4969-a822-f24c16d83652" />

---

[Demo screencast](https://screencast.googleplex.com/cast/NDU1MDM3NjQwODc0MzkzNnwyYTNlNDQzMi1hMA)

---

Related GitHub Issue: https://github.com/googlecolab/colab-vscode/issues/223
Internal tracking bug: b/480693365