### PR TITLE
fix: update drive scopes to include `REQUIRED_SCOPES` and use `drive.…

### DIFF
--- a/src/auth/auth-provider.unit.test.ts
+++ b/src/auth/auth-provider.unit.test.ts
@@ -50,8 +50,7 @@ const DEFAULT_AUTH_SESSION: vscode.AuthenticationSession = {
   account: DEFAULT_REFRESH_SESSION.account,
   scopes: DEFAULT_REFRESH_SESSION.scopes.sort(),
 };
-const ADDITIONAL_SCOPES = [...DRIVE_SCOPES];
-const UPGRADED_SCOPES = [...SCOPES, ...ADDITIONAL_SCOPES];
+const UPGRADED_SCOPES = [...DRIVE_SCOPES];
 const UPGRADED_ACCESS_TOKEN = '43';
 const UPGRADED_REFRESH_SESSION: RefreshableAuthenticationSession = {
   id: '2',
@@ -513,7 +512,7 @@ describe('GoogleAuthProvider', () => {
 
       it('returns an empty array when the specified scopes are allowed but do not match the stored session', async () => {
         await expect(
-          authProvider.getSessions(ADDITIONAL_SCOPES, {}),
+          authProvider.getSessions(UPGRADED_SCOPES, {}),
         ).to.eventually.deep.equal([]);
       });
 
@@ -619,7 +618,7 @@ describe('GoogleAuthProvider', () => {
         await authProvider.initialize();
       });
 
-      for (const scopes of [SCOPES, ADDITIONAL_SCOPES, UPGRADED_SCOPES]) {
+      for (const scopes of [SCOPES, UPGRADED_SCOPES]) {
         it('returns the session when the specified scopes match', async () => {
           const sessions = authProvider.getSessions(scopes, {});
 

--- a/src/auth/scopes.ts
+++ b/src/auth/scopes.ts
@@ -13,7 +13,8 @@ export const REQUIRED_SCOPES = [
 
 /** Scopes required to use the Drive integration */
 export const DRIVE_SCOPES = [
-  'https://www.googleapis.com/auth/drive.readonly',
+  ...REQUIRED_SCOPES,
+  'https://www.googleapis.com/auth/drive.file',
 ] as const;
 
 /** Set of all scopes that are permitted to be used by this extension */


### PR DESCRIPTION
Update drive scopes to include `REQUIRED_SCOPES` and use `drive.file` as it's already supported. 

Also fix tests since `ADDITIONAL_SCOPES` and `UPGRADED_SCOPES` are the same now. 