### PR TITLE
fix: join colab: URI paths with POSIX separators on Windows

### DIFF
--- a/src/colab/commands/files.ts
+++ b/src/colab/commands/files.ts
@@ -8,7 +8,7 @@ import vscode, { QuickPickItem } from 'vscode';
 import { log } from '../../common/logging';
 import { AssignmentManager } from '../../jupyter/assignments';
 import { ColabAssignedServer } from '../../jupyter/servers';
-import { buildColabFileUri } from '../files';
+import { buildColabFileUri, joinUriPath } from '../files';
 import { UPLOAD } from './constants';
 
 /**
@@ -149,8 +149,8 @@ async function buildUploadPlan(
       for (const [name] of entries) {
         try {
           await planUploadsRecursively(
-            vs.Uri.joinPath(source, name),
-            vs.Uri.joinPath(dest, name),
+            joinUriPath(source, name),
+            joinUriPath(dest, name),
             operations,
           );
         } catch (err) {
@@ -169,7 +169,7 @@ async function buildUploadPlan(
       failCount++;
       continue;
     }
-    const destUri = vs.Uri.joinPath(serverRootUri, itemName);
+    const destUri = joinUriPath(serverRootUri, itemName);
     try {
       await planUploadsRecursively(inputUri, destUri, operations);
     } catch (err) {

--- a/src/colab/content-browser/commands.ts
+++ b/src/colab/content-browser/commands.ts
@@ -5,6 +5,7 @@
  */
 
 import vscode, { Uri } from 'vscode';
+import { joinUriPath } from '../files';
 import type { ContentItem } from './content-item';
 
 /**
@@ -27,7 +28,7 @@ export async function newFile(vs: typeof vscode, contextItem: ContentItem) {
   if (!name) {
     return;
   }
-  const uri = vs.Uri.joinPath(destination, name);
+  const uri = joinUriPath(destination, name);
   const isFolder = name.endsWith('/');
   try {
     if (isFolder) {
@@ -63,7 +64,7 @@ export async function newFolder(vs: typeof vscode, contextItem: ContentItem) {
   if (!name) {
     return;
   }
-  const uri = vs.Uri.joinPath(destination, name);
+  const uri = joinUriPath(destination, name);
   try {
     await vs.workspace.fs.createDirectory(uri);
   } catch (err: unknown) {
@@ -124,7 +125,7 @@ export async function download(vs: typeof vscode, contextItem: ContentItem) {
 // TODO: Look into preserving expanded state of renamed folders.
 export async function renameFile(vs: typeof vscode, contextItem: ContentItem) {
   const oldName = contextItem.uri.path.split('/').pop() ?? '';
-  const destination = vs.Uri.joinPath(contextItem.uri, '..');
+  const destination = joinUriPath(contextItem.uri, '..');
 
   const newName = await vs.window.showInputBox({
     title: 'Rename',
@@ -142,7 +143,7 @@ export async function renameFile(vs: typeof vscode, contextItem: ContentItem) {
     return;
   }
 
-  const newUri = vs.Uri.joinPath(destination, newName);
+  const newUri = joinUriPath(destination, newName);
   try {
     await vs.workspace.fs.rename(contextItem.uri, newUri, { overwrite: false });
   } catch (err: unknown) {
@@ -189,7 +190,7 @@ async function validateFileOrFolder(
     return error;
   }
   try {
-    await vs.workspace.fs.stat(vs.Uri.joinPath(destination, name));
+    await vs.workspace.fs.stat(joinUriPath(destination, name));
     return 'A file or folder with this name already exists';
   } catch {
     return undefined;
@@ -207,8 +208,8 @@ function validateName(value: string): string | undefined {
   return undefined;
 }
 
-function folderOrParent(vs: typeof vscode, item: ContentItem): Uri {
+function folderOrParent(_vs: typeof vscode, item: ContentItem): Uri {
   return item.contextValue === 'file'
-    ? vs.Uri.joinPath(item.uri, '..')
+    ? joinUriPath(item.uri, '..')
     : item.uri;
 }

--- a/src/colab/content-browser/commands.ts
+++ b/src/colab/content-browser/commands.ts
@@ -209,7 +209,5 @@ function validateName(value: string): string | undefined {
 }
 
 function folderOrParent(_vs: typeof vscode, item: ContentItem): Uri {
-  return item.contextValue === 'file'
-    ? joinUriPath(item.uri, '..')
-    : item.uri;
+  return item.contextValue === 'file' ? joinUriPath(item.uri, '..') : item.uri;
 }

--- a/src/colab/content-browser/content-tree.ts
+++ b/src/colab/content-browser/content-tree.ts
@@ -22,6 +22,7 @@ import {
   AssignmentChangeEvent,
   AssignmentManager,
 } from '../../jupyter/assignments';
+import { joinUriPath } from '../files';
 import { ContentItem } from './content-item';
 
 /**
@@ -189,7 +190,7 @@ export class ContentTreeProvider
       });
 
       return entries.map(([name, type]) => {
-        const itemUri = Uri.joinPath(uri, name);
+        const itemUri = joinUriPath(uri, name);
         const uriString = itemUri.toString();
         const existing = this.contentItemsByUri.get(uriString);
         if (existing?.type === type) {
@@ -229,5 +230,5 @@ function getParent(uri: Uri): Uri | undefined {
   if (uri.path === '/') {
     return undefined;
   }
-  return Uri.joinPath(uri, '..');
+  return joinUriPath(uri, '..');
 }

--- a/src/colab/files.ts
+++ b/src/colab/files.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import vscode, { Uri } from 'vscode';
+import { posix } from 'path';
+import type vscode from 'vscode';
+import type { Uri } from 'vscode';
 import { ColabAssignedServer } from '../jupyter/servers';
 
 /**
@@ -21,7 +23,7 @@ export function buildColabFileUri(
   server: ColabAssignedServer,
   filePath = '',
 ): Uri {
-  return vs.Uri.joinPath(
+  return joinUriPath(
     vs.Uri.from({
       scheme: 'colab',
       authority: server.endpoint,
@@ -29,4 +31,21 @@ export function buildColabFileUri(
     }),
     filePath,
   );
+}
+
+/**
+ * Joins path segments onto a URI, preserving POSIX-style separators for Colab
+ * URIs across platforms.
+ *
+ * @param uri - The base URI.
+ * @param pathSegments - The path segments to join.
+ * @returns The updated URI.
+ */
+export function joinUriPath(uri: Uri, ...pathSegments: string[]): Uri {
+  const normalizedSegments = pathSegments.map((segment) =>
+    segment.replaceAll('\\', '/'),
+  );
+  return uri.with({
+    path: posix.join(uri.path, ...normalizedSegments),
+  });
 }

--- a/src/colab/files.unit.test.ts
+++ b/src/colab/files.unit.test.ts
@@ -10,7 +10,7 @@ import { describe } from 'mocha';
 import { TestUri } from '../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
 import { Variant } from './api';
-import { buildColabFileUri } from './files';
+import { buildColabFileUri, joinUriPath } from './files';
 
 const DEFAULT_SERVER = {
   id: randomUUID(),
@@ -55,6 +55,47 @@ describe('files', () => {
           'foo/../bar.txt',
         ).toString(),
       ).to.equal('colab://m-s-foo/bar.txt');
+    });
+  });
+
+  describe('joinUriPath', () => {
+    let vs: VsCodeStub;
+
+    beforeEach(() => {
+      vs = newVsCodeStub();
+    });
+
+    it('joins path segments with forward slashes for colab URIs', () => {
+      const base = vs.Uri.from({
+        scheme: 'colab',
+        authority: 'm-s-foo',
+        path: '/content',
+      });
+      expect(joinUriPath(base, 'a', 'b').toString()).to.equal(
+        'colab://m-s-foo/content/a/b',
+      );
+    });
+
+    it('normalizes backslashes in segments to forward slashes', () => {
+      const base = vs.Uri.from({
+        scheme: 'colab',
+        authority: 'm-s-foo',
+        path: '/content',
+      });
+      expect(joinUriPath(base, 'subdir\\nested\\file.txt').toString()).to.equal(
+        'colab://m-s-foo/content/subdir/nested/file.txt',
+      );
+    });
+
+    it('joins a parent segment consistently with posix paths', () => {
+      const base = vs.Uri.from({
+        scheme: 'colab',
+        authority: 'm-s-foo',
+        path: '/content/item',
+      });
+      expect(joinUriPath(base, '..').toString()).to.equal(
+        'colab://m-s-foo/content',
+      );
     });
   });
 });

--- a/src/jupyter/contents/file-system.ts
+++ b/src/jupyter/contents/file-system.ts
@@ -16,7 +16,7 @@ import vscode, {
   Uri,
   WorkspaceFoldersChangeEvent,
 } from 'vscode';
-import { buildColabFileUri } from '../../colab/files';
+import { buildColabFileUri, joinUriPath } from '../../colab/files';
 import { log } from '../../common/logging';
 import { traceMethod } from '../../common/logging/decorators';
 import {
@@ -461,7 +461,7 @@ export class ContentsFileSystemProvider
         // If children exist, recursively delete all children first.
         for (const child of children) {
           const childName = child[0];
-          const childUri = this.vs.Uri.joinPath(uri, childName);
+          const childUri = joinUriPath(uri, childName);
           await this.deleteInternal(childUri, options);
         }
       }


### PR DESCRIPTION
# fix: join `colab:` URI paths with POSIX separators on Windows

## Summary

Adds `joinUriPath()` in `src/colab/files.ts` and uses **`path.posix.join`** with `uri.with({ path })` instead of `vscode.Uri.joinPath()` for Colab-related URIs. `Uri.joinPath()` follows OS path rules and can insert **backslashes** on Windows; `colab:` paths must use **forward slashes** or uploads, the content browser, tree items, and the mounted Jupyter contents provider break (including unit tests on Windows).

## Problem

- `Uri.joinPath()` is **platform-dependent**.
- On Windows, `uri.path` can contain backslashes (e.g. `colab://endpoint\content\file.txt` instead of `colab://endpoint/content/file.txt`).
- That breaks comparisons, Jupyter path usage, and tests that expect `/`-separated paths.

## Solution

- **`joinUriPath(uri, ...segments)`** — normalizes `\` → `/` per segment, then `path.posix.join(uri.path, ...segments)`, returns `uri.with({ path })`.
- **`buildColabFileUri()`** — uses `joinUriPath` for relative paths.
- **Updated call sites:** `src/colab/commands/files.ts`, `src/colab/content-browser/commands.ts`, `src/colab/content-browser/content-tree.ts`, `src/jupyter/contents/file-system.ts`.
- **Unchanged:** `Uri.joinPath` for normal workspace / `file:` URIs (e.g. `src/drive/commands/import.ts`).

## Tests

- `src/colab/files.unit.test.ts` — `joinUriPath` (join, backslash normalization, `..`).
- Full unit suite passes locally.

## Verification (local)

`npm run build`, `npm run lint`, `npm run typecheck`, `npm run test:unit`.

CI (`format:check`, spell check, etc.) is authoritative on Linux.

## Note for reviewers

Please sanity check that new or changed `colab:` paths in these flows use **only `/`** in `.path`. This PR only changes URI path construction, not the Colab or Jupyter APIs.
