### PR TITLE
test: simplify signatures of ui clicks

### DIFF
--- a/src/test/e2e/extension.e2e.test.ts
+++ b/src/test/e2e/extension.e2e.test.ts
@@ -68,29 +68,17 @@ describe('Colab Extension', () => {
 
       // Select the Colab server provider from the kernel selector.
       await workbench.executeCommand('Notebook: Select Notebook Kernel');
-      await selectQuickPickItem(driver, {
-        item: 'Colab',
-        quickPick: 'Select Another Kernel',
-      });
-      await selectQuickPickItem(driver, {
-        item: 'New Colab Server',
-        quickPick: 'Select a Jupyter Server',
-      });
+      await selectQuickPickItem(driver, 'Colab');
+      await selectQuickPickItem(driver, 'New Colab Server');
 
       // Accept the dialog allowing the Colab extension to sign in using Google.
-      await pushDialogButton(driver, {
-        button: 'Allow',
-        dialog: "The extension 'Colab' wants to sign in using Google.",
-      });
+      await pushDialogButton(driver, 'Allow');
       // Begin the sign-in process by copying the OAuth URL to the clipboard and
       // opening it in a browser window. Why do this instead of triggering the
       // "Open" button in the dialog? We copy the URL so that we can use a new
       // driver instance for the OAuth flow, since the original driver instance
       // does not have a handle to the window that would be spawned with "Open".
-      await pushDialogButton(driver, {
-        button: 'Copy',
-        dialog: 'Do you want Code to open the external website?',
-      });
+      await pushDialogButton(driver, 'Copy');
       await doOauthSignIn(
         /* oauthUrl= */ clipboard.readSync(),
         /* expectedRedirectUrl= */ 'vscode/auth-success',
@@ -98,21 +86,12 @@ describe('Colab Extension', () => {
 
       // Now that we're authenticated, we can resume creating a Colab server via
       // the open kernel selector.
-      await selectQuickPickItem(driver, {
-        item: 'CPU',
-        quickPick: 'Select a variant (1/3)',
-      });
-      await selectQuickPickItem(driver, {
-        item: 'Latest',
-        quickPick: 'Select a runtime version (2/3)',
-      });
+      await selectQuickPickItem(driver, 'CPU');
+      await selectQuickPickItem(driver, 'Latest');
       // Alias the server with the default name.
       const inputBox = await InputBox.create();
       await inputBox.sendKeys(Key.ENTER);
-      await selectQuickPickItem(driver, {
-        item: 'Python 3 (ipykernel)',
-        quickPick: 'Select a Kernel from Colab CPU',
-      });
+      await selectQuickPickItem(driver, 'Python 3 (ipykernel)');
     });
 
     afterEach(async () => {
@@ -160,27 +139,18 @@ df`);
 
       await workbench.executeCommand('Notebook: Run All');
 
-      await pushDialogButton(driver, {
-        button: 'Connect to Google Drive',
-        dialog: 'Permit server to access your Google Drive files?',
-      });
+      await pushDialogButton(driver, 'Connect to Google Drive');
       // Begin the sign-in process by copying the OAuth URL to the clipboard and
       // opening it in a browser window. Why do this instead of triggering the
       // "Open" button in the dialog? We copy the URL so that we can use a new
       // driver instance for the OAuth flow, since the original driver instance
       // does not have a handle to the window that would be spawned with "Open".
-      await pushDialogButton(driver, {
-        button: 'Copy',
-        dialog: 'Do you want Code to open the external website?',
-      });
+      await pushDialogButton(driver, 'Copy');
       await doOauthSignIn(
         /* oauthUrl= */ clipboard.readSync(),
         /* expectedRedirectUrl= */ 'tun/m/authorize-for-drive-credentials-ephem',
       );
-      await pushDialogButton(driver, {
-        button: 'Continue',
-        dialog: 'Please complete the authorization in your browser.',
-      });
+      await pushDialogButton(driver, 'Continue');
 
       await assertAllCellsExecutedSuccessfully(driver, workbench);
     });

--- a/src/test/e2e/ui.ts
+++ b/src/test/e2e/ui.ts
@@ -18,16 +18,7 @@ const ELEMENT_WAIT_MS = 10000;
 /**
  * Selects the QuickPick option.
  */
-export function selectQuickPickItem(
-  driver: WebDriver,
-  {
-    item,
-    quickPick,
-  }: {
-    item: string;
-    quickPick: string;
-  },
-) {
+export function selectQuickPickItem(driver: WebDriver, item: string) {
   return driver.wait(
     async () => {
       try {
@@ -46,23 +37,14 @@ export function selectQuickPickItem(
       }
     },
     ELEMENT_WAIT_MS,
-    `Select "${item}" item for QuickPick "${quickPick}" failed`,
+    `Could not select "${item}" from QuickPick`,
   );
 }
 
 /**
  * Pushes a button in a modal dialog and waits for the action to complete.
  */
-export function pushDialogButton(
-  driver: WebDriver,
-  {
-    button,
-    dialog,
-  }: {
-    button: string;
-    dialog: string;
-  },
-) {
+export function pushDialogButton(driver: WebDriver, button: string) {
   // ModalDialog.pushButton will throw if the dialog is not found; to reduce
   // flakes we attempt this until it succeeds or times out.
   return driver.wait(
@@ -77,7 +59,7 @@ export function pushDialogButton(
       }
     },
     ELEMENT_WAIT_MS,
-    `Push "${button}" button for dialog "${dialog}" failed`,
+    `Could not select "${button}" from dialog`,
   );
 }
 


### PR DESCRIPTION
Brevity adds a bit of clarity here. Source mappings, logs, screenshots and the fact that the quickpick items are unique should be enough to determine failures. Makes the tests a little easier to read and write! Also, and perhaps most importantly, reduces the chance a rename or mismatch goes unnoticed in the test code.