### PR TITLE
feat: allow `GoogleAuthProvider` to support multiple auth sessions

### DIFF
--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -294,21 +294,21 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
       return;
     }
     const record = await this.storage.getSessionById(sessionId);
-    if(record){
-    try {
-      // OR this.oAuth2Client.revokeToken() OR do I need to store tokenInfo
-      this.oAuth2Client.setCredentials({
+    if (record) {
+      try {
+        // OR this.oAuth2Client.revokeToken() OR do I need to store tokenInfo
+        this.oAuth2Client.setCredentials({
           refresh_token: record.refreshToken,
           token_type: 'Bearer',
           scope: record.scopes.join(' '),
         });
-      await this.oAuth2Client.revokeCredentials();
-    } catch {
-      // It's possible the token is already expired or revoked. We can swallow
-      // errors since the user will be required to login again.
+        await this.oAuth2Client.revokeCredentials();
+      } catch {
+        // It's possible the token is already expired or revoked. We can swallow
+        // errors since the user will be required to login again.
+      }
+      await this.storage.removeSession(sessionId);
     }
-    await this.storage.removeSession(sessionId);
-  }
     this.deleteSession(sessionId);
     this.notifySessionRemoved(removedSession);
   }
@@ -410,26 +410,24 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
     }
   }
 
-  private listSessions() {
+  private listSessions(): AuthenticationSession[] {
     return Array.from(this.sessions.values());
   }
 
-  private hasSessions() {
+  private hasSessions(): boolean {
     return this.sessions.size > 0;
   }
 
-  private hasSessionForScopes(scopes: readonly string[]) {
-    return this.listSessions().some((s) =>
-      matchesScopes(s.scopes, scopes),
-    );
+  private hasSessionForScopes(scopes: readonly string[]): boolean {
+    return this.listSessions().some((s) => matchesScopes(s.scopes, scopes));
   }
 
-  private getSession(id: string) {
+  private getSession(id: string): AuthenticationSession | undefined {
     return this.sessions.get(id);
   }
 
   private updateSession(
-    record: RefreshableAuthenticationSession,
+    record: AuthenticationSession | RefreshableAuthenticationSession,
     accessToken: string,
   ): AuthenticationSession {
     const session: AuthenticationSession = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,7 +124,8 @@ export async function activate(context: vscode.ExtensionContext) {
   // issuing authenticated requests to Colab. This can only be done after the
   // user has signed in. We don't block extension activation on completing the
   // heavily asynchronous sign-in flow.
-  const whileAuthorizedToggle = authProvider.whileAuthorized(REQUIRED_SCOPES,
+  const whileAuthorizedToggle = authProvider.whileAuthorized(
+    REQUIRED_SCOPES,
     connections,
     keepServersAlive,
     consumptionMonitor.toggle,


### PR DESCRIPTION
+ Remove safeguards that require the that scopes must match `REQUIRED_SCOPES`
+ Make `scopes` a param in methods that assume scopes are always `REQUIRED_SCOPES`
+ Change session storage from a single session to a map