### PR TITLE
feat: add `DriveClient` to interact with the Google Drive API

### DIFF
--- a/src/drive/api.ts
+++ b/src/drive/api.ts
@@ -11,7 +11,7 @@
 import { z } from 'zod';
 
 /**
- * The schema for Drive file metadata.
+ * Drive file metadata.
  *
  * This is a small subset of the full object that is returned.
  */

--- a/src/drive/client.ts
+++ b/src/drive/client.ts
@@ -25,26 +25,28 @@ export class DriveClient {
    *
    * @param getAccessToken - Function to retrieve the access token.
    * @param onAuthError - Callback when an auth error occurs.
-   * @returns A new ColabClient instance.
+   * @returns A new DriveClient instance.
    */
   static create(
     getAccessToken: () => Promise<string>,
     onAuthError: (() => Promise<void>) | undefined,
   ): DriveClient {
-    return new DriveClient(
-      buildFetchChain(
-        [
-          createAcceptJsonMiddleware(),
-          createErrorMiddleware(),
-          createAuthMiddleware(getAccessToken, onAuthError),
-        ],
-        fetch,
-      ),
-    );
+    const baseMiddleware = [
+      createErrorMiddleware(),
+      createAuthMiddleware(getAccessToken, onAuthError),
+    ];
+    const jsonMiddleware = [...baseMiddleware, createAcceptJsonMiddleware()];
+    const blobFetch = buildFetchChain(baseMiddleware, fetch);
+    const jsonFetch = buildFetchChain(jsonMiddleware, fetch);
+    return new DriveClient(blobFetch, jsonFetch);
   }
 
   private constructor(
-    private readonly authenticatedFetch: (
+    private readonly blobFetch: (
+      url: string | Request,
+      init?: RequestInit,
+    ) => Promise<Response>,
+    private readonly jsonFetch: (
       url: string | Request,
       init?: RequestInit,
     ) => Promise<Response>,
@@ -52,6 +54,10 @@ export class DriveClient {
 
   /**
    * Retrieves the content of a file from Google Drive.
+   *
+   * TODO: Convert to a stream to better support larger files as
+   * response.arrayBuffer() loads the entire file into memory at once.
+   * The tricky part here is that VsCode Web does not accept streams.
    *
    * @param fileId - The ID of the Drive file.
    * @param signal - Optional {@link AbortSignal} to cancel the request.
@@ -62,7 +68,7 @@ export class DriveClient {
     signal?: AbortSignal,
   ): Promise<Uint8Array> {
     const url = new URL(`${FILES_ENDPOINT}/${fileId}?alt=media`);
-    const response = await this.authenticatedFetch(url.toString(), {
+    const response = await this.blobFetch(url.toString(), {
       method: 'GET',
       signal,
     });
@@ -99,7 +105,7 @@ export class DriveClient {
     url.searchParams.append('fields', 'name');
 
     return fetchAndParse(
-      this.authenticatedFetch,
+      this.jsonFetch,
       url.toString(),
       DriveFileMetadataSchema,
       {

--- a/src/drive/client.unit.test.ts
+++ b/src/drive/client.unit.test.ts
@@ -37,13 +37,10 @@ describe('DriveClient', () => {
   describe('getDriveFileContent', () => {
     it('should return the file content', async () => {
       const fileId = 'test-file-id';
-      const fileContent = { cells: [], metadata: {} };
-      const expectedContent = new TextEncoder().encode(
-        JSON.stringify(fileContent),
-      );
-      fetchStub.resolves(
-        new Response(JSON.stringify(fileContent), { status: 200 }),
-      );
+      // .ipynb files are just JSON files
+      const fileContent = JSON.stringify({ cells: [], metadata: {} });
+      const expectedContent = new TextEncoder().encode(fileContent);
+      fetchStub.resolves(new Response(fileContent, { status: 200 }));
 
       const result = await client.getDriveFileContent(fileId);
 


### PR DESCRIPTION
This PR adds `DriveClient` which interacts with the Google Drive API to support the upcoming "Import notebook" command.  

Currently this is a no-op as nothing interacts with this client.