### PR TITLE
chore: turn on `uploading` and `activityBar` by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,19 +69,13 @@
         },
         "colab.uploading": {
           "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enables the ability to upload files and folders to Colab servers from the explorer context menu (e.g. right-click a local file > _Upload to Colab_).",
-          "tags": [
-            "experimental"
-          ]
+          "default": true,
+          "markdownDescription": "Enables the ability to upload files and folders to Colab servers from the explorer context menu (e.g. right-click a local file > _Upload to Colab_)."
         },
         "colab.activityBar": {
           "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enables the Colab activity bar where you can view servers and interact with their `/content` directories.",
-          "tags": [
-            "experimental"
-          ]
+          "default": true,
+          "markdownDescription": "Enables the Colab activity bar where you can view servers and interact with their `/content` directories."
         },
         "colab.serverMounting": {
           "type": "boolean",


### PR DESCRIPTION
**Why**? New Colab _Activity Bar_ and _Uploading_ features have been released for a while now. After a few recent bug fixes (https://github.com/googlecolab/colab-vscode/pull/391, https://github.com/googlecolab/colab-vscode/pull/413, https://github.com/googlecolab/colab-vscode/pull/417), these 2 features are ready to graduate from experimental features.

---

On the other hand, _Server Mounting_ feature is less used / tested and not as intuitive to use as the _Activity Bar_ server browser, so it will still remain as an experimental feature and off by default for now.