### PR TITLE
feat: fallback to available accelerator(s)

### DIFF
--- a/src/colab/client.ts
+++ b/src/colab/client.ts
@@ -180,11 +180,13 @@ export class ColabClient {
    *
    * @param notebookHash - Represents a web-safe base-64 encoded SHA256 digest.
    * This value should always be a string of length 44.
-   * @param params - The assignment parameters {@link AssignParams}
-   * like variant, accelerator, shape and version.
+   * @param params - The assignment parameters {@link AssignParams} like
+   * variant, accelerator, shape and version.
    * @param signal - Optional {@link AbortSignal} to cancel the request.
    * @returns The assignment which is assigned to the user.
    * @throws TooManyAssignmentsError if the user has too many assignments.
+   * @throws AcceleratorUnavailableError if the requested machine accelerator is
+   * unavailable.
    * @throws InsufficientQuotaError if the user lacks the quota to assign.
    * @throws DenylistedError if the user has been banned.
    */
@@ -217,6 +219,15 @@ export class ColabClient {
             error.response.status === 412
           ) {
             throw new TooManyAssignmentsError(error.message);
+          }
+          // Check for no machine availability.
+          if (
+            error instanceof ColabRequestError &&
+            error.response.status === 503
+          ) {
+            throw new AcceleratorUnavailableError(
+              params.accelerator ?? 'default',
+            );
           }
           throw error;
         }
@@ -585,6 +596,18 @@ export class ColabClient {
 
 /** Error thrown when the user has too many assignments. */
 export class TooManyAssignmentsError extends Error {}
+
+/** Error thrown when the requested machine accelerator is unavailable. */
+export class AcceleratorUnavailableError extends Error {
+  /**
+   * Initializes a new instance.
+   *
+   * @param requested - The name of the requested accelerator.
+   */
+  constructor(readonly requested: string) {
+    super(`Requested accelerator "${requested}" is unavailable`);
+  }
+}
 
 /** Error thrown when the user has been denylisted. */
 export class DenylistedError extends Error {}

--- a/src/colab/client.unit.test.ts
+++ b/src/colab/client.unit.test.ts
@@ -28,6 +28,7 @@ import {
   ListedAssignment,
 } from './api';
 import {
+  AcceleratorUnavailableError,
   ColabClient,
   DenylistedError,
   InsufficientQuotaError,
@@ -442,6 +443,29 @@ describe('ColabClient', () => {
         await expect(
           client.assign(NOTEBOOK_HASH, { variant: Variant.DEFAULT }),
         ).to.eventually.be.rejectedWith(TooManyAssignmentsError);
+      });
+
+      it('rejects when accelerator is unavailable', async () => {
+        fetchStub
+          .withArgs(
+            urlMatcher({
+              method: 'POST',
+              host: COLAB_HOST,
+              path: ASSIGN_PATH,
+              queryParams,
+              otherHeaders: {
+                'X-Goog-Colab-Token': 'mock-xsrf-token',
+              },
+            }),
+          )
+          .resolves(new Response(undefined, { status: 503 }));
+
+        await expect(
+          client.assign(NOTEBOOK_HASH, {
+            variant: Variant.GPU,
+            accelerator: 'H100',
+          }),
+        ).to.eventually.be.rejectedWith(AcceleratorUnavailableError, /H100/);
       });
 
       for (const quotaTest of [

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -622,26 +622,26 @@ export class AssignmentManager implements Disposable {
       if (!(error instanceof AcceleratorUnavailableError)) {
         throw error;
       }
+      let newFallback: typeof fallback;
       // The initial attempt failed, start falling back.
       if (!fallback) {
-        const all = await this.getAvailableServerDescriptors();
-        const toAttemptSet = new Set<string>();
+        const all = await this.getAvailableServerDescriptors(signal);
+        const toAttempt = new Set<string>();
         for (const d of all) {
           if (
             d.variant === variant &&
             d.accelerator &&
             d.accelerator !== accelerator
           ) {
-            toAttemptSet.add(d.accelerator);
+            toAttempt.add(d.accelerator);
           }
         }
-        const toAttempt = Array.from(toAttemptSet);
-        fallback = {
-          toAttempt,
+        newFallback = {
+          toAttempt: Array.from(toAttempt),
           attempted: [accelerator],
         };
       } else {
-        fallback = {
+        newFallback = {
           toAttempt: fallback.toAttempt.slice(1),
           attempted: [
             ...fallback.attempted,
@@ -649,16 +649,19 @@ export class AssignmentManager implements Disposable {
           ],
         };
       }
-      if (fallback.toAttempt.length === 0) {
-        throw new AllAcceleratorsUnavailableError(variant, fallback.attempted);
+      if (newFallback.toAttempt.length === 0) {
+        throw new AllAcceleratorsUnavailableError(
+          variant,
+          newFallback.attempted,
+        );
       }
       log.info(
-        `Assignment failed with unavailable accelerator ${accelerator}, retrying with ${fallback.toAttempt[0]}`,
+        `Assignment failed with unavailable accelerator ${accelerator}, retrying with ${newFallback.toAttempt[0]}`,
       );
       return this.assignWithFallback(
         id,
-        { ...descriptor, accelerator: fallback.toAttempt[0] },
-        fallback,
+        { ...descriptor, accelerator: newFallback.toAttempt[0] },
+        newFallback,
         signal,
       );
     }

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -24,6 +24,7 @@ import {
   isHighMemOnlyAccelerator,
 } from '../colab/api';
 import {
+  AcceleratorUnavailableError,
   ColabClient,
   DenylistedError,
   InsufficientQuotaError,
@@ -320,25 +321,33 @@ export class AssignmentManager implements Disposable {
    * @returns The assigned server.
    */
   async assignServer(
-    { label, variant, accelerator, shape, version }: ColabServerDescriptor,
+    descriptor: ColabServerDescriptor,
     signal?: AbortSignal,
   ): Promise<ColabAssignedServer> {
     this.guardDisposed();
     const id = randomUUID();
+    const { label, variant, accelerator, shape, version } = descriptor;
     let assignment: Assignment;
     try {
-      ({ assignment } = await this.client.assign(
-        id,
-        {
-          variant,
-          accelerator,
-          shape,
-          version,
-        },
-        signal,
-      ));
+      if (isColabServerDescriptorWithAccelerator(descriptor)) {
+        assignment = await this.assignWithFallback(
+          id,
+          descriptor,
+          /* fallbacks= */ undefined,
+          signal,
+        );
+      } else {
+        ({ assignment } = await this.client.assign(
+          id,
+          { variant, accelerator, shape, version },
+          signal,
+        ));
+      }
     } catch (error) {
       log.trace(`Failed assigning server ${id}`, error);
+      if (error instanceof AllAcceleratorsUnavailableError) {
+        void this.notifyAllAcceleratorsUnavailable(error);
+      }
       // TODO: Consider listing assignments to check if there are too many
       // before the user goes through the assignment flow. This handling logic
       // would still be needed for the rare race condition where an assignment
@@ -584,6 +593,77 @@ export class AssignmentManager implements Disposable {
     return reconciled;
   }
 
+  private async assignWithFallback(
+    id: UUID,
+    descriptor: ColabServerDescriptorWithAccelerator,
+    fallback?: {
+      toAttempt: string[];
+      attempted: string[];
+    },
+    signal?: AbortSignal,
+  ): Promise<Assignment> {
+    const { variant, accelerator, shape, version } = descriptor;
+    try {
+      const { assignment } = await this.client.assign(
+        id,
+        { variant, accelerator, shape, version },
+        signal,
+      );
+      const original = fallback?.attempted
+        ? fallback.attempted[0]
+        : accelerator;
+      if (original !== accelerator) {
+        void this.vs.window.showInformationMessage(
+          `Requested accelerator "${original}" is unavailable, assigned "${accelerator}"`,
+        );
+      }
+      return assignment;
+    } catch (error) {
+      if (!(error instanceof AcceleratorUnavailableError)) {
+        throw error;
+      }
+      // The initial attempt failed, start falling back.
+      if (!fallback) {
+        const all = await this.getAvailableServerDescriptors();
+        const toAttemptSet = new Set<string>();
+        for (const d of all) {
+          if (
+            d.variant === variant &&
+            d.accelerator &&
+            d.accelerator !== accelerator
+          ) {
+            toAttemptSet.add(d.accelerator);
+          }
+        }
+        const toAttempt = Array.from(toAttemptSet);
+        fallback = {
+          toAttempt,
+          attempted: [accelerator],
+        };
+      } else {
+        fallback = {
+          toAttempt: fallback.toAttempt.slice(1),
+          attempted: [
+            ...fallback.attempted,
+            fallback.toAttempt[0], // The one that just failed.
+          ],
+        };
+      }
+      if (fallback.toAttempt.length === 0) {
+        throw new AllAcceleratorsUnavailableError(variant, fallback.attempted);
+      }
+      log.info(
+        `Assignment failed with unavailable accelerator ${accelerator}, retrying with ${fallback.toAttempt[0]}`,
+      );
+      return this.assignWithFallback(
+        id,
+        { ...descriptor, accelerator: fallback.toAttempt[0] },
+        fallback,
+        signal,
+      );
+    }
+  }
+
   private toAssignedServer(
     server: ColabJupyterServer,
     endpoint: string,
@@ -620,6 +700,14 @@ export class AssignmentManager implements Disposable {
         WebSocket: colabProxyWebSocket(this.vs, this.client, colabServer),
       },
     };
+  }
+
+  private async notifyAllAcceleratorsUnavailable(
+    error: AllAcceleratorsUnavailableError,
+  ) {
+    void (await this.vs.window.showErrorMessage(
+      `Unable to assign server. ${error.message}`,
+    ));
   }
 
   private async notifyMaxAssignmentsExceeded() {
@@ -694,6 +782,17 @@ const LEARN_MORE = 'Learn More';
 
 const UNKNOWN_REMOTE_SERVER_NAME = 'Untitled';
 
+class AllAcceleratorsUnavailableError extends Error {
+  constructor(
+    variant: string,
+    readonly attempted: string[],
+  ) {
+    const l = attempted.join(', ');
+    const msg = `All ${variant} accelerators are unavailable: ${l}`;
+    super(msg);
+  }
+}
+
 /**
  * Creates a fetch function that adds the Colab runtime proxy token as a header.
  *
@@ -734,4 +833,14 @@ function colabProxyFetch(
 
 function isRequest(info: RequestInfo): info is Request {
   return typeof info !== 'string' && !('href' in info);
+}
+
+type ColabServerDescriptorWithAccelerator = ColabServerDescriptor & {
+  accelerator: string;
+};
+
+function isColabServerDescriptorWithAccelerator(
+  descriptor: ColabServerDescriptor,
+): descriptor is ColabServerDescriptorWithAccelerator {
+  return !!descriptor.accelerator;
 }

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -24,6 +24,7 @@ import {
   InsufficientQuotaError,
   NotFoundError,
   TooManyAssignmentsError,
+  AcceleratorUnavailableError,
 } from '../colab/client';
 import { REMOVE_SERVER } from '../colab/commands/constants';
 import {
@@ -1011,6 +1012,101 @@ describe('AssignmentManager', () => {
         sinon.assert.calledOnceWithMatch(
           vsCodeStub.window.showErrorMessage as sinon.SinonStub,
           /Unable to assign .* 👨‍⚖️/,
+        );
+      });
+    });
+
+    describe('with an accelerator that is unavailable', () => {
+      beforeEach(() => {
+        colabClientStub.getUserInfo.resolves({
+          subscriptionTier: SubscriptionTier.PRO,
+          paidComputeUnitsBalance: 1,
+          eligibleAccelerators: [
+            { variant: Variant.GPU, models: ['T4', 'V100', 'A100', 'H100'] },
+          ],
+          ineligibleAccelerators: [],
+        });
+
+        colabClientStub.assign
+          .withArgs(sinon.match(isUUID), {
+            variant: Variant.GPU,
+            accelerator: 'A100',
+            shape: undefined,
+            version: undefined,
+          })
+          .rejects(new AcceleratorUnavailableError('A100'));
+      });
+
+      it('falls back to the next available accelerator', async () => {
+        colabClientStub.assign
+          .withArgs(sinon.match(isUUID), {
+            variant: Variant.GPU,
+            accelerator: 'T4',
+            shape: undefined,
+            version: undefined,
+          })
+          .resolves({
+            assignment: { ...defaultAssignment, accelerator: 'T4' },
+            isNew: false,
+          });
+
+        const result = await assignmentManager.assignServer({
+          label: 'Colab GPU A100',
+          variant: Variant.GPU,
+          accelerator: 'A100',
+        });
+
+        expect(result.accelerator).to.equal('T4');
+        sinon.assert.calledWithMatch(
+          vsCodeStub.window.showInformationMessage as sinon.SinonStub,
+          /Requested accelerator "A100" is unavailable, assigned "T4"/,
+        );
+      });
+
+      it('falls back multiple times to the next available accelerator', async () => {
+        colabClientStub.assign
+          .withArgs(
+            sinon.match(isUUID),
+            sinon.match({
+              accelerator: sinon.match.in(['A100', 'T4', 'V100']),
+            }),
+          )
+          .rejects(new AcceleratorUnavailableError('A100'))
+          .withArgs(sinon.match(isUUID), sinon.match({ accelerator: 'H100' }))
+          .resolves({
+            assignment: { ...defaultAssignment, accelerator: 'H100' },
+            isNew: false,
+          });
+
+        const result = await assignmentManager.assignServer({
+          label: 'Colab GPU A100',
+          variant: Variant.GPU,
+          accelerator: 'A100',
+        });
+
+        expect(result.accelerator).to.equal('H100');
+        sinon.assert.calledWithMatch(
+          vsCodeStub.window.showInformationMessage as sinon.SinonStub,
+          /Requested accelerator "A100" is unavailable, assigned "H100"/,
+        );
+      });
+
+      it('throws an error if all fallbacks fail', async () => {
+        colabClientStub.assign.rejects(new AcceleratorUnavailableError('any'));
+
+        await expect(
+          assignmentManager.assignServer({
+            label: 'Colab GPU A100',
+            variant: Variant.GPU,
+            accelerator: 'A100',
+          }),
+        ).to.be.rejectedWith(
+          /All GPU accelerators are unavailable: A100, T4, V100/,
+        );
+
+        sinon.assert.calledWithMatch(
+          vsCodeStub.window.showErrorMessage as sinon.SinonStub,
+          /Unable to assign server. All GPU accelerators are unavailable: A100, T4, V100/,
         );
       });
     });


### PR DESCRIPTION
https://github.com/googlecolab/colab-vscode/issues/502

This mirrors Colab (web) behaviour; when the requested accelerator is unavailable, fallback to one that is.

Admittedly, this leaves the UI in a bit of a weird, seemingly "hanging" state, where the kernel selector is just spinning as we wait a while for the server and fallback (up to a minute per accelerator). We should consider popping a progress notification on assignment, or at least calls that take over `n` seconds? I'd prefer to get this functional fix in before enriching the UX with something like that.

<img width="2131" height="1046" alt="image" src="https://github.com/user-attachments/assets/876d5dad-e9dc-4ff1-be01-4666c9b669cb" />