### PR TITLE
fix: `colab.mountServer` command visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
         "category": "Colab",
         "command": "colab.mountServer",
         "enablement": "colab.hasAssignedServer",
-        "when": "config.colab.serverMounting",
         "title": "Mount Server to Workspace..."
       },
       {
@@ -123,7 +122,6 @@
         "category": "Colab",
         "command": "colab.upload",
         "enablement": "colab.hasAssignedServer",
-        "when": "config.colab.uploading",
         "title": "Upload to Colab"
       },
       {
@@ -213,6 +211,10 @@
         {
           "command": "colab.upload",
           "when": "false"
+        },
+        {
+          "command": "colab.mountServer",
+          "when": "config.colab.serverMounting"
         }
       ],
       "explorer/context": [


### PR DESCRIPTION
It turns out that we've added `when` clause to the wrong place for `colab.mountServer` command according to [VS Code docs](https://code.visualstudio.com/api/extension-guides/command#controlling-when-a-command-shows-up-in-the-command-palette). This PR fixes that.

**Demo screencasts**:
* [Before](https://screencast.googleplex.com/cast/NDc2OTc0NzcwMTg1ODMwNHwwYTZmNzIxNi0xOA)
* [After](https://screencast.googleplex.com/cast/NjI1OTI2NjExNjY0ODk2MHxkYmZlMmVhMi02Yg)

---

`colab.upload` command is unaffected because it's already *not* showing in command palette.