### PR TITLE
fix: 2 high severity vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@cspell/eslint-plugin": "^8.17.3",
         "@eslint/js": "^9.33.0",
-        "@openapitools/openapi-generator-cli": "^2.25.2",
+        "@openapitools/openapi-generator-cli": "^2.28.3",
         "@stylistic/eslint-plugin": "^5.2.2",
         "@types/chai": "^4.3.20",
         "@types/chai-as-promised": "^7.1.8",

--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
   "devDependencies": {
     "@cspell/eslint-plugin": "^8.17.3",
     "@eslint/js": "^9.33.0",
-    "@openapitools/openapi-generator-cli": "^2.25.2",
+    "@openapitools/openapi-generator-cli": "^2.28.3",
     "@stylistic/eslint-plugin": "^5.2.2",
     "@types/chai": "^4.3.20",
     "@types/chai-as-promised": "^7.1.8",


### PR DESCRIPTION
Fixed 2 high severity vulnerabilities by running `npm audit fix`.

### Before:
```
# npm audit report

axios  <=1.13.4
Severity: high
Axios is Vulnerable to Denial of Service via __proto__ Key in mergeConfig - https://github.com/advisories/GHSA-43fc-jf86-j433
fix available via `npm audit fix`
node_modules/axios
  @openapitools/openapi-generator-cli  2.8.0 - 2.28.2
  Depends on vulnerable versions of axios
  node_modules/@openapitools/openapi-generator-cli

2 high severity vulnerabilities
```

### After:
```
found 0 vulnerabilities
```