### PR TITLE
feat: wrap registered commands with error tracking

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -34,7 +34,6 @@ tpus
 unassigning
 unassignment
 unassigns
-unregisters
 veryhighmem
 vscode
 vsdiag

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -268,7 +268,7 @@ function registerCommands(
  *
  * @param command - The unique identifier for the command.
  * @param handler - A command handler function.
- * @returns Disposable which unregisters this command on disposal.
+ * @returns Disposable which deregisters this command on disposal.
  */
 function registerCommand<T extends (...args: Parameters<T>) => ReturnType<T>>(
   command: string,


### PR DESCRIPTION
Wraps registered commands with error tracking.

note: this is currently a no-op as telemetry is not yet being initialized

https://github.com/user-attachments/assets/4036850e-98b2-4c38-957d-46c285bfad60
