### PR TITLE
fix: `Accelerator.models` may be undefined

### DIFF
--- a/src/colab/api.ts
+++ b/src/colab/api.ts
@@ -152,7 +152,10 @@ export const Accelerator = z.object({
   /** The variant of the assignment. */
   variant: z.enum(ColabGapiVariant).transform(normalizeVariant),
   /** The assigned accelerator. */
-  models: z.array(z.string().toUpperCase()),
+  models: z
+    .array(z.string().toUpperCase())
+    .optional()
+    .transform((models) => models ?? []),
 });
 
 /**

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -102,7 +102,10 @@ describe('ColabClient', () => {
           models: ['V5E1', 'V6E1', 'V28'],
         },
       ],
-      ineligibleAccelerators: [],
+      ineligibleAccelerators: [
+        { variant: 'VARIANT_GPU' },
+        { variant: 'VARIANT_TPU' },
+      ],
     };
     fetchStub
       .withArgs(
@@ -131,7 +134,10 @@ describe('ColabClient', () => {
           models: ['V5E1', 'V6E1', 'V28'],
         },
       ],
-      ineligibleAccelerators: [],
+      ineligibleAccelerators: [
+        { variant: Variant.GPU, models: [] },
+        { variant: Variant.TPU, models: [] },
+      ],
     };
     await expect(response).to.eventually.deep.equal(expectedResponse);
     sinon.assert.calledOnce(fetchStub);


### PR DESCRIPTION
**Why**? `Accelerator.models` may be undefined when returned empty from the server. See https://github.com/googlecolab/colab-vscode/issues/450 for more info.

*Note: This is a proto serialization behavior which we likely cannot change because `Accelerator.models` is [always explicitly set in the backend](http://google3/research/colab/boq/oneplatform/userinfo/service/userinfoservice.go;l=110;rcl=843719330).*