### PR TITLE
fix: event when server isn't found when resolving

### DIFF
--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -16,7 +16,7 @@ import { CancellationToken, Disposable, Event, ProviderResult } from 'vscode';
 import vscode from 'vscode';
 import { AuthChangeEvent } from '../auth/auth-provider';
 import { SubscriptionTier } from '../colab/api';
-import { ColabClient } from '../colab/client';
+import { ColabClient, NotFoundError } from '../colab/client';
 import {
   AUTO_CONNECT,
   Command,
@@ -136,14 +136,22 @@ export class ColabJupyterServerProvider
    */
   @traceMethod
   @trackErrors
-  resolveJupyterServer(
+  async resolveJupyterServer(
     server: JupyterServer,
     _token: CancellationToken,
-  ): ProviderResult<JupyterServer> {
+  ): Promise<JupyterServer> {
     if (!isUUID(server.id)) {
       throw new Error('Unexpected server ID format, expected UUID');
     }
-    return this.assignmentManager.refreshConnection(server.id);
+    try {
+      return await this.assignmentManager.refreshConnection(server.id);
+    } catch (e: unknown) {
+      if (e instanceof NotFoundError) {
+        this.serverChangeEmitter.fire();
+        return server;
+      }
+      throw e;
+    }
   }
 
   /**

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -17,7 +17,7 @@ import * as sinon from 'sinon';
 import { CancellationToken, CancellationTokenSource } from 'vscode';
 import { AuthChangeEvent } from '../auth/auth-provider';
 import { SubscriptionTier, Variant } from '../colab/api';
-import { ColabClient } from '../colab/client';
+import { ColabClient, NotFoundError } from '../colab/client';
 import {
   AUTO_CONNECT,
   NEW_SERVER,
@@ -252,12 +252,12 @@ describe('ColabJupyterServerProvider', () => {
   });
 
   describe('resolveJupyterServer', () => {
-    it('throws when the server ID is not a UUID', () => {
+    it('throws when the server ID is not a UUID', async () => {
       const server = { ...DEFAULT_SERVER, id: 'not-a-uuid' };
 
-      expect(() =>
+      await expect(
         serverProvider.resolveJupyterServer(server, cancellationToken),
-      ).to.throw(/expected UUID/);
+      ).to.eventually.be.rejectedWith(/expected UUID/);
     });
 
     it('returns the assigned server with refreshed connection info', async () => {
@@ -279,6 +279,32 @@ describe('ColabJupyterServerProvider', () => {
       await expect(
         serverProvider.resolveJupyterServer(DEFAULT_SERVER, cancellationToken),
       ).to.eventually.deep.equal(refreshedServer);
+    });
+
+    it('fires onDidChangeServers and returns the server as-is when NotFoundError is thrown', async () => {
+      assignmentStub.refreshConnection
+        .withArgs(DEFAULT_SERVER.id)
+        .rejects(new NotFoundError('Server is not assigned'));
+      const listener = sinon.stub();
+      serverProvider.onDidChangeServers(listener);
+
+      const result = await serverProvider.resolveJupyterServer(
+        DEFAULT_SERVER,
+        cancellationToken,
+      );
+
+      expect(result).to.deep.equal(DEFAULT_SERVER);
+      sinon.assert.calledOnce(listener);
+    });
+
+    it('rethrows non-NotFoundError errors', async () => {
+      assignmentStub.refreshConnection
+        .withArgs(DEFAULT_SERVER.id)
+        .rejects(new Error('some other error'));
+
+      await expect(
+        serverProvider.resolveJupyterServer(DEFAULT_SERVER, cancellationToken),
+      ).to.eventually.be.rejectedWith('some other error');
     });
   });
 


### PR DESCRIPTION
Made `resolveJupyterServer` `async` and added a try/catch when `refreshConnection` throws a `NotFoundError`, the method fires `onDidChangeServers` (to notify the Jupyter extension that the server list has changed) and returns the original server as-is (per the Jupyter API contract: _It is OK to return the given server_). Other errors are re-thrown.