### PR TITLE
fix: server path for file upload

### DIFF
--- a/src/colab/commands/files.ts
+++ b/src/colab/commands/files.ts
@@ -161,7 +161,7 @@ async function buildUploadPlan(
     }
   };
 
-  const serverRootUri = buildColabFileUri(vs, selectedServer);
+  const serverRootUri = buildColabFileUri(vs, selectedServer, 'content');
   for (const inputUri of inputs) {
     const itemName = inputUri.path.split('/').pop();
     if (!itemName) {

--- a/src/colab/commands/files.unit.test.ts
+++ b/src/colab/commands/files.unit.test.ts
@@ -91,7 +91,7 @@ describe('File Commands', () => {
       sinon.assert.notCalled(vsCodeStub.window.showQuickPick);
       sinon.assert.calledWith(
         vsCodeStub.workspace.fs.writeFile,
-        TestUri.parse('colab://m-s-foo/my-file.txt'),
+        TestUri.parse('colab://m-s-foo/content/my-file.txt'),
         fileContent,
       );
       sinon.assert.calledWith(
@@ -121,7 +121,7 @@ describe('File Commands', () => {
 
       sinon.assert.calledWith(
         vsCodeStub.workspace.fs.writeFile,
-        TestUri.parse('colab://m-s-bar/my-file.txt'),
+        TestUri.parse('colab://m-s-bar/content/my-file.txt'),
         fileContent,
       );
       sinon.assert.calledWith(
@@ -178,12 +178,12 @@ describe('File Commands', () => {
 
       sinon.assert.calledWith(
         vsCodeStub.workspace.fs.writeFile,
-        TestUri.parse('colab://m-s-foo/my-file.txt'),
+        TestUri.parse('colab://m-s-foo/content/my-file.txt'),
         content1,
       );
       sinon.assert.calledWith(
         vsCodeStub.workspace.fs.writeFile,
-        TestUri.parse('colab://m-s-foo/other.txt'),
+        TestUri.parse('colab://m-s-foo/content/other.txt'),
         content2,
       );
       sinon.assert.calledWith(progressSpy, {
@@ -234,11 +234,11 @@ describe('File Commands', () => {
 
       sinon.assert.calledWith(
         vsCodeStub.workspace.fs.createDirectory,
-        TestUri.parse('colab://m-s-foo/dir'),
+        TestUri.parse('colab://m-s-foo/content/dir'),
       );
       sinon.assert.calledWith(
         vsCodeStub.workspace.fs.writeFile,
-        TestUri.parse('colab://m-s-foo/dir/sub.txt'),
+        TestUri.parse('colab://m-s-foo/content/dir/sub.txt'),
         subContent,
       );
       sinon.assert.calledWith(


### PR DESCRIPTION
**Why**? As raised in this [issue comment](https://github.com/googlecolab/colab-vscode/issues/223#issuecomment-3833403895), file upload capability was not working. Upon investigation, this was broken by https://github.com/googlecolab/colab-vscode/pull/359, causing file to be uploaded to server root directory instead of `/content` directory.

---

**Screencasts**:
* [Before](https://screencast.googleplex.com/cast/NjM2NjcxMTY2OTMyNTgyNHwwMjhhNGE4NC01NA)
* [After](https://screencast.googleplex.com/cast/NjAyMDQ3ODI4MzAyMjMzNnwzMzU4MzgxZS0wMQ)

---

Related GitHub issue: https://github.com/googlecolab/colab-vscode/issues/223
Internal tracking bug: b/481100090