### PR TITLE
feat: add the ability to use experiment flags from the colab web UI

### DIFF
--- a/src/colab/api.ts
+++ b/src/colab/api.ts
@@ -452,3 +452,40 @@ export function isHighMemOnlyAccelerator(accelerator?: string): boolean {
     accelerator !== undefined && HIGHMEM_ONLY_ACCELERATORS.has(accelerator)
   );
 }
+
+/** The experiment flags supported by the Colab extension. */
+export enum ExperimentFlag {
+  RuntimeVersionNames = 'runtime_version_names',
+}
+
+// Define the basic types allowed
+const PrimitiveExperimentFlagValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+]);
+const ExperimentFlagValueSchema = z.union([
+  PrimitiveExperimentFlagValueSchema,
+  z.array(PrimitiveExperimentFlagValueSchema),
+]);
+/** The type for the value of an experiment flag. */
+export type ExperimentFlagValue = z.infer<typeof ExperimentFlagValueSchema>;
+
+/** The schema for the experiment state response. */
+export const ExperimentStateSchema = z.object({
+  /** The map of experiment flags. */
+  experiments: z
+    .record(z.string(), ExperimentFlagValueSchema.optional())
+    .transform((val) => {
+      /** Filter out entries where the value is undefined */
+      const validKeys = new Set(Object.values(ExperimentFlag) as string[]);
+      const entries = Object.entries(val).filter(([k, v]) => {
+        return v !== undefined && validKeys.has(k);
+      });
+
+      return new Map(entries) as Map<ExperimentFlag, ExperimentFlagValue>;
+    })
+    .optional(),
+});
+/** The experiment state response. */
+export type ExperimentState = z.infer<typeof ExperimentStateSchema>;

--- a/src/colab/experiment-state.ts
+++ b/src/colab/experiment-state.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { log } from '../common/logging';
+import { AsyncToggle } from '../common/toggleable';
+import { ExperimentFlag, ExperimentFlagValue } from './api';
+import { ColabClient } from './client';
+
+let flags: Map<ExperimentFlag, ExperimentFlagValue> = new Map<
+  ExperimentFlag,
+  ExperimentFlagValue
+>();
+
+/**
+ * Provides experiment state information from the Colab backend.
+ */
+export class ExperimentStateProvider extends AsyncToggle {
+  constructor(private readonly client: ColabClient) {
+    super();
+    // Reset experiment flags.
+    flags = new Map<ExperimentFlag, ExperimentFlagValue>();
+    this.getExperimentState = this.getExperimentState.bind(this);
+  }
+
+  /** Called when user is authorized */
+  protected override async turnOn(signal: AbortSignal): Promise<void> {
+    await this.getExperimentState(/** requireAccessToken= */ true, signal);
+  }
+
+  /** Called when user is un-authorized */
+  protected override async turnOff(signal: AbortSignal): Promise<void> {
+    await this.getExperimentState(/** requireAccessToken= */ false, signal);
+  }
+
+  private async getExperimentState(
+    requireAccessToken: boolean,
+    signal: AbortSignal,
+  ): Promise<void> {
+    try {
+      const result = await this.client.getExperimentState(
+        requireAccessToken,
+        signal,
+      );
+      if (result.experiments) {
+        flags = result.experiments;
+      }
+    } catch (e) {
+      log.error('Failed to update experiment state:', e);
+    }
+  }
+}
+
+function getDefaultValueForExperimentFlag(
+  flag: ExperimentFlag,
+): ExperimentFlagValue {
+  switch (flag) {
+    // Add default values for experiment flags here.
+    default:
+      return [];
+  }
+}
+
+/** Gets the value of an experiment flag.
+ *
+ * @param flag - The experiment flag to get.
+ * @returns The value of the experiment flag.
+ */
+export function getFlag(flag: ExperimentFlag): ExperimentFlagValue {
+  return flags.get(flag) ?? getDefaultValueForExperimentFlag(flag);
+}

--- a/src/colab/experiment-state.unit.test.ts
+++ b/src/colab/experiment-state.unit.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import sinon, { SinonStubbedInstance } from 'sinon';
+import { ExperimentFlag } from './api';
+import { ColabClient } from './client';
+import { ExperimentStateProvider, getFlag } from './experiment-state';
+
+/**
+ * Test subclass to expose protected methods for testing.
+ */
+class TestExperimentStateProvider extends ExperimentStateProvider {
+  override async turnOn(signal: AbortSignal): Promise<void> {
+    return super.turnOn(signal);
+  }
+
+  override async turnOff(signal: AbortSignal): Promise<void> {
+    return super.turnOff(signal);
+  }
+}
+
+describe('ExperimentStateProvider', () => {
+  let colabClientStub: SinonStubbedInstance<ColabClient>;
+  let provider: TestExperimentStateProvider;
+
+  beforeEach(() => {
+    colabClientStub = sinon.createStubInstance(ColabClient);
+    provider = new TestExperimentStateProvider(colabClientStub);
+
+    // Default value of the flag
+    expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.be.deep.equal([]);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('fetches experiment state with auth when turned on', async () => {
+    const experiments = new Map([[ExperimentFlag.RuntimeVersionNames, true]]);
+    colabClientStub.getExperimentState.resolves({ experiments });
+
+    await provider.turnOn(new AbortController().signal);
+
+    sinon.assert.calledOnceWithExactly(
+      colabClientStub.getExperimentState,
+      true,
+      sinon.match.any,
+    );
+    expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.be.true;
+  });
+
+  it('fetches experiment state without auth when turned off', async () => {
+    const experiments = new Map([[ExperimentFlag.RuntimeVersionNames, false]]);
+    colabClientStub.getExperimentState.resolves({ experiments });
+
+    await provider.turnOff(new AbortController().signal);
+
+    sinon.assert.calledOnceWithExactly(
+      colabClientStub.getExperimentState,
+      false,
+      sinon.match.any,
+    );
+    expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.be.false;
+  });
+
+  it('handles errors when fetching experiment state', async () => {
+    colabClientStub.getExperimentState.rejects(new Error('Network error'));
+
+    // Should not throw
+    await provider.turnOn(new AbortController().signal);
+
+    sinon.assert.calledOnce(colabClientStub.getExperimentState);
+  });
+
+  it('returns default value when flag is missing', async () => {
+    // Ensure flags are empty
+    colabClientStub.getExperimentState.resolves({ experiments: new Map() });
+    await provider.turnOn(new AbortController().signal);
+
+    expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.deep.equal([]);
+  });
+
+  it('updates flags when state changes', async () => {
+    // Set to true
+    colabClientStub.getExperimentState.resolves({
+      experiments: new Map([[ExperimentFlag.RuntimeVersionNames, true]]),
+    });
+    await provider.turnOn(new AbortController().signal);
+    expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.be.true;
+
+    // Set to false
+    colabClientStub.getExperimentState.resolves({
+      experiments: new Map([[ExperimentFlag.RuntimeVersionNames, false]]),
+    });
+    await provider.turnOn(new AbortController().signal);
+    expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.be.false;
+  });
+
+  it('does not update flags if response is empty', async () => {
+    // Set initial state
+    colabClientStub.getExperimentState.resolves({
+      experiments: new Map([[ExperimentFlag.RuntimeVersionNames, true]]),
+    });
+    await provider.turnOn(new AbortController().signal);
+    expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.be.true;
+
+    // Return empty experiments (undefined)
+    colabClientStub.getExperimentState.resolves({});
+    await provider.turnOn(new AbortController().signal);
+
+    // Should still be true (previous state preserved)
+    expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.be.true;
+  });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import { mountServer, removeServer } from './colab/commands/server';
 import { ConnectionRefreshController } from './colab/connection-refresher';
 import { ConsumptionNotifier } from './colab/consumption/notifier';
 import { ConsumptionPoller } from './colab/consumption/poller';
+import { ExperimentStateProvider } from './colab/experiment-state';
 import { ServerKeepAliveController } from './colab/keep-alive';
 import {
   deleteFile,
@@ -115,6 +116,7 @@ export async function activate(context: vscode.ExtensionContext) {
     assignmentManager,
   );
   const consumptionMonitor = watchConsumption(colabClient);
+  const experimentStateProvider = new ExperimentStateProvider(colabClient);
   await authProvider.initialize();
   // Sending server "keep-alive" pings and monitoring consumption requires
   // issuing authenticated requests to Colab. This can only be done after the
@@ -124,6 +126,7 @@ export async function activate(context: vscode.ExtensionContext) {
     connections,
     keepServersAlive,
     consumptionMonitor.toggle,
+    experimentStateProvider,
   );
   const disposeFs = vscode.workspace.registerFileSystemProvider('colab', fs, {
     isCaseSensitive: true,


### PR DESCRIPTION
Add the ability to use experiment flags from the Colab web UI (as long as they are tagged with 'vscode'). The only flag currently declared is `runtime_versions_names` in preparation for the adding the runtime version selector. 

(This was tested in sandbox, but we should wait till the corresponding endpoint is in production before we merge)