### PR TITLE
fix: remove stat call when reading a file

### DIFF
--- a/src/jupyter/contents/file-system.ts
+++ b/src/jupyter/contents/file-system.ts
@@ -255,12 +255,12 @@ export class ContentsFileSystemProvider
         type: ContentsGetTypeEnum.File,
       });
 
-      if (
-        isDirectoryContents(content) ||
-        content.format !== ContentsGetFormatEnum.Base64 ||
-        typeof content.content !== 'string'
-      ) {
-        throw this.vs.FileSystemError.FileIsADirectory(uri);
+      if (typeof content.content !== 'string') {
+        const err = new Error(
+          'Unexpected content format received from Jupyter Server',
+        );
+        log.error(`Cannot read file "${uri.toString()}"`, err, content);
+        throw err;
       }
 
       return Buffer.from(content.content, 'base64');

--- a/src/jupyter/contents/file-system.unit.test.ts
+++ b/src/jupyter/contents/file-system.unit.test.ts
@@ -622,27 +622,7 @@ describe('ContentsFileSystemProvider', () => {
       ).to.eventually.rejectedWith(/FileNotFound/);
     });
 
-    it('throws file system file is a directory when the contents are for a directory', async () => {
-      const contentsStub = stubClient('m-s-foo');
-      contentsStub.get.resolves(CONTENT_DIR.withoutContents);
-
-      await expect(
-        fs.readFile(TestUri.parse('colab://m-s-foo/')),
-      ).to.eventually.rejectedWith(/FileIsADirectory/);
-    });
-
-    it('throws file system file is a directory when the contents not base64 encoded', async () => {
-      const contentsStub = stubClient('m-s-foo');
-      contentsStub.get
-        .withArgs({ path: '/foo.txt', format: 'base64', type: 'file' })
-        .resolves({ ...FOO_CONTENT_FILE, format: 'text' });
-
-      await expect(
-        fs.readFile(TestUri.parse('colab://m-s-foo/foo.txt')),
-      ).to.eventually.rejectedWith(/FileIsADirectory/);
-    });
-
-    it('throws file system file is a directory when the contents not a string', async () => {
+    it('throws when the contents are not a string', async () => {
       const contentsStub = stubClient('m-s-foo');
       contentsStub.get
         .withArgs({ path: '/foo.txt', format: 'base64', type: 'file' })
@@ -650,10 +630,19 @@ describe('ContentsFileSystemProvider', () => {
 
       await expect(
         fs.readFile(TestUri.parse('colab://m-s-foo/foo.txt')),
-      ).to.eventually.rejectedWith(/FileIsADirectory/);
+      ).to.eventually.rejectedWith(/Unexpected content format/);
     });
 
-    it('returns a buffer of the the base64 encoded contents for a file', async () => {
+    it('returns a buffer for a file with empty content', async () => {
+      const contentsStub = stubClient('m-s-foo');
+      contentsStub.get.resolves(CONTENT_DIR.withoutContents);
+
+      const result = await fs.readFile(TestUri.parse('colab://m-s-foo/'));
+
+      expect(result).to.deep.equal(Buffer.from(''));
+    });
+
+    it('returns a buffer of the base64 encoded contents for a file', async () => {
       const contentsStub = stubClient('m-s-foo');
       const content = 'hello world';
       const encoded = Buffer.from(content).toString('base64');


### PR DESCRIPTION
Per VS Code [docs](https://code.visualstudio.com/api/references/vscode-api#FileSystem), `readFile` is invoked to _read the entire contents of a file_ and won't be called for folders. Restores behaviour before https://github.com/googlecolab/colab-vscode/pull/417 while preserving the addition of `type` to ensure `.ipynb` files are read properly.