### PR TITLE
test: fix e2e test by disabling new welcome page

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,6 +5,7 @@
 .vscode-test.mjs
 .vscode-test/
 .vscode/
+.worktrees
 cspell.config.yaml
 docs/
 esbuild.config.mts

--- a/src/test/e2e/settings.json
+++ b/src/test/e2e/settings.json
@@ -1,16 +1,17 @@
 {
+  "chat.disableAIFeatures": true,
   "colab.logging.level": "trace",
-  "jupyter.logging.level": "debug",
-  "telemetry.telemetryLevel": "off",
-  "update.mode": "off",
-  "workbench.startupEditor": "none",
-  "workbench.welcomePage.enabled": false,
   "extensions.autoCheckUpdates": false,
   "extensions.autoUpdate": false,
+  "extensions.ignoreRecommendations": true,
+  "jupyter.logging.level": "debug",
   "security.workspace.trust.enabled": false,
+  "telemetry.telemetryLevel": "off",
+  "update.mode": "none",
   "window.restoreWindows": "none",
   "workbench.editor.enablePreview": false,
-  "workbench.auxiliaryBar.visible": false,
-  "extensions.ignoreRecommendations": true,
-  "chat.disableAIFeatures": true
+  "workbench.startupEditor": "none",
+  "workbench.welcomePage.enabled": false,
+  "workbench.welcomePage.experimentalOnboarding": false,
+  "workbench.welcomePage.walkthroughs.openOnInstall": false
 }


### PR DESCRIPTION
The VS Code update shipped today ([1.116](https://code.visualstudio.com/updates/v1_116)) introduces a new "experimental" welcome page which is enabled by default. Naturally, our e2e tests don't have logic to move past it. This disables it. I'm sure there'll be another similar change needed in the future unless it replaces `"workbench.welcomePage.enabled"`.

This change also:

- sorts the settings
- fixes a few invalid or unnecessary settings
- ignores `.worktrees/`, the folder I use for repo worktrees. Not _needed_ but makes local devex better.