### PR TITLE
feat: add e2e test for import notebook from drive feature

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -3,6 +3,7 @@ authuser
 autorestarting
 chromedriver
 colab
+consentsummary
 dryrun
 ephem
 extest

--- a/src/test/e2e/auth.ts
+++ b/src/test/e2e/auth.ts
@@ -22,28 +22,7 @@ export async function doOAuthSignIn(
   oAuthUrl: string,
   expectedRedirectUrl: string,
 ): Promise<void> {
-  await chromeDriver.get(oAuthUrl);
-
-  // Input the test account email address.
-  const emailInput = await chromeDriver.findElement(
-    By.css("input[type='email']"),
-  );
-  await emailInput.clear();
-  await emailInput.sendKeys(process.env.TEST_ACCOUNT_EMAIL ?? '');
-  await emailInput.sendKeys(Key.ENTER);
-
-  // Input the test account password. Note that we wait for the page to
-  // settle to avoid getting a stale element reference.
-  await chromeDriver.wait(
-    until.urlContains('accounts.google.com/v3/signin/challenge'),
-    ELEMENT_WAIT_MS,
-  );
-  await chromeDriver.sleep(1000);
-  const passwordInput = await chromeDriver.findElement(
-    By.css("input[type='password']"),
-  );
-  await passwordInput.sendKeys(process.env.TEST_ACCOUNT_PASSWORD ?? '');
-  await passwordInput.sendKeys(Key.ENTER);
+  await login(chromeDriver, oAuthUrl);
 
   // Click Continue to sign in to Colab.
   await chromeDriver.wait(
@@ -73,6 +52,38 @@ export async function doOAuthSignIn(
 }
 
 /**
+ * Performs the OAuth sign-in flow for the Colab extension.
+ *
+ * @param chromeDriver - The Chrome driver.
+ * @param oAuthUrl - The OAuth url.
+ * @param expectedRedirectUrl - The expected redirect url.
+ */
+export async function doIncrementalOAuthSignIn(
+  chromeDriver: WebDriver,
+  oAuthUrl: string,
+  expectedRedirectUrl: string,
+): Promise<void> {
+  await login(chromeDriver, oAuthUrl);
+
+  await chromeDriver.wait(
+    until.urlContains('accounts.google.com/signin/oauth/v2/consentsummary'),
+    ELEMENT_WAIT_MS,
+  );
+  // Click Continue to sign in to Colab.
+  await safeClick(
+    chromeDriver,
+    By.xpath("//span[text()='Continue']"),
+    '"Continue" button not visible on ID screen',
+  );
+
+  // Check that the test account's authenticated.
+  await chromeDriver.wait(
+    until.urlContains(expectedRedirectUrl),
+    ELEMENT_WAIT_MS,
+  );
+}
+
+/**
  * Creates a new Chrome WebDriver instance for the OAuth flow.
  *
  * @returns The Chrome WebDriver instance.
@@ -88,4 +99,29 @@ export function getOAuthDriver(): Promise<WebDriver> {
       new chrome.Options().addArguments(...authDriverArgs) as chrome.Options,
     )
     .build();
+}
+
+async function login(chromeDriver: WebDriver, oAuthUrl: string) {
+  await chromeDriver.get(oAuthUrl);
+
+  // Input the test account email address.
+  const emailInput = await chromeDriver.findElement(
+    By.css("input[type='email']"),
+  );
+  await emailInput.clear();
+  await emailInput.sendKeys(process.env.TEST_ACCOUNT_EMAIL ?? '');
+  await emailInput.sendKeys(Key.ENTER);
+
+  // Input the test account password. Note that we wait for the page to
+  // settle to avoid getting a stale element reference.
+  await chromeDriver.wait(
+    until.urlContains('accounts.google.com/v3/signin/challenge'),
+    ELEMENT_WAIT_MS,
+  );
+  await chromeDriver.sleep(1000);
+  const passwordInput = await chromeDriver.findElement(
+    By.css("input[type='password']"),
+  );
+  await passwordInput.sendKeys(process.env.TEST_ACCOUNT_PASSWORD ?? '');
+  await passwordInput.sendKeys(Key.ENTER);
 }

--- a/src/test/e2e/import-notebook.e2e.test.ts
+++ b/src/test/e2e/import-notebook.e2e.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import clipboard from 'clipboardy';
+import {
+  Workbench,
+  InputBox,
+  TextEditor,
+  VSBrowser,
+} from 'vscode-extension-tester';
+import { doIncrementalOAuthSignIn, getOAuthDriver } from './auth';
+import { pushDialogButton } from './ui';
+
+// Owned by the colab test account, anyone with a link should have read access
+const NOTEBOOK_URL =
+  'https://colab.research.google.com/drive/1wkAcggP4rr0zkEXupVfOSwNE62jciQ_J';
+
+it('imports a notebook from a URL', async () => {
+  const workbench = new Workbench();
+  const driver = workbench.getDriver();
+
+  await workbench.executeCommand('Colab: Import notebook file from URL');
+
+  // Get URL
+  const urlInputBox = await InputBox.create();
+  await urlInputBox.setText(NOTEBOOK_URL);
+  await urlInputBox.confirm();
+
+  // Sign in.
+  await pushDialogButton(driver, 'Allow');
+  await pushDialogButton(driver, 'Copy');
+  await authorizeDrive();
+
+  // Pick save location
+  const saveInputBox = await InputBox.create();
+  const existingFileName = await saveInputBox.getText();
+  const targetDirectory = path.resolve(__dirname, '..', 'test-output-folder');
+  const finalSavePath = path.join(targetDirectory, existingFileName);
+  // Clean up the file if it already exists from a previous run
+  if (fs.existsSync(finalSavePath)) {
+    fs.unlinkSync(finalSavePath);
+  }
+  await saveInputBox.setText(finalSavePath);
+  await saveInputBox.confirm();
+
+  // Wait some time to allow the file to be opened
+  await driver.sleep(5000);
+
+  // Grab the currently active text editor
+  const editor = new TextEditor();
+  // Verify the file name by checking the tab title
+  const activeTabTitle = await editor.getTitle();
+  assert.strictEqual(
+    activeTabTitle,
+    existingFileName.slice(1),
+    `Verification failed: Expected active tab to be '${existingFileName}', but found '${activeTabTitle}'`,
+  );
+});
+
+async function authorizeDrive() {
+  const chromeDriver = await getOAuthDriver();
+  try {
+    await doIncrementalOAuthSignIn(
+      chromeDriver,
+      /* oauthUrl= */ clipboard.readSync(),
+      /* expectedRedirectUrl= */ 'vscode/auth-success',
+    );
+  } catch (err: unknown) {
+    const screenshotsDir = VSBrowser.instance.getScreenshotsDir();
+    fs.writeFileSync(
+      `${screenshotsDir}/import-drive-notebook-chrome.png`,
+      await chromeDriver.takeScreenshot(),
+      'base64',
+    );
+    throw err;
+  }
+}

--- a/src/test/e2e/import-notebook.e2e.test.ts
+++ b/src/test/e2e/import-notebook.e2e.test.ts
@@ -73,8 +73,11 @@ async function authorizeDrive() {
     );
   } catch (err: unknown) {
     const screenshotsDir = VSBrowser.instance.getScreenshotsDir();
+    if (!fs.existsSync(screenshotsDir)) {
+      fs.mkdirSync(screenshotsDir, { recursive: true });
+    }
     fs.writeFileSync(
-      `${screenshotsDir}/import-drive-notebook-chrome.png`,
+      path.join(screenshotsDir, 'import-drive-notebook-chrome.png'),
       await chromeDriver.takeScreenshot(),
       'base64',
     );

--- a/src/test/e2e/settings.json
+++ b/src/test/e2e/settings.json
@@ -12,5 +12,6 @@
   "workbench.editor.enablePreview": false,
   "workbench.auxiliaryBar.visible": false,
   "extensions.ignoreRecommendations": true,
-  "chat.disableAIFeatures": true
+  "chat.disableAIFeatures": true,
+  "files.simpleDialog.enable": true
 }


### PR DESCRIPTION
This will require adding the scope `drive.file` to the production client i.e. without that the E2E test will fail with the below error. 
<img width="945" height="921" alt="import-drive-notebook-chrome" src="https://github.com/user-attachments/assets/1a95dc56-8e2d-4a9e-9838-c735fa81f62a" />
