### PR TITLE
build: bump version to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@jupyterlab/services": "^7.5.3",
         "glob": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
Changes since last bump:

- fix: remove stat call when reading a file (#444)
- build(deps-dev): bump basic-ftp from 5.1.0 to 5.2.0 (#446)
- fix: add Colab icon to terminal and simplify name (#445)
- test: Drive mounting e2e (#441)
- chore: migrate `listAssignments` to new OnePlatform API (#434)
- fix: cosmetic and test improvements to telemetry (#436)
- chore: readme command clarity (#439)
- build(deps-dev): bump minimatch from 3.1.2 to 3.1.4 (#440)
- chore: test helper type safety (#438)
- chore: minor naming improvements (#437)
- chore: migrate `/ccu-info` to new `v1/user-info` API (#432)
- chore: turn on `uploading` and `activityBar` by default (#430)
- chore: migrate `refreshConnection` to new API (#425)
- fix: update clearcut flush interval response type (#428)
- feat: periodically refresh experiment state (#429)
- feat: add ability to select runtime version to server picker (#424)
- feat: use flag as telemetry off-switch (#423)
- build(deps-dev): bump qs from 6.14.1 to 6.14.2 (#421)
- docs: README and extension command updates (#420)
- fix: error reading ipynb file on server (#417)
- feat: log app name and platform (#416)