### PR TITLE
test: update sinon spy to stub to fix hanging tests

### DIFF
--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -75,10 +75,10 @@ describe('Telemetry Module', () => {
 
   describe('logs to Clearcut', () => {
     let baseLog: ColabLogEventBase & { timestamp: string };
-    let logSpy: SinonSpy;
+    let logStub: SinonSpy;
 
     beforeEach(() => {
-      logSpy = sinon.stub(ClearcutClient.prototype, 'log');
+      logStub = sinon.stub(ClearcutClient.prototype, 'log');
       baseLog = {
         extension_version: VERSION_COLAB,
         jupyter_extension_version: VERSION_JUPYTER,
@@ -93,7 +93,7 @@ describe('Telemetry Module', () => {
     it('on activation', () => {
       telemetry.logActivation();
 
-      sinon.assert.calledOnceWithExactly(logSpy, {
+      sinon.assert.calledOnceWithExactly(logStub, {
         ...baseLog,
         activation_event: {},
       });
@@ -132,7 +132,7 @@ describe('Telemetry Module', () => {
       it(`on error with type ${type}`, () => {
         telemetry.logError(getError());
 
-        sinon.assert.calledOnceWithExactly(logSpy, {
+        sinon.assert.calledOnceWithExactly(logStub, {
           ...baseLog,
           error_event,
         });
@@ -144,7 +144,7 @@ describe('Telemetry Module', () => {
 
       telemetry.logActivation();
 
-      sinon.assert.calledOnceWithExactly(logSpy, {
+      sinon.assert.calledOnceWithExactly(logStub, {
         ...baseLog,
         activation_event: {},
         timestamp: new Date(curTime).toISOString(),


### PR DESCRIPTION
why? when using a spy, the original method still runs, where some internals probably what caused the tests to hang. we can make the same assertion with a stub, which overrides the method behavior and fixes the issue.