### PR TITLE
feat: api and client definitions for resource monitoring

### DIFF
--- a/src/colab/api.ts
+++ b/src/colab/api.ts
@@ -422,6 +422,91 @@ export const SessionSchema: z.ZodType<GeneratedSession> = z.object({
 });
 export type Session = z.infer<typeof SessionSchema>;
 
+/** Information about memory usage on a Colab runtime. */
+export const MemorySchema = z.object({
+  /** Total memory available in bytes. */
+  totalBytes: z.number(),
+  /** Free memory available in bytes. */
+  freeBytes: z.number(),
+});
+/** Memory usage on a Colab runtime. */
+export type Memory = z.infer<typeof MemorySchema>;
+
+/** Information about a GPU on a Colab runtime. */
+export const GpuInfoSchema = z.object({
+  /** The name of the GPU. */
+  name: z.string(),
+  /** Memory used in bytes. */
+  memoryUsedBytes: z.number(),
+  /** Total memory in bytes. */
+  memoryTotalBytes: z.number(),
+  /** GPU utilization as a percentage (0-1). */
+  gpuUtilization: z.number(),
+  /** Memory utilization as a percentage (0-1). */
+  memoryUtilization: z.number(),
+  /** Whether the GPU has ever been used. */
+  everUsed: z.boolean(),
+});
+/** GPU information on a Colab runtime. */
+export type GpuInfo = z.infer<typeof GpuInfoSchema>;
+
+/** Information about a filesystem on a Colab runtime. */
+export const FilesystemSchema = z
+  .object({
+    /** The name of the filesystem. */
+    name: z.string().optional(),
+    /** The label of the filesystem (legacy). */
+    label: z.string().optional(),
+    /** Total space on the filesystem in bytes. */
+    totalBytes: z.number(),
+    /** Used space on the filesystem in bytes (legacy). */
+    usedBytes: z.number().optional(),
+    /** Free space on the filesystem in bytes. */
+    freeBytes: z.number().optional(),
+  })
+  .transform((val) => ({
+    name: val.name ?? val.label ?? '',
+    totalBytes: val.totalBytes,
+    freeBytes: val.freeBytes ?? val.totalBytes - (val.usedBytes ?? 0),
+  }));
+/** A filesystem on a Colab runtime. */
+export type Filesystem = z.infer<typeof FilesystemSchema>;
+
+/** Information about a disk on a Colab runtime. */
+export const DiskSchema = z
+  .object({
+    /** The name of the disk. */
+    name: z.string().optional(),
+    /** Total size of the disk in bytes. */
+    sizeBytes: z.number().optional(),
+    /** The filesystems on the disk. */
+    filesystems: z.array(FilesystemSchema).optional(),
+    /** Legacy representation of a single filesystem. */
+    filesystem: FilesystemSchema.optional(),
+  })
+  .transform((val) => ({
+    name: val.name ?? '',
+    sizeBytes: val.sizeBytes ?? val.filesystem?.totalBytes ?? 0,
+    filesystems: val.filesystems ?? (val.filesystem ? [val.filesystem] : []),
+  }));
+/** A disk on a Colab runtime. */
+export type Disk = z.infer<typeof DiskSchema>;
+
+/** The schema for resources (RAM, disk, etc.) on a Colab runtime. */
+export const ResourcesSchema = z.object({
+  /** Memory usage information. */
+  memory: MemorySchema.optional(),
+  /** Disk usage information. */
+  disks: z.array(DiskSchema),
+  /** GPU information. */
+  gpus: z
+    .array(GpuInfoSchema)
+    .optional()
+    .transform((val) => val ?? []),
+});
+/** Resources on a Colab runtime. */
+export type Resources = z.infer<typeof ResourcesSchema>;
+
 /** Result from the Colab Drive credentials propagation API. */
 export const CredentialsPropagationResultSchema = z
   .object({

--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -37,6 +37,8 @@ import {
   ExperimentStateSchema,
   ExperimentState,
   isHighMemOnlyAccelerator,
+  Resources,
+  ResourcesSchema,
 } from './api';
 import {
   ACCEPT_JSON_HEADER,
@@ -294,6 +296,34 @@ export class ColabClient {
         signal,
       },
       z.array(SessionSchema),
+    );
+  }
+
+  /**
+   * Gets the resources (RAM and disk usage) for a given server by its endpoint.
+   *
+   * @param endpoint - The assignment endpoint to get resources for.
+   * @param signal - Optional {@link AbortSignal} to cancel the request.
+   * @returns The resources information.
+   */
+  async getResources(
+    endpoint: string,
+    signal?: AbortSignal,
+  ): Promise<Resources> {
+    const url = new URL(
+      `${TUN_ENDPOINT}/${endpoint}/api/colab/resources`,
+      this.colabDomain,
+    );
+    const headers = { [COLAB_TUNNEL_HEADER.key]: COLAB_TUNNEL_HEADER.value };
+
+    return await this.issueRequest(
+      url,
+      {
+        method: 'GET',
+        headers,
+        signal,
+      },
+      ResourcesSchema,
     );
   }
 

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -787,6 +787,63 @@ describe('ColabClient', () => {
 
       sinon.assert.calledOnce(fetchStub);
     });
+
+    it('successfully gets resources by assignment endpoint', async () => {
+      const mockResources = {
+        memory: { totalBytes: 13605834752, freeBytes: 12475244544 },
+        disks: [
+          {
+            filesystem: {
+              label: 'kernel',
+              totalBytes: 115658190848,
+              usedBytes: 22869635072,
+            },
+          },
+        ],
+        gpus: [],
+      };
+      fetchStub
+        .withArgs(
+          urlMatcher({
+            method: 'GET',
+            host: COLAB_HOST,
+            path: `/tun/m/${assignedServer.endpoint}/api/colab/resources`,
+            otherHeaders: {
+              [COLAB_TUNNEL_HEADER.key]: COLAB_TUNNEL_HEADER.value,
+            },
+            withAuthUser: false,
+          }),
+        )
+        .resolves(
+          new Response(withXSSI(JSON.stringify(mockResources)), {
+            status: 200,
+          }),
+        );
+
+      const response = await client.getResources(assignedServer.endpoint);
+
+      const expectedResources = {
+        memory: mockResources.memory,
+        disks: [
+          {
+            name: '',
+            sizeBytes: mockResources.disks[0].filesystem.totalBytes,
+            filesystems: [
+              {
+                name: mockResources.disks[0].filesystem.label,
+                totalBytes: mockResources.disks[0].filesystem.totalBytes,
+                freeBytes:
+                  mockResources.disks[0].filesystem.totalBytes -
+                  mockResources.disks[0].filesystem.usedBytes,
+              },
+            ],
+          },
+        ],
+        gpus: [],
+      };
+      expect(response).to.deep.equal(expectedResources);
+      sinon.assert.calledOnce(fetchStub);
+    });
   });
 
   it('successfully issues keep-alive pings', async () => {


### PR DESCRIPTION
This API definition was largely _reverse engineered_ from our web front-end, our backend impl. and the observed Chrome response(s) for `api/colab/resources`.

_The following all contain internal links, but leaving as breadcrumbs for @hjjackyang who's expressed interest in building this out._

- [`Resources`](http://google3/logs/proto/colab/resourcestats.proto;l=20;rcl=877490900)
- [Backend definitions (partial)](http://google3/research/colab/datalab/tunnel/tunnelutil.go;l=406;rcl=868754694)
- Some of the fields (for accelerators) get merged in from the runtime ([example](http://google3/third_party/py/google/colab/_serverextension/_resource_monitor.py;l=227;rcl=783013361))

Support for this endpoint is a bit convoluted and varies slightly per machine/accelerator. I've defined what's in this PR as best I could, but I wouldn't be surprised if there are little mistakes here and there. Hopefully is at least a good starting point 🤞.