### PR TITLE
build: bump version to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@jupyterlab/services": "^7.5.3",
         "glob": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
Changes since last bump:

- fix: highmem only accelerators should pass default shape value (#414)
- fix: error deleting non-empty directories on server (#413)
- fix: clear session and retry if issue request encounters a 401 (#412)
- feat: add the ability to use experiment flags from the colab web UI (#401)
- feat: telemetry is enabled based on VS Code setting (#408)
- fix: 2 high severity vulnerabilities (#410)
- test: update sinon spy to stub to fix hanging tests (#411)
- refactor: move telemetry interfaces and types to api file (#409)
- feat: add a telemetry entrypoint (#402)
- fix: 2 low severity vulnerabilities (#406)
- feat: retry logs on 5XX errors (#404)
- feat: Colab terminal behind experimental config (#398)
- fix: `colab.mountServer` command visibility (#399)
- feat: handle `auth_user_ephemeral` in code (#394)
- docs: new "mount Drive" command in README (#397)