### PR TITLE
feat: include access token in Clearcut request

### DIFF
--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -90,7 +90,8 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
   }
 
   /**
-   * Retrieves the Google OAuth2 authentication session.
+   * Retrieves the Google OAuth2 authentication session. Prompts the user to
+   * sign in if no matching sessions are found.
    *
    * @param vs - The VS Code API.
    * @returns The authentication session.
@@ -106,6 +107,19 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
       },
     );
     return session;
+  }
+
+  /**
+   * Retrieves the Google OAuth2 authentication session.
+   *
+   * @param vs - The VS Code API.
+   * @returns A promise that resolves with the authentication session if it
+   *  exists and undefined otherwise.
+   */
+  static async getSession(
+    vs: typeof vscode,
+  ): Promise<AuthenticationSession | undefined> {
+    return vs.authentication.getSession(PROVIDER_ID, REQUIRED_SCOPES);
   }
 
   /**

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -22,9 +22,14 @@ let isTelemetryEnabled: () => boolean;
  * Initializes the telemetry module
  * @param context - The VS Code extension context
  * @param vs - The vscode module.
+ * @param getAccessToken - A function that resolves with the access token, or
+ *   undefined if the user is unauthenticated.
  * @returns A {@link Disposable} that can be used to clean up the client.
  */
-export function initializeTelemetry(vs: typeof vscode): Disposable {
+export function initializeTelemetry(
+  vs: typeof vscode,
+  getAccessToken: () => Promise<string | undefined>,
+): Disposable {
   if (client) {
     throw new Error('Telemetry has already been initialized.');
   }
@@ -46,7 +51,7 @@ export function initializeTelemetry(vs: typeof vscode): Disposable {
   };
 
   isTelemetryEnabled = () => vs.env.isTelemetryEnabled;
-  client = new ClearcutClient();
+  client = new ClearcutClient(getAccessToken);
 
   return {
     dispose: () => {

--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -23,6 +23,7 @@ const VERSION_VSCODE = '1.109.0';
 
 describe('Telemetry Module', () => {
   let disposeTelemetry: Disposable | undefined;
+  const getAccessToken = () => Promise.resolve(undefined);
   let fakeClock: SinonFakeTimers;
   let vs: VsCodeStub;
 
@@ -50,10 +51,10 @@ describe('Telemetry Module', () => {
 
   describe('lifecycle', () => {
     it('throws if doubly initialized', () => {
-      disposeTelemetry = initializeTelemetry(vs.asVsCode());
+      disposeTelemetry = initializeTelemetry(vs.asVsCode(), getAccessToken);
 
       expect(() => {
-        initializeTelemetry(vs.asVsCode());
+        initializeTelemetry(vs.asVsCode(), getAccessToken);
       }).to.throw(/already been initialized/);
     });
 
@@ -65,7 +66,7 @@ describe('Telemetry Module', () => {
 
     it('disposes the client when disposed', () => {
       const disposeSpy = sinon.spy(ClearcutClient.prototype, 'dispose');
-      disposeTelemetry = initializeTelemetry(vs.asVsCode());
+      disposeTelemetry = initializeTelemetry(vs.asVsCode(), getAccessToken);
 
       disposeTelemetry.dispose();
 
@@ -76,7 +77,7 @@ describe('Telemetry Module', () => {
   it('does not log to Clearcut when telemetry is disabled', () => {
     const logStub = sinon.stub(ClearcutClient.prototype, 'log');
     vs.env.isTelemetryEnabled = false;
-    disposeTelemetry = initializeTelemetry(vs.asVsCode());
+    disposeTelemetry = initializeTelemetry(vs.asVsCode(), getAccessToken);
 
     telemetry.logActivation();
 
@@ -88,7 +89,7 @@ describe('Telemetry Module', () => {
     vs.env.isTelemetryEnabled = false;
     // Maintain a reference to this stub as that's the reference telemetry has.
     const vscodeStub = vs.asVsCode();
-    disposeTelemetry = initializeTelemetry(vscodeStub);
+    disposeTelemetry = initializeTelemetry(vscodeStub, getAccessToken);
 
     telemetry.logActivation();
     sinon.assert.notCalled(logStub);
@@ -105,7 +106,7 @@ describe('Telemetry Module', () => {
     const logStub = sinon.stub(ClearcutClient.prototype, 'log');
     // Maintain a reference to this stub as that's the reference telemetry has.
     const vscodeStub = vs.asVsCode();
-    disposeTelemetry = initializeTelemetry(vscodeStub);
+    disposeTelemetry = initializeTelemetry(vscodeStub, getAccessToken);
 
     telemetry.logActivation();
     sinon.assert.calledOnce(logStub);
@@ -136,7 +137,7 @@ describe('Telemetry Module', () => {
         vscode_version: VERSION_VSCODE,
         timestamp: new Date(NOW).toISOString(),
       };
-      disposeTelemetry = initializeTelemetry(vs.asVsCode());
+      disposeTelemetry = initializeTelemetry(vs.asVsCode(), getAccessToken);
     });
 
     it('on activation', () => {


### PR DESCRIPTION
(wip) This change includes the access token in the Clearcut request when available

DO NOT SUBMIT: the api currently returns a 401 when the `Authorization` header is present . we'll wait to hear more from the Clearcut team before proceeding