### PR TITLE
refactor: show `mountDrive` command in active notebook only

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,6 +246,10 @@
           "when": "false"
         },
         {
+          "command": "colab.mountDrive",
+          "when": "activeEditor == 'workbench.editor.notebook'"
+        },
+        {
           "command": "colab.mountServer",
           "when": "config.colab.serverMounting"
         },


### PR DESCRIPTION
**Why**? The `colab.mountDrive` command [requires an active notebook editor to work](https://github.com/googlecolab/colab-vscode/blob/4c8d5262fcac83cfa1d246fe0c0b0873fe126bec/src/colab/commands/notebook.ts#L64), so it makes sense to only show it in an active notebook editor.

[Demo screencast](https://screencast.googleplex.com/cast/NTkyNzkzODc4MzQ0NDk5MnxkNjJkNzRjYi1hZA)