### PR TITLE
test: increase OAuth timeout waiting for password screen

### DIFF
--- a/src/test/e2e/extension.e2e.test.ts
+++ b/src/test/e2e/extension.e2e.test.ts
@@ -28,6 +28,9 @@ import {
   selectQuickPickItem,
 } from './ui';
 
+const VSC_SETUP_SLEEP_MS = 8000;
+const OAUTH_PASSWORD_SLEEP_MS = 1000;
+const OAUTH_PASSWORD_WAIT_MS = 20000;
 const ELEMENT_WAIT_MS = 10000;
 const CELL_EXECUTION_WAIT_MS = 30000;
 
@@ -47,7 +50,7 @@ describe('Colab Extension', () => {
     // Wait for VS Code UI to settle before running tests.
     workbench = new Workbench();
     driver = workbench.getDriver();
-    await driver.sleep(8000);
+    await driver.sleep(VSC_SETUP_SLEEP_MS);
   });
 
   beforeEach(function () {
@@ -207,9 +210,9 @@ df`);
       // settle to avoid getting a stale element reference.
       await oauthDriver.wait(
         until.urlContains('accounts.google.com/v3/signin/challenge'),
-        ELEMENT_WAIT_MS,
+        OAUTH_PASSWORD_WAIT_MS,
       );
-      await oauthDriver.sleep(1000);
+      await oauthDriver.sleep(OAUTH_PASSWORD_SLEEP_MS);
       const passwordInput = await oauthDriver.findElement(
         By.css("input[type='password']"),
       );


### PR DESCRIPTION
**Why**? New `mounts Google Drive` e2e test is currently flaky due to Drive auth timing out waiting for password screen to come up. For now, I just bumped it from 10s to 20s.

* Flaky run: https://github.com/googlecolab/colab-vscode/actions/runs/22496147376/job/65171184839
* Failure screenshot:
  <img width="325" height="300" alt="Colab Extension with a notebook authenticated and connected to a Colab server mounts Google Drive (oauth window)" src="https://github.com/user-attachments/assets/bd41f799-5c05-43ef-80c4-db34a303c92a" />

*Note: This change also applies to the initial Colab OAuth, but is functionally a no-op if everything goes smoothly.*