### PR TITLE
refactor: use `URL.searchParams.set` instead of `append`

### DIFF
--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -113,7 +113,7 @@ export class ColabClient {
     signal?: AbortSignal,
   ): Promise<ConsumptionUserInfo> {
     const url = new URL('v1/user-info', this.colabGapiDomain);
-    url.searchParams.append('get_ccu_consumption_info', 'true');
+    url.searchParams.set('get_ccu_consumption_info', 'true');
     return await this.issueRequest(
       url,
       { method: 'GET', signal },
@@ -227,8 +227,8 @@ export class ColabClient {
     signal?: AbortSignal,
   ): Promise<RuntimeProxyToken> {
     const url = new URL('v1/runtime-proxy-token', this.colabGapiDomain);
-    url.searchParams.append('endpoint', endpoint);
-    url.searchParams.append('port', '8080');
+    url.searchParams.set('endpoint', endpoint);
+    url.searchParams.set('port', '8080');
     return await this.issueRequest(
       url,
       { method: 'GET', signal },
@@ -406,12 +406,12 @@ export class ColabClient {
     { variant, accelerator, shape, version }: AssignParams,
   ): URL {
     const url = new URL(`${TUN_ENDPOINT}/assign`, this.colabDomain);
-    url.searchParams.append('nbh', uuidToWebSafeBase64(notebookHash));
+    url.searchParams.set('nbh', uuidToWebSafeBase64(notebookHash));
     if (variant !== Variant.DEFAULT) {
-      url.searchParams.append('variant', variant);
+      url.searchParams.set('variant', variant);
     }
     if (accelerator) {
-      url.searchParams.append('accelerator', accelerator);
+      url.searchParams.set('accelerator', accelerator);
     }
     const shapeURLParam = mapShapeToURLParam(
       // High mem only accelerators only have one shape option
@@ -420,10 +420,10 @@ export class ColabClient {
         : (shape ?? Shape.STANDARD),
     );
     if (shapeURLParam) {
-      url.searchParams.append('shape', shapeURLParam);
+      url.searchParams.set('shape', shapeURLParam);
     }
     if (version) {
-      url.searchParams.append('runtime_version_label', version);
+      url.searchParams.set('runtime_version_label', version);
     }
     return url;
   }
@@ -463,7 +463,7 @@ export class ColabClient {
   ): Promise<unknown> {
     // The Colab API requires the authuser parameter to be set.
     if (endpoint.hostname === this.colabDomain.hostname) {
-      endpoint.searchParams.append('authuser', '0');
+      endpoint.searchParams.set('authuser', '0');
     }
 
     let response: Response | undefined;


### PR DESCRIPTION
**Why**? Kevin noticed a double `authuser=0&authuser=0` params in https://github.com/googlecolab/colab-vscode/issues/442#issuecomment-3964349035. This is not an issue, but may be confusing and suboptimal.

Using `URL.searchParams.set` instead of `append` to set the params will overwrite the previous value if the param already exists, or create it if it doesn't. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/set) for more info.

This change is a refactoring and is functionally a no-op for all existing use cases.

---

Screenshot showing the double `authuser=0&authuser=0` params gone:
<img width="1584" height="961" alt="searchParamFix" src="https://github.com/user-attachments/assets/cc49d0d3-670c-4e44-9b36-b949d0b0b6d0" />
