### PR TITLE
refactor: increase "Connect to Google Drive" dialog wait timeout in Mount Drive E2E test

### DIFF
--- a/src/test/e2e/mount-drive.e2e.test.ts
+++ b/src/test/e2e/mount-drive.e2e.test.ts
@@ -17,7 +17,7 @@ import {
   selectQuickPicksInOrder,
 } from './ui';
 
-const CONNECT_DRIVE_WAIT_MS = 20000;
+const CONNECT_DRIVE_DIALOG_WAIT_MS = 20000;
 
 it('mounts Google Drive', async () => {
   const workbench = new Workbench();
@@ -48,7 +48,7 @@ it('mounts Google Drive', async () => {
   await pushDialogButton(
     driver,
     'Connect to Google Drive',
-    CONNECT_DRIVE_WAIT_MS,
+    CONNECT_DRIVE_DIALOG_WAIT_MS,
   );
   // Begin the sign-in process by copying the OAuth URL to the clipboard and
   // opening it in a browser window. Why do this instead of triggering the

--- a/src/test/e2e/mount-drive.e2e.test.ts
+++ b/src/test/e2e/mount-drive.e2e.test.ts
@@ -17,6 +17,8 @@ import {
   selectQuickPicksInOrder,
 } from './ui';
 
+const CONNECT_DRIVE_WAIT_MS = 20000;
+
 it('mounts Google Drive', async () => {
   const workbench = new Workbench();
   const driver = workbench.getDriver();
@@ -43,7 +45,11 @@ it('mounts Google Drive', async () => {
   // Kick-off Drive mounting.
   await workbench.executeCommand('Colab: Mount Google Drive to Server...');
   await workbench.executeCommand('Notebook: Run All');
-  await pushDialogButton(driver, 'Connect to Google Drive');
+  await pushDialogButton(
+    driver,
+    'Connect to Google Drive',
+    CONNECT_DRIVE_WAIT_MS,
+  );
   // Begin the sign-in process by copying the OAuth URL to the clipboard and
   // opening it in a browser window. Why do this instead of triggering the
   // "Open" button in the dialog? We copy the URL so that we can use a new


### PR DESCRIPTION
**Why**? Based on my observations, majority of the Mount Drive E2E test failures were due to `TimeoutError: Could not select "Connect to Google Drive" from dialog`. Increasing this timeout from 10 to 20s to reduce the test flakiness.