### PR TITLE
fix: preserve Request headers in colabProxyFetch

### DIFF
--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -828,14 +828,14 @@ function colabProxyFetch(
       info = new Request(info.url, info);
     }
 
-    init ??= {};
-    const headers = new Headers(init.headers);
-    headers.append(COLAB_RUNTIME_PROXY_TOKEN_HEADER.key, token);
-    headers.append(
+    const headers = new Headers(isRequest(info) ? info.headers : undefined);
+    new Headers(init?.headers).forEach((value, key) => headers.set(key, value));
+    headers.set(COLAB_RUNTIME_PROXY_TOKEN_HEADER.key, token);
+    headers.set(
       COLAB_CLIENT_AGENT_HEADER.key,
       COLAB_CLIENT_AGENT_HEADER.value,
     );
-    init.headers = headers;
+    init = { ...init, headers };
 
     return fetch(info, init);
   };

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -815,7 +815,10 @@ class AllAcceleratorsUnavailableError extends Error {
  * To work around this, we create a new `Request` instance to ensure
  * compatibility.
  *
- * @param token - The cancellation token.
+ * Colab proxy headers always win over any caller-supplied values for the
+ * same keys.
+ *
+ * @param token - The Colab runtime proxy token.
  * @returns A fetch function that adds the Colab runtime proxy token as a
  * header.
  */

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -823,18 +823,19 @@ function colabProxyFetch(
   token: string,
 ): (info: RequestInfo, init?: RequestInit) => Promise<Response> {
   return async (info: RequestInfo, init?: RequestInit) => {
+    let infoHeaders: Headers | undefined;
     if (isRequest(info)) {
       // Ensure compatibility with `node-fetch`
       info = new Request(info.url, info);
+      infoHeaders = info.headers;
     }
 
-    const headers = new Headers(isRequest(info) ? info.headers : undefined);
-    new Headers(init?.headers).forEach((value, key) => headers.set(key, value));
+    const headers = new Headers(infoHeaders);
+    new Headers(init?.headers).forEach((value, key) => {
+      headers.set(key, value);
+    });
     headers.set(COLAB_RUNTIME_PROXY_TOKEN_HEADER.key, token);
-    headers.set(
-      COLAB_CLIENT_AGENT_HEADER.key,
-      COLAB_CLIENT_AGENT_HEADER.value,
-    );
+    headers.set(COLAB_CLIENT_AGENT_HEADER.key, COLAB_CLIENT_AGENT_HEADER.value);
     init = { ...init, headers };
 
     return fetch(info, init);

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -601,6 +601,40 @@ describe('AssignmentManager', () => {
           );
         });
 
+        it('overrides caller-supplied Colab proxy headers', async () => {
+          const servers = await assignmentManager.getServers('extension');
+          assert.lengthOf(servers, 1);
+          const server = servers[0];
+          assert.isDefined(server.connectionInformation.fetch);
+          const fetchStub = sinon.stub(fetch, 'default');
+          const request = new Request('https://example.com', {
+            headers: {
+              [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: 'spoofed-request-token',
+              [COLAB_CLIENT_AGENT_HEADER.key]: 'spoofed-request-agent',
+            },
+          });
+
+          await server.connectionInformation.fetch(request, {
+            headers: {
+              [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: 'spoofed-init-token',
+              [COLAB_CLIENT_AGENT_HEADER.key]: 'spoofed-init-agent',
+            },
+          });
+
+          sinon.assert.calledOnceWithMatch(
+            fetchStub,
+            sinon.match.instanceOf(Request),
+            {
+              headers: new Headers({
+                [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
+                  server.connectionInformation.token,
+                [COLAB_CLIENT_AGENT_HEADER.key]:
+                  COLAB_CLIENT_AGENT_HEADER.value,
+              }),
+            },
+          );
+        });
+
         it('includes a custom WebSocket implementation', async () => {
           const servers = await assignmentManager.getServers('extension');
           assert.lengthOf(servers, 1);

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -549,15 +549,55 @@ describe('AssignmentManager', () => {
 
           await server.connectionInformation.fetch(request);
 
-          sinon.assert.calledOnce(fetchStub);
-          const headers = fetchStub.firstCall.args[1]?.headers as Headers;
-          expect(headers.get('Accept')).to.equal('application/json');
-          expect(headers.get('X-Test')).to.equal('existing-value');
-          expect(headers.get(COLAB_RUNTIME_PROXY_TOKEN_HEADER.key)).to.equal(
-            server.connectionInformation.token,
+          sinon.assert.calledOnceWithMatch(
+            fetchStub,
+            sinon.match.instanceOf(Request),
+            {
+              headers: new Headers({
+                Accept: 'application/json',
+                'X-Test': 'existing-value',
+                [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
+                  server.connectionInformation.token,
+                [COLAB_CLIENT_AGENT_HEADER.key]:
+                  COLAB_CLIENT_AGENT_HEADER.value,
+              }),
+            },
           );
-          expect(headers.get(COLAB_CLIENT_AGENT_HEADER.key)).to.equal(
-            COLAB_CLIENT_AGENT_HEADER.value,
+        });
+
+        it('allows init headers to override request headers', async () => {
+          const servers = await assignmentManager.getServers('extension');
+          assert.lengthOf(servers, 1);
+          const server = servers[0];
+          assert.isDefined(server.connectionInformation.fetch);
+          const fetchStub = sinon.stub(fetch, 'default');
+          const request = new Request('https://example.com', {
+            headers: {
+              Accept: 'text/plain',
+              'X-Test': 'request-value',
+            },
+          });
+
+          await server.connectionInformation.fetch(request, {
+            headers: {
+              Accept: 'application/json',
+              'X-Test': 'init-value',
+            },
+          });
+
+          sinon.assert.calledOnceWithMatch(
+            fetchStub,
+            sinon.match.instanceOf(Request),
+            {
+              headers: new Headers({
+                Accept: 'application/json',
+                'X-Test': 'init-value',
+                [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
+                  server.connectionInformation.token,
+                [COLAB_CLIENT_AGENT_HEADER.key]:
+                  COLAB_CLIENT_AGENT_HEADER.value,
+              }),
+            },
           );
         });
 

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -6,7 +6,7 @@
 
 import { randomUUID } from 'crypto';
 import { assert, expect } from 'chai';
-import fetch, { Headers } from 'node-fetch';
+import fetch, { Headers, Request } from 'node-fetch';
 import sinon, { SinonFakeTimers, SinonStubbedInstance } from 'sinon';
 import { MessageItem, Uri } from 'vscode';
 import {
@@ -532,6 +532,33 @@ describe('AssignmentManager', () => {
               [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
             }),
           });
+        });
+
+        it('preserves request headers when wrapping a Request object', async () => {
+          const servers = await assignmentManager.getServers('extension');
+          assert.lengthOf(servers, 1);
+          const server = servers[0];
+          assert.isDefined(server.connectionInformation.fetch);
+          const fetchStub = sinon.stub(fetch, 'default');
+          const request = new Request('https://example.com', {
+            headers: {
+              Accept: 'application/json',
+              'X-Test': 'existing-value',
+            },
+          });
+
+          await server.connectionInformation.fetch(request);
+
+          sinon.assert.calledOnce(fetchStub);
+          const headers = fetchStub.firstCall.args[1]?.headers as Headers;
+          expect(headers.get('Accept')).to.equal('application/json');
+          expect(headers.get('X-Test')).to.equal('existing-value');
+          expect(headers.get(COLAB_RUNTIME_PROXY_TOKEN_HEADER.key)).to.equal(
+            server.connectionInformation.token,
+          );
+          expect(headers.get(COLAB_CLIENT_AGENT_HEADER.key)).to.equal(
+            COLAB_CLIENT_AGENT_HEADER.value,
+          );
         });
 
         it('includes a custom WebSocket implementation', async () => {


### PR DESCRIPTION
## Summary                                                                                                             
                                                                                                                         
  Fix `colabProxyFetch(...)` so it preserves headers already present on a passed `Request` object before injecting the   
  Colab proxy headers.

  Previously, when the caller passed a `Request`, the wrapper rebuilt headers from `init.headers` only. That dropped any 
  headers already attached to the original request.

  ## What changed

  - Merge existing `Request` headers into the outgoing header set
  - Overlay any headers from `init.headers`
  - Continue setting:
    - `X-Colab-Runtime-Proxy-Token`
    - `X-Colab-Client-Agent`

  ## Why this matters

  Some Jupyter/client code paths may pass a preconstructed `Request` with important headers already attached. Dropping   
  them can cause subtle request failures or behavior changes that are hard to trace.

  ## Tests

  Added a regression test that verifies a wrapped `Request` keeps its original headers (`Accept` and a custom test       
  header) while still receiving the required Colab proxy headers.

  ## Files

  - `src/jupyter/assignments.ts`
  - `src/jupyter/assignments.unit.test.ts`