### PR TITLE
test: remove -i flag from e2e test command

### DIFF
--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -116,7 +116,7 @@ build_test_cmd() {
     base_cmd=(extest setup-and-run "${storage_flag[@]+"${storage_flag[@]}"}")
   fi
 
-  base_cmd+=("-o" "./out/test/e2e/settings.json" "-i")
+  base_cmd+=("-o" "./out/test/e2e/settings.json")
 
   # Print each part of the command on a new line.
   printf "%s\n" "${base_cmd[@]}"


### PR DESCRIPTION
We don't _need_ it for running the tests from source (`setup-and-run`) and it isn't an allowed param when running over a provided `.vsix` (`run-tests`).