### PR TITLE
chore: turn on `colab.activityBarResourceView` feature by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,12 +76,12 @@
         "colab.activityBarContentView": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Enables the Colab activity bar where you can view servers and interact with their `/content` directories."
+          "markdownDescription": "Enables the content view in the Colab activity bar where you can view servers and interact with their `/content` directories."
         },
         "colab.activityBarResourceView": {
           "type": "boolean",
           "default": true,
-          "description": "Enables the Colab activity bar where you can monitor server resources (RAM and disk usage)."
+          "description": "Enables the resource view in the Colab activity bar where you can monitor server resources (RAM and disk usage)."
         },
         "colab.serverMounting": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -80,11 +80,8 @@
         },
         "colab.activityBarResourceView": {
           "type": "boolean",
-          "default": false,
-          "description": "Enables the Colab activity bar where you can monitor server resources (RAM and disk usage).",
-          "tags": [
-            "experimental"
-          ]
+          "default": true,
+          "description": "Enables the Colab activity bar where you can monitor server resources (RAM and disk usage)."
         },
         "colab.serverMounting": {
           "type": "boolean",

--- a/src/test/e2e/settings.json
+++ b/src/test/e2e/settings.json
@@ -1,5 +1,6 @@
 {
   "chat.disableAIFeatures": true,
+  "colab.activityBarResourceView": true,
   "colab.logging.level": "trace",
   "extensions.autoCheckUpdates": false,
   "extensions.autoUpdate": false,

--- a/src/test/e2e/settings.json
+++ b/src/test/e2e/settings.json
@@ -1,6 +1,5 @@
 {
   "chat.disableAIFeatures": true,
-  "colab.activityBarResourceView": true,
   "colab.logging.level": "trace",
   "extensions.autoCheckUpdates": false,
   "extensions.autoUpdate": false,


### PR DESCRIPTION
With `colab.activityBarResourceView` feature initially released in `v0.5.0` and e2e test coverage in https://github.com/googlecolab/colab-vscode/pull/557, we can now turn on this feature by default and also remove the "experimental" tag.