### PR TITLE
fix: only attempt to recover from auth errors once

### DIFF
--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -504,24 +504,34 @@ export class ColabClient {
         break;
       }
 
-      if (response.status === 401 && this.onAuthError) {
+      // If it's a 401 and we have an auth error handler, try to recover.
+      // But don't retry if this is already our last attempt.
+      if (response.status === 401 && this.onAuthError && attempt < 1) {
         await this.onAuthError();
       } else {
-        let errorBody;
-        try {
-          errorBody = await response.text();
-        } catch {
-          // Ignore errors reading the body
-        }
-        throw new ColabRequestError({
-          request,
-          response,
-          responseBody: errorBody,
-        });
+        break;
       }
     }
 
-    if (!schema || !response) {
+    if (!response || !request) {
+      return;
+    }
+
+    if (!response.ok) {
+      let errorBody;
+      try {
+        errorBody = await response.text();
+      } catch {
+        // Ignore errors reading the body
+      }
+      throw new ColabRequestError({
+        request,
+        response,
+        responseBody: errorBody,
+      });
+    }
+
+    if (!schema) {
       return;
     }
 

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -878,7 +878,8 @@ describe('ColabClient', () => {
     );
 
     sinon.assert.calledTwice(fetchStub);
-    sinon.assert.calledTwice(onAuthErrorStub);
+    // There's only one attempt to fix the auth error.
+    sinon.assert.calledOnce(onAuthErrorStub);
   });
 
   it('throws on 401 if onAuthError is not provided', async () => {


### PR DESCRIPTION
The callback should just be invoked once for persistent 401s.