### PR TITLE
build: bump selenium-webdriver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "eslint-plugin-tsdoc": "^0.4.0",
         "mocha": "^10.8.2",
         "prettier": "3.4.2",
-        "selenium-webdriver": "^4.34.0",
+        "selenium-webdriver": "^4.41.0",
         "sinon": "^21.0.1",
         "source-map-support": "^0.5.21",
         "tsx": "^4.19.4",
@@ -288,9 +288,9 @@
       }
     },
     "node_modules/@bazel/runfiles": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.3.1.tgz",
-      "integrity": "sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.5.0.tgz",
+      "integrity": "sha512-RzahvqTkfpY2jsDxo8YItPX+/iZ6hbiikw1YhE0bA9EKBR5Og8Pa6FHn9PO9M0zaXRVsr0GFQLKbB/0rzy9SzA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -10968,9 +10968,9 @@
       }
     },
     "node_modules/selenium-webdriver": {
-      "version": "4.34.0",
-      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.34.0.tgz",
-      "integrity": "sha512-zGfQFcsASAv3KrYzYh+iw4fFqB7iZAgHW7BU6rRz7isK1i1X4x3LvjmZad4bUUgHDwTnAhlqTzDh21byB+zHMg==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.41.0.tgz",
+      "integrity": "sha512-1XxuKVhr9az24xwixPBEDGSZP+P0z3ZOnCmr9Oiep0MlJN2Mk+flIjD3iBS9BgyjS4g14dikMqnrYUPIjhQBhA==",
       "dev": true,
       "funding": [
         {
@@ -10984,19 +10984,19 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@bazel/runfiles": "^6.3.1",
+        "@bazel/runfiles": "^6.5.0",
         "jszip": "^3.10.1",
-        "tmp": "^0.2.3",
-        "ws": "^8.18.2"
+        "tmp": "^0.2.5",
+        "ws": "^8.19.0"
       },
       "engines": {
         "node": ">= 20.0.0"
       }
     },
     "node_modules/selenium-webdriver/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -362,7 +362,7 @@
     "eslint-plugin-tsdoc": "^0.4.0",
     "mocha": "^10.8.2",
     "prettier": "3.4.2",
-    "selenium-webdriver": "^4.34.0",
+    "selenium-webdriver": "^4.41.0",
     "sinon": "^21.0.1",
     "source-map-support": "^0.5.21",
     "tsx": "^4.19.4",


### PR DESCRIPTION
There were some breaking changes in the latest version of Chrome and when running locally our older version of selenium-webdriver was not working for me. There was a Chrome mismatch between my devbox and the chromedriver. Apparently recent changes to the _Selenium Manager_ address this, which I can confirm fixes my issue.