### PR TITLE
docs: new "mount Drive" command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,11 @@ cell](./docs/assets/hello-world.gif)
 
 Activate the command palette with `Ctrl+Shift+P` or `Cmd+Shift+P` on Mac.
 
-| Command                                                | Description                                           |
-| ------------------------------------------------------ | ----------------------------------------------------- |
-| `Colab: Remove Server`                                 | Select an assigned Colab server to remove.            |
-| `Colab: Sign Out`                                      | Sign out of Colab.                                    |
-| `Colab: Mount Google Drive to Server...`               | Add a code snippet to notebook to mount Google Drive. |
-| (_Experimental_) `Colab: Mount Server to Workspace...` | Mount Colab server to VS Code workspace.              |
+| Command                                  | Description                                           |
+| ---------------------------------------- | ----------------------------------------------------- |
+| `Colab: Remove Server`                   | Select an assigned Colab server to remove.            |
+| `Colab: Sign Out`                        | Sign out of Colab.                                    |
+| `Colab: Mount Google Drive to Server...` | Add a code snippet in notebook to mount Google Drive. |
 
 ## Contributing
 


### PR DESCRIPTION
Documenting new `Colab: Mount Google Drive to Server...` command in README which is Generally Available in `v0.2.1`.