### PR TITLE
fix: revoke managed connections when assignment removals are mixed

### DIFF
--- a/src/jupyter/contents/sessions.ts
+++ b/src/jupyter/contents/sessions.ts
@@ -235,16 +235,18 @@ export class JupyterConnectionManager implements Disposable {
     if (!endpoints.length) {
       return;
     }
+    const revoked: string[] = [];
     for (const endpoint of endpoints) {
       const promise = this.connections.get(endpoint);
       if (!promise) {
-        return;
+        continue;
       }
       bestEffortDisposeConnection(promise);
       this.connections.delete(endpoint);
+      revoked.push(endpoint);
     }
-    if (!silent) {
-      this.revokeConnectionEmitter.fire(endpoints);
+    if (!silent && revoked.length) {
+      this.revokeConnectionEmitter.fire(revoked);
     }
   }
 }

--- a/src/jupyter/contents/sessions.unit.test.ts
+++ b/src/jupyter/contents/sessions.unit.test.ts
@@ -320,6 +320,28 @@ describe('JupyterConnectionManager', () => {
       await expect(manager.get(DEFAULT_SERVER.endpoint)).to.eventually.not.be
         .undefined;
     });
+
+    it('revokes managed connections even when unrelated removals are included first', async () => {
+      const otherServer = { ...DEFAULT_SERVER, endpoint: 'other' };
+      // Cast needed due to overload.
+      (assignmentManager.getServers as sinon.SinonStub).resolves([
+        DEFAULT_SERVER,
+      ]);
+      await manager.getOrCreate(DEFAULT_SERVER.endpoint);
+
+      assignmentEmitter.fire({
+        added: [],
+        changed: [],
+        removed: [
+          { server: otherServer, userInitiated: true },
+          { server: DEFAULT_SERVER, userInitiated: true },
+        ],
+      });
+
+      sinon.assert.calledOnceWithExactly(listener, [DEFAULT_SERVER.endpoint]);
+      await expect(manager.get(DEFAULT_SERVER.endpoint)).to.eventually.be
+        .undefined;
+    });
   });
 
   describe('get', () => {


### PR DESCRIPTION
## Summary                                                                                                             
                                                                                                                         
  Fix `JupyterConnectionManager.revoke(...)` so a mixed assignment-removal batch does not stop revocation early when some
  removed endpoints do not have a managed local connection.                                                              
                                                                                                                         
  Previously, the method returned immediately on the first missing endpoint. If a later endpoint in the same batch did   
  have a managed connection, it would never be revoked.

  ## What changed

  - Replace the early `return` with `continue` when a removed endpoint is not present in the local connection map        
  - Track which endpoints were actually revoked
  - Emit `onDidRevokeConnections` only for endpoints that were actually revoked

  ## Why this matters

  Assignment change events can include a mix of:
  - endpoints managed by this connection manager
  - unrelated endpoints with no local connection

  The old behavior made revocation order-dependent and could leave stale managed connections alive.

  ## Tests

  Added a regression test covering this case:
  - an unrelated removed endpoint appears first
  - a managed endpoint appears later in the same removal batch
  - the managed connection is still revoked

  ## Files

  - `src/jupyter/contents/sessions.ts`
  - `src/jupyter/contents/sessions.unit.test.ts`