### PR TITLE
refactor: move telemetry interfaces and types to api file

### DIFF
--- a/src/telemetry/api.ts
+++ b/src/telemetry/api.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * API types for logging telemetry events to Clearcut.
+ */
+
+/** The Colab log event structure. */
+// TODO: Convert to proto definition.
+// TODO: Record events for MVP CUJs.
+export type ColabLogEvent = ColabLogEventBase &
+  ColabEvent & {
+    // The timestamp of the event as an ISO string.
+    timestamp: string;
+  };
+
+/**
+ * Base information common to all ColabLogEvents. These fields are not expected
+ * to change for the duration of the session.
+ */
+export interface ColabLogEventBase {
+  extension_version: string;
+  jupyter_extension_version: string;
+  // A unique identifier for the current VS Code session.
+  session_id: string;
+  // The kinds of UIs that VS Code can run on.
+  ui_kind: 'UI_KIND_DESKTOP' | 'UI_KIND_WEB';
+  vscode_version: string;
+}
+
+/** The telemetry event being logged. */
+export type ColabEvent =
+  | { activation_event: ColabActivationEvent }
+  | { error_event: ColabErrorEvent };
+
+type ColabActivationEvent = Record<string, never>;
+
+interface ColabErrorEvent {
+  // The name of the error.
+  name: string;
+  // The error message.
+  msg: string;
+  // The stack trace of the error.
+  stack: string;
+}
+
+/** The Clearcut log event structure. */
+export interface LogEvent {
+  // ColabLogEvent serialized as a JSON string.
+  source_extension_json: string;
+}
+
+/** The source identifier for Colab VS Code logs. */
+export const LOG_SOURCE = 'COLAB_VSCODE';
+
+/** The Clearcut log request structure. */
+export interface LogRequest {
+  log_source: typeof LOG_SOURCE;
+  log_event: LogEvent[];
+}
+
+/** The Clearcut log response structure. */
+export interface LogResponse {
+  // Minimum wait time before the next request in milliseconds.
+  next_request_wait_millis: number;
+}

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -8,68 +8,21 @@ import fetch, { Request } from 'node-fetch';
 import { Disposable } from 'vscode';
 import { CONTENT_TYPE_JSON_HEADER } from '../colab/headers';
 import { log } from '../common/logging';
+import {
+  ColabLogEvent,
+  LogEvent,
+  LogRequest,
+  LogResponse,
+  LOG_SOURCE,
+} from './api';
 
 // The Clearcut endpoint.
 const LOGS_ENDPOINT = 'https://play.googleapis.com/log?format=json_proto';
-// The source identifier for Colab VS Code logs.
-const LOG_SOURCE = 'COLAB_VSCODE';
 // Maximum number of pending events before flushing. When exceeded, events will
 // be dropped from the front of the queue.
 const MAX_PENDING_EVENTS = 1000;
 // Minimum wait time between flushes in milliseconds.
 const MIN_WAIT_BETWEEN_FLUSHES_MS = 10 * 1000;
-
-// The Colab log event structure.
-// TODO: Convert to proto definition.
-// TODO: Record events for MVP CUJs.
-export type ColabLogEvent = ColabLogEventBase &
-  ColabEvent & {
-    // The timestamp of the event as an ISO string.
-    timestamp: string;
-  };
-
-export interface ColabLogEventBase {
-  extension_version: string;
-  jupyter_extension_version: string;
-  // A unique identifier for the current VS Code session.
-  session_id: string;
-  // The kinds of UIs that VS Code can run on.
-  ui_kind: 'UI_KIND_DESKTOP' | 'UI_KIND_WEB';
-  vscode_version: string;
-}
-
-export type ColabEvent =
-  | { activation_event: ColabActivationEvent }
-  | { error_event: ColabErrorEvent };
-
-type ColabActivationEvent = Record<string, never>;
-
-interface ColabErrorEvent {
-  // The name of the error.
-  name: string;
-  // The error message.
-  msg: string;
-  // The stack trace of the error.
-  stack: string;
-}
-
-// The Clearcut log event structure.
-interface LogEvent {
-  // ColabLogEvent serialized as a JSON string.
-  source_extension_json: string;
-}
-
-// The Clearcut log request structure.
-interface LogRequest {
-  log_source: typeof LOG_SOURCE;
-  log_event: LogEvent[];
-}
-
-// The Clearcut log response structure.
-interface LogResponse {
-  // Minimum wait time before the next request in milliseconds.
-  next_request_wait_millis: number;
-}
 
 /**
  * A client for sending logs to Clearcut.
@@ -197,7 +150,6 @@ export class ClearcutClient implements Disposable {
 
 export const TEST_ONLY = {
   LOGS_ENDPOINT,
-  LOG_SOURCE,
   MAX_PENDING_EVENTS,
   MIN_WAIT_BETWEEN_FLUSHES_MS,
 };

--- a/src/telemetry/client.unit.test.ts
+++ b/src/telemetry/client.unit.test.ts
@@ -9,7 +9,8 @@ import fetch, { Response, Request } from 'node-fetch';
 import { SinonFakeTimers } from 'sinon';
 import * as sinon from 'sinon';
 import { Deferred } from '../test/helpers/async';
-import { ClearcutClient, ColabLogEvent, TEST_ONLY } from './client';
+import { ColabLogEvent, LOG_SOURCE } from './api';
+import { ClearcutClient, TEST_ONLY } from './client';
 
 const NOW = Date.now();
 const DEFAULT_LOG: ColabLogEvent = {
@@ -473,7 +474,7 @@ function logRequest(events: ColabLogEvent[]): Request {
   return new Request(TEST_ONLY.LOGS_ENDPOINT, {
     method: 'POST',
     body: JSON.stringify({
-      log_source: TEST_ONLY.LOG_SOURCE,
+      log_source: LOG_SOURCE,
       log_event: logEvents,
     }),
     headers: {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -9,7 +9,8 @@ import { Disposable } from 'vscode';
 import { COLAB_EXT_IDENTIFIER } from '../config/constants';
 import { getPackageInfo } from '../config/package-info';
 import { JUPYTER_EXT_IDENTIFIER } from '../jupyter/jupyter-extension';
-import { ClearcutClient, ColabLogEventBase, ColabEvent } from './client';
+import { ColabLogEventBase, ColabEvent } from './api';
+import { ClearcutClient } from './client';
 
 let client: ClearcutClient | undefined;
 // Fields that aren't expected to change for the duration of the session.

--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -11,7 +11,8 @@ import { Disposable } from 'vscode';
 import { COLAB_EXT_IDENTIFIER } from '../config/constants';
 import { JUPYTER_EXT_IDENTIFIER } from '../jupyter/jupyter-extension';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
-import { ClearcutClient, ColabLogEventBase } from './client';
+import { ColabLogEventBase } from './api';
+import { ClearcutClient } from './client';
 import { initializeTelemetry, telemetry } from '.';
 
 const NOW = Date.now();


### PR DESCRIPTION
This change moves telemetry interfaces and types to `api.ts`. This is a follow up PR from discussion in https://github.com/googlecolab/colab-vscode/pull/402.

I initially went with `api.ts` to be consistent with patterns in the Colab client, though if another name's better, happy to adjust! While here, I updated comments to JSDoc to follow go/tsjs-style#document-all-top-level-exports-of-modules  