### PR TITLE
refactor: resources API call

### DIFF
--- a/src/colab/api.ts
+++ b/src/colab/api.ts
@@ -423,79 +423,78 @@ export const SessionSchema: z.ZodType<GeneratedSession> = z.object({
 export type Session = z.infer<typeof SessionSchema>;
 
 /** Information about memory usage on a Colab runtime. */
-export const MemorySchema = z.object({
-  /** Total memory available in bytes. */
-  totalBytes: z.number(),
-  /** Free memory available in bytes. */
-  freeBytes: z.number(),
-});
+export const MemorySchema = z
+  .object({
+    /** Total memory available in bytes. */
+    totalBytes: z.number().optional(),
+    /** Free memory available in bytes. */
+    freeBytes: z.number().optional(),
+  })
+  .transform(({ totalBytes, freeBytes }) => ({
+    totalBytes: totalBytes ?? 0,
+    freeBytes: freeBytes ?? 0,
+  }));
 /** Memory usage on a Colab runtime. */
 export type Memory = z.infer<typeof MemorySchema>;
 
 /** Information about a GPU on a Colab runtime. */
-export const GpuInfoSchema = z.object({
-  /** The name of the GPU. */
-  name: z.string(),
-  /** Memory used in bytes. */
-  memoryUsedBytes: z.number(),
-  /** Total memory in bytes. */
-  memoryTotalBytes: z.number(),
-  /** GPU utilization as a percentage (0-1). */
-  gpuUtilization: z.number(),
-  /** Memory utilization as a percentage (0-1). */
-  memoryUtilization: z.number(),
-  /** Whether the GPU has ever been used. */
-  everUsed: z.boolean(),
-});
+export const GpuInfoSchema = z
+  .object({
+    /** The name of the GPU. */
+    name: z.string().optional(),
+    /** Memory used in bytes. */
+    memoryUsedBytes: z.number().optional(),
+    /** Total memory in bytes. */
+    memoryTotalBytes: z.number().optional(),
+    /** GPU utilization as a percentage (0-1). */
+    gpuUtilization: z.number().optional(),
+    /** Memory utilization as a percentage (0-1). */
+    memoryUtilization: z.number().optional(),
+    /** Whether the GPU has ever been used. */
+    everUsed: z.boolean().optional(),
+  })
+  .transform(({ memoryUsedBytes, memoryTotalBytes, ...rest }) => ({
+    ...rest,
+    memoryUsedBytes: memoryUsedBytes ?? 0,
+    memoryTotalBytes: memoryTotalBytes ?? 0,
+  }));
 /** GPU information on a Colab runtime. */
 export type GpuInfo = z.infer<typeof GpuInfoSchema>;
 
 /** Information about a filesystem on a Colab runtime. */
 export const FilesystemSchema = z
   .object({
-    /** The name of the filesystem. */
-    name: z.string().optional(),
-    /** The label of the filesystem (legacy). */
+    /** The label of the filesystem. */
     label: z.string().optional(),
     /** Total space on the filesystem in bytes. */
-    totalBytes: z.number(),
-    /** Used space on the filesystem in bytes (legacy). */
+    totalBytes: z.number().optional(),
+    /** Used space on the filesystem in bytes. */
     usedBytes: z.number().optional(),
-    /** Free space on the filesystem in bytes. */
-    freeBytes: z.number().optional(),
   })
-  .transform((val) => ({
-    name: val.name ?? val.label ?? '',
-    totalBytes: val.totalBytes,
-    freeBytes: val.freeBytes ?? val.totalBytes - (val.usedBytes ?? 0),
+  .transform(({ totalBytes, usedBytes, ...rest }) => ({
+    ...rest,
+    totalBytes: totalBytes ?? 0,
+    usedBytes: usedBytes ?? 0,
   }));
 /** A filesystem on a Colab runtime. */
 export type Filesystem = z.infer<typeof FilesystemSchema>;
 
 /** Information about a disk on a Colab runtime. */
-export const DiskSchema = z
-  .object({
-    /** The name of the disk. */
-    name: z.string().optional(),
-    /** Total size of the disk in bytes. */
-    sizeBytes: z.number().optional(),
-    /** The filesystems on the disk. */
-    filesystems: z.array(FilesystemSchema).optional(),
-    /** Legacy representation of a single filesystem. */
-    filesystem: FilesystemSchema.optional(),
-  })
-  .transform((val) => ({
-    name: val.name ?? '',
-    sizeBytes: val.sizeBytes ?? val.filesystem?.totalBytes ?? 0,
-    filesystems: val.filesystems ?? (val.filesystem ? [val.filesystem] : []),
-  }));
+export const DiskSchema = z.object({
+  /** The filesystem on the disk. */
+  filesystem: FilesystemSchema.optional().transform(
+    (filesystem) => filesystem ?? { totalBytes: 0, usedBytes: 0 },
+  ),
+});
 /** A disk on a Colab runtime. */
 export type Disk = z.infer<typeof DiskSchema>;
 
 /** The schema for resources (RAM, disk, etc.) on a Colab runtime. */
 export const ResourcesSchema = z.object({
   /** Memory usage information. */
-  memory: MemorySchema.optional(),
+  memory: MemorySchema.optional().transform(
+    (memory) => memory ?? { totalBytes: 0, freeBytes: 0 },
+  ),
   /** Disk usage information. */
   disks: z.array(DiskSchema),
   /** GPU information. */

--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import { REQUIRED_SCOPES } from '../auth/scopes';
 import { traceMethod } from '../common/logging/decorators';
 import { Session } from '../jupyter/client/generated';
+import { ColabAssignedServer } from '../jupyter/servers';
 import { uuidToWebSafeBase64 } from '../utils/uuid';
 import {
   Assignment,
@@ -44,6 +45,7 @@ import {
   ACCEPT_JSON_HEADER,
   AUTHORIZATION_HEADER,
   COLAB_CLIENT_AGENT_HEADER,
+  COLAB_RUNTIME_PROXY_TOKEN_HEADER,
   COLAB_TUNNEL_HEADER,
   COLAB_VS_CODE_APP_NAME,
   COLAB_VS_CODE_EXTENSION_VERSION,
@@ -302,19 +304,22 @@ export class ColabClient {
   /**
    * Gets the resources (RAM and disk usage) for a given server by its endpoint.
    *
-   * @param endpoint - The assignment endpoint to get resources for.
+   * @param server - The assigned server to get resources for.
    * @param signal - Optional {@link AbortSignal} to cancel the request.
    * @returns The resources information.
    */
   async getResources(
-    endpoint: string,
+    server: ColabAssignedServer,
     signal?: AbortSignal,
   ): Promise<Resources> {
     const url = new URL(
-      `${TUN_ENDPOINT}/${endpoint}/api/colab/resources`,
-      this.colabDomain,
+      'api/colab/resources',
+      server.connectionInformation.baseUrl.toString(),
     );
-    const headers = { [COLAB_TUNNEL_HEADER.key]: COLAB_TUNNEL_HEADER.value };
+    const headers = {
+      [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
+        server.connectionInformation.token,
+    };
 
     return await this.issueRequest(
       url,

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -38,6 +38,7 @@ import {
   ACCEPT_JSON_HEADER,
   AUTHORIZATION_HEADER,
   COLAB_CLIENT_AGENT_HEADER,
+  COLAB_RUNTIME_PROXY_TOKEN_HEADER,
   COLAB_TUNNEL_HEADER,
   COLAB_VS_CODE_APP_NAME,
   COLAB_VS_CODE_EXTENSION_VERSION,
@@ -788,7 +789,7 @@ describe('ColabClient', () => {
       sinon.assert.calledOnce(fetchStub);
     });
 
-    it('successfully gets resources by assignment endpoint', async () => {
+    it('successfully gets resources by server', async () => {
       const mockResources = {
         memory: { totalBytes: 13605834752, freeBytes: 12475244544 },
         disks: [
@@ -799,17 +800,35 @@ describe('ColabClient', () => {
               usedBytes: 22869635072,
             },
           },
+          {
+            filesystem: {
+              // Intentionally empty to test zod transform logic
+            },
+          },
         ],
-        gpus: [],
+        gpus: [
+          {
+            name: 'Tesla T4',
+            memoryUsedBytes: 2869635072,
+            memoryTotalBytes: 13605834752,
+            gpuUtilization: 0.15,
+            memoryUtilization: 0.21,
+            everUsed: true,
+          },
+          {
+            // Intentionally empty to test zod transform logic
+          },
+        ],
       };
       fetchStub
         .withArgs(
           urlMatcher({
             method: 'GET',
-            host: COLAB_HOST,
-            path: `/tun/m/${assignedServer.endpoint}/api/colab/resources`,
+            host: assignedServerUrl.host,
+            path: '/api/colab/resources',
             otherHeaders: {
-              [COLAB_TUNNEL_HEADER.key]: COLAB_TUNNEL_HEADER.value,
+              [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
+                assignedServer.connectionInformation.token,
             },
             withAuthUser: false,
           }),
@@ -820,26 +839,20 @@ describe('ColabClient', () => {
           }),
         );
 
-      const response = await client.getResources(assignedServer.endpoint);
+      const response = await client.getResources(assignedServer);
 
       const expectedResources = {
         memory: mockResources.memory,
         disks: [
+          mockResources.disks[0],
           {
-            name: '',
-            sizeBytes: mockResources.disks[0].filesystem.totalBytes,
-            filesystems: [
-              {
-                name: mockResources.disks[0].filesystem.label,
-                totalBytes: mockResources.disks[0].filesystem.totalBytes,
-                freeBytes:
-                  mockResources.disks[0].filesystem.totalBytes -
-                  mockResources.disks[0].filesystem.usedBytes,
-              },
-            ],
+            filesystem: { totalBytes: 0, usedBytes: 0 },
           },
         ],
-        gpus: [],
+        gpus: [
+          mockResources.gpus[0],
+          { memoryUsedBytes: 0, memoryTotalBytes: 0 },
+        ],
       };
       expect(response).to.deep.equal(expectedResources);
       sinon.assert.calledOnce(fetchStub);


### PR DESCRIPTION
This is the *first* of a series of PRs to implement the resources tree view.

E2E screencast preview can be found [here](https://screencast.googleplex.com/cast/NjQyMjQ5MDQ0MzE1MzQwOHwxNGMyN2FkNC00NA).

---

**Why**?
1. `/api/colab/resources` is an API available on Colab server (like Jupyter REST APIs) instead of TFE. I refactored it to invoke directly via `ColabAssignedServer.connectionInformation` to avoid going through TFE.
2. I found the [`Resources` proto](http://google3/logs/proto/colab/resourcestats.proto) used by this API and aligned our zod schema with it.
3. To be extra safe, I made all fields optional because I can't test all accelerator types possible (many are not available to me) and want to avoid crashing issue like [this](https://github.com/googlecolab/colab-vscode/issues/450). I think it's probably better to display some zeros than throwing errors and not displaying anything.

---

Relevant GitHub issue: https://github.com/googlecolab/colab-vscode/issues/326
Internal tracking bug: b/493678674