### PR TITLE
test: configure e2e code instance settings

### DIFF
--- a/esbuild.config.mts
+++ b/esbuild.config.mts
@@ -158,6 +158,7 @@ async function main(): Promise<void> {
     cpSync('src/auth/media/favicon.ico', 'out/auth/media/favicon.ico');
     if (isTestBuild) {
       cpSync('src/auth/media/favicon.ico', 'out/test/media/favicon.ico');
+      cpSync('src/test/e2e-settings.json', 'out/test/e2e-settings.json');
     }
 
     // Determine which build options to use based on 'isTestBuild' flag

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -116,6 +116,8 @@ build_test_cmd() {
     base_cmd=(extest setup-and-run "${storage_flag[@]+"${storage_flag[@]}"}")
   fi
 
+  base_cmd+=("-o" "./out/test/e2e-settings.json" "-i")
+
   # Print each part of the command on a new line.
   printf "%s\n" "${base_cmd[@]}"
   printf "%s\n" ./out/test/*.e2e.test.js -m ./out/test/e2e.mocharc.js

--- a/src/test/e2e-settings.json
+++ b/src/test/e2e-settings.json
@@ -1,0 +1,14 @@
+{
+  "colab.logging.level": "trace",
+  "jupyter.logging.level": "debug",
+  "telemetry.telemetryLevel": "off",
+  "update.mode": "off",
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.enabled": false,
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false,
+  "security.workspace.trust.enabled": false,
+  "window.restoreWindows": "none",
+  "workbench.editor.enablePreview": false,
+  "workbench.auxiliaryBar.visible": false
+}


### PR DESCRIPTION
Make it _slim_ by disabling a few things that add noise and make it more _useful_ by bumping log verbosity of both Colab and Jupyter.