### PR TITLE
refactor: move `issueRequest` logic to it's own class

### DIFF
--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -73,7 +73,6 @@ interface AssignParams {
  * A client for interacting with the Colab APIs.
  */
 export class ColabClient {
-  private readonly requester: Transport;
   private readonly httpsAgent?: https.Agent;
 
   /**
@@ -81,31 +80,23 @@ export class ColabClient {
    *
    * @param colabDomain - The Colab domain URL.
    * @param colabGapiDomain - The Colab GAPI domain URL.
-   * @param getAccessToken - Function to retrieve the access token.
+   * @param transport - The transport layer used to issue network requests.
    * @param callerInfo - Information about the caller.
-   * @param onAuthError - Callback invoked on authentication error.
    */
   constructor(
     private readonly colabDomain: URL,
     private readonly colabGapiDomain: URL,
-    getAccessToken: (scopes: readonly string[]) => Promise<string>,
+    private readonly transport: Transport,
     private readonly callerInfo: {
       appName: string;
       extensionVersion: string;
     },
-    readonly onAuthError?: () => Promise<void>,
   ) {
     // TODO: Temporary workaround to allow self-signed certificates
     // in local development.
     if (colabDomain.hostname === 'localhost') {
       this.httpsAgent = new https.Agent({ rejectUnauthorized: false });
     }
-
-    this.requester = new Transport(
-      () => getAccessToken(REQUIRED_SCOPES),
-      onAuthError,
-      this.httpsAgent,
-    );
   }
 
   /**
@@ -528,15 +519,24 @@ export class ColabClient {
       ...init,
       headers: requestHeaders,
     };
+    const optionsWithOverrides = {
+      ...options,
+      scopes: REQUIRED_SCOPES,
+      agent: this.httpsAgent,
+    };
 
     return schema
-      ? this.requester.issueRequestAndParse(
+      ? this.transport.issueRequestAndParse(
           endpoint,
           requestInit,
           schema,
-          options,
+          optionsWithOverrides,
         )
-      : this.requester.issueRequest(endpoint, requestInit, options);
+      : this.transport.issueRequest(
+          endpoint,
+          requestInit,
+          optionsWithOverrides,
+        );
   }
 }
 

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -43,6 +43,7 @@ import {
   COLAB_VS_CODE_EXTENSION_VERSION,
   COLAB_XSRF_TOKEN_HEADER,
 } from './headers';
+import { Transport } from './transport';
 
 const COLAB_HOST = 'colab.example.com';
 const GOOGLE_APIS_HOST = 'colab.example.googleapis.com';
@@ -75,6 +76,7 @@ const DEFAULT_ASSIGNMENT: Assignment = {
 describe('ColabClient', () => {
   let fetchStub: sinon.SinonStubbedMember<typeof fetch>;
   let sessionStub: SinonStub<[readonly string[]], Promise<string>>;
+  let transport: Transport;
   let client: ColabClient;
   let onAuthErrorStub: SinonStub<[], Promise<void>>;
 
@@ -89,12 +91,12 @@ describe('ColabClient', () => {
       });
     sessionStub.withArgs(REQUIRED_SCOPES).resolves(BEARER_TOKEN);
     onAuthErrorStub = sinon.stub();
+    transport = new Transport(sessionStub, onAuthErrorStub);
     client = new ColabClient(
       new URL(`https://${COLAB_HOST}`),
       new URL(`https://${GOOGLE_APIS_HOST}`),
-      sessionStub,
+      transport,
       { appName: APP_NAME, extensionVersion: EXTENSION_VERSION },
-      onAuthErrorStub,
     );
   });
 

--- a/src/colab/transport.ts
+++ b/src/colab/transport.ts
@@ -6,14 +6,19 @@
 import * as https from 'https';
 import fetch, { Headers, Request, RequestInit, Response } from 'node-fetch';
 import { z } from 'zod';
+import { REQUIRED_SCOPES } from '../auth/scopes';
 import { ACCEPT_JSON_HEADER, AUTHORIZATION_HEADER } from './headers';
 
 /**
  * Options for the issueRequest methods
  */
 export interface IssueRequestOptions {
+  /** The set of scopes to request the access token for. Defaults to {@link REQUIRED_SCOPES} */
+  scopes?: readonly string[];
   /** Whether or not to include the access token in the request. Defaults to true. */
   requireAccessToken?: boolean;
+  /** HttpAgent to make the request. */
+  httpsAgent?: https.Agent;
 }
 
 const XSSI_PREFIX = ")]}'\n";
@@ -28,12 +33,12 @@ export class Transport {
    *
    * @param getAccessToken - Function to retrieve the access token.
    * @param onAuthError - Callback invoked on authentication error.
-   * @param httpsAgent - HttpAgent to make the request.
    */
   constructor(
-    private readonly getAccessToken: () => Promise<string>,
+    private readonly getAccessToken: (
+      scopes: readonly string[],
+    ) => Promise<string>,
     private readonly onAuthError?: () => Promise<void>,
-    private readonly httpsAgent?: https.Agent,
   ) {}
 
   /**
@@ -78,7 +83,11 @@ export class Transport {
   private async performFetch(
     endpoint: URL,
     init: RequestInit,
-    { requireAccessToken = true }: IssueRequestOptions = {},
+    {
+      scopes = REQUIRED_SCOPES,
+      requireAccessToken = true,
+      httpsAgent,
+    }: IssueRequestOptions = {},
   ): Promise<Response> {
     let response: Response | undefined;
     let request: Request | undefined;
@@ -89,14 +98,14 @@ export class Transport {
     // authentication error i.e. if the first attempt fails with a 401,
     for (let attempt = 0; attempt < 2; attempt++) {
       if (requireAccessToken) {
-        const token = await this.getAccessToken();
+        const token = await this.getAccessToken(scopes);
         requestHeaders.set(AUTHORIZATION_HEADER.key, `Bearer ${token}`);
       }
 
       request = new Request(endpoint, {
         ...init,
         headers: requestHeaders,
-        agent: this.httpsAgent,
+        agent: httpsAgent,
       });
       response = await fetch(request);
       if (response.ok) {

--- a/src/colab/transport.unit.test.ts
+++ b/src/colab/transport.unit.test.ts
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as https from 'https';
 import { expect } from 'chai';
 import fetch, { Response } from 'node-fetch';
 import { SinonStub } from 'sinon';
 import * as sinon from 'sinon';
 import { z } from 'zod';
+import { REQUIRED_SCOPES } from '../auth/scopes';
 import { ACCEPT_JSON_HEADER, AUTHORIZATION_HEADER } from './headers';
 import { Transport, ColabRequestError } from './transport';
 
@@ -17,7 +19,7 @@ const BEARER_TOKEN = 'access-token';
 
 describe('Transport', () => {
   let fetchStub: sinon.SinonStubbedMember<typeof fetch>;
-  let getAccessTokenStub: SinonStub<[], Promise<string>>;
+  let getAccessTokenStub: SinonStub<[readonly string[]], Promise<string>>;
   let onAuthErrorStub: SinonStub<[], Promise<void>>;
   let transport: Transport;
 
@@ -26,7 +28,7 @@ describe('Transport', () => {
       throw new Error('fetch was called with non-matching call');
     });
     getAccessTokenStub = sinon
-      .stub<[], Promise<string>>()
+      .stub<[readonly string[]], Promise<string>>()
       .resolves(BEARER_TOKEN);
     onAuthErrorStub = sinon.stub<[], Promise<void>>().resolves();
     transport = new Transport(getAccessTokenStub, onAuthErrorStub);
@@ -51,21 +53,21 @@ describe('Transport', () => {
     const schema = z.object({ foo: z.string() });
 
     await transport.issueRequestAndParse(new URL(DOMAIN), {}, schema);
-    
+
     sinon.assert.calledOnce(fetchStub);
     sinon.assert.calledWith(
       fetchStub,
       sinon.match({
         headers: sinon.match((headers: Headers) => {
           return (
-            headers.get(AUTHORIZATION_HEADER.key) === `Bearer ${BEARER_TOKEN}` &&
+            headers.get(AUTHORIZATION_HEADER.key) ===
+              `Bearer ${BEARER_TOKEN}` &&
             headers.get(ACCEPT_JSON_HEADER.key) === ACCEPT_JSON_HEADER.value
           );
         }),
       }),
     );
   });
-
 
   it('does not set authorization header if requireAccessToken is false', async () => {
     fetchStub.resolves(
@@ -74,15 +76,48 @@ describe('Transport', () => {
     const schema = z.object({ foo: z.string() });
 
     await transport.issueRequestAndParse(new URL(DOMAIN), {}, schema, {
-        requireAccessToken: false,
+      requireAccessToken: false,
     });
 
     sinon.assert.calledOnce(fetchStub);
     sinon.assert.calledWith(
-        fetchStub,
-        sinon.match((req: Request) => req.headers.get(AUTHORIZATION_HEADER.key) === null),
+      fetchStub,
+      sinon.match(
+        (req: Request) => req.headers.get(AUTHORIZATION_HEADER.key) === null,
+      ),
     );
     sinon.assert.notCalled(getAccessTokenStub);
+  });
+
+  it('uses provided scopes to retrieve access token', async () => {
+    const customScopes = ['scope1', 'scope2'];
+    fetchStub.resolves(new Response(undefined, { status: 200 }));
+
+    await transport.issueRequest(new URL(DOMAIN), {}, { scopes: customScopes });
+
+    sinon.assert.calledWith(getAccessTokenStub, customScopes);
+  });
+
+  it('uses REQUIRED_SCOPES as default scopes', async () => {
+    fetchStub.resolves(new Response(undefined, { status: 200 }));
+
+    await transport.issueRequest(new URL(DOMAIN), {});
+
+    sinon.assert.calledWith(getAccessTokenStub, REQUIRED_SCOPES);
+  });
+
+  it('uses provided https agent', async () => {
+    const agent = new https.Agent();
+    fetchStub.resolves(new Response(undefined, { status: 200 }));
+
+    await transport.issueRequest(new URL(DOMAIN), {}, { httpsAgent: agent });
+
+    sinon.assert.calledWith(
+      fetchStub,
+      sinon.match({
+        agent,
+      }),
+    );
   });
 
   it('strips XSSI prefix if present', async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,6 +40,7 @@ import {
 import { ServerItem } from './colab/server-browser/server-item';
 import { ServerTreeProvider } from './colab/server-browser/server-tree';
 import { ServerPicker } from './colab/server-picker';
+import { Transport } from './colab/transport';
 import { CONFIG } from './colab-config';
 import { initializeLogger, log } from './common/logging';
 import { Toggleable } from './common/toggleable';
@@ -86,15 +87,18 @@ async function activateInternal(context: vscode.ExtensionContext) {
     (scopes: string[], options?: LoginOptions) =>
       login(vscode, authFlows, authClient, scopes, options),
   );
-  const colabClient = new ColabClient(
-    new URL(CONFIG.ColabApiDomain),
-    new URL(CONFIG.ColabGapiDomain),
+  const transport = new Transport(
     (scopes: readonly string[]) =>
       GoogleAuthProvider.getOrCreateSession(vscode, scopes).then(
         (session) => session.accessToken,
       ),
-    { appName: vscode.env.appName, extensionVersion: packageInfo.version },
     () => authProvider.signOut(),
+  );
+  const colabClient = new ColabClient(
+    new URL(CONFIG.ColabApiDomain),
+    new URL(CONFIG.ColabGapiDomain),
+    transport,
+    { appName: vscode.env.appName, extensionVersion: packageInfo.version },
   );
   const serverStorage = new ServerStorage(vscode, context.secrets);
   const assignmentManager = new AssignmentManager(


### PR DESCRIPTION
Move `ColabClient.issueRequest` logic to it's own class so it can be used for other clients (will be adding `DriveClient` in a follow up CL).

I left the `ColabClient` test's as-is for the most part as it demonstrates that the refactor is WAI. 