### PR TITLE
fix: highmem only accelerators should pass default shape value

### DIFF
--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -36,6 +36,7 @@ import {
   CredentialsPropagationResultSchema,
   ExperimentStateSchema,
   ExperimentState,
+  isHighMemOnlyAccelerator,
 } from './api';
 import {
   ACCEPT_JSON_HEADER,
@@ -426,7 +427,12 @@ export class ColabClient {
     if (accelerator) {
       url.searchParams.append('accelerator', accelerator);
     }
-    const shapeURLParam = mapShapeToURLParam(shape ?? Shape.STANDARD);
+    const shapeURLParam = mapShapeToURLParam(
+      // High mem only accelerators only have one shape option
+      isHighMemOnlyAccelerator(accelerator)
+        ? Shape.STANDARD
+        : (shape ?? Shape.STANDARD),
+    );
     if (shapeURLParam) {
       url.searchParams.append('shape', shapeURLParam);
     }


### PR DESCRIPTION
Highmem only accelerator assignment calls expect that that a standard memory shape is provided (default) and should not provide a `hm` shape to the assignment call. 

The fix was tested manually and confirmed to work by another Googler.