### PR TITLE
test: use POSIX join semantics in TestUri.joinPath

### DIFF
--- a/src/test/helpers/uri.ts
+++ b/src/test/helpers/uri.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable jsdoc/require-jsdoc */
 
-import { join } from 'path';
+import { join } from 'path/posix';
 import * as sinon from 'sinon';
 import { Uri } from 'vscode';
 
@@ -45,10 +45,13 @@ export class TestUri implements Uri {
 
   static joinPath(base: TestUri, ...pathSegments: string[]): TestUri {
     const { path: p, ...rest } = base;
+    const normalizedSegments = pathSegments.map((segment) =>
+      segment.replaceAll('\\', '/'),
+    );
     return new this(
       rest.scheme,
       rest.authority,
-      join(p, ...pathSegments),
+      join(p, ...normalizedSegments),
       rest.query,
       rest.fragment,
     );

--- a/src/test/helpers/uri.unit.test.ts
+++ b/src/test/helpers/uri.unit.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { TestUri } from './uri';
+
+describe('TestUri', () => {
+  describe('joinPath', () => {
+    it('uses forward slashes for URI paths', () => {
+      const base = TestUri.parse('colab://m-s-foo/content');
+
+      expect(TestUri.joinPath(base, 'foo', 'bar.txt').toString()).to.equal(
+        'colab://m-s-foo/content/foo/bar.txt',
+      );
+    });
+
+    it('normalizes backslashes in segments', () => {
+      const base = TestUri.parse('colab://m-s-foo/content');
+
+      expect(
+        TestUri.joinPath(base, 'nested\\child\\file.txt').toString(),
+      ).to.equal('colab://m-s-foo/content/nested/child/file.txt');
+    });
+
+    it('preserves parent traversal with POSIX semantics', () => {
+      const base = TestUri.parse('colab://m-s-foo/content/folder');
+
+      expect(TestUri.joinPath(base, '..', 'other.txt').toString()).to.equal(
+        'colab://m-s-foo/content/other.txt',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- update `TestUri.joinPath()` to use `path/posix` join semantics instead of OS path semantics
- normalize `\` to `/` in path segments before joining
- add focused regression tests for forward-slash joining, backslash normalization, and `..` traversal

## Context

This change is intentionally limited to the test helper and tests.

It aligns `src/test/helpers/uri.ts` with URI/POSIX path behavior and mirrors what `vscode-uri` does. It does not make any runtime/product behavior claim.

## Verification

- `npm run test:unit`
