### PR TITLE
build: bump version to 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@jupyterlab/services": "^7.5.3",
         "glob": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
Changes since last bump:

- build(deps): bump @isaacs/brace-expansion from 5.0.0 to 5.0.1 (#395)
- fix: server path for file upload (#391)
- chore: clean up `driveMounting` experiment config (#390)
- feat: add manual "Refresh" button in Colab Activity Bar (#389)
- refactor: `colabProxyWebSocket` to capture client session ID from Kernel messages (#385)
- feat: use telemetry endpoint response to set next flush time (#383)
- feat: add new `colab.mountDrive` to VS Code command palette and Colab toolbar (#384)
- feat: add telemetry client (#379)