### PR TITLE
build: bump version to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.7.5",
+      "version": "0.8.0",
       "dependencies": {
         "@jupyterlab/services": "^7.5.3",
         "glob": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
Changes since last bump:

- fix: several moderate and high vulnerabilities (#563)
- chore: turn on `colab.activityBarResourceView` feature by default (#562)
- test: resource tree view e2e (#557)
- build(deps-dev): bump follow-redirects from 1.15.11 to 1.16.0 (#560)
- fix: revoke managed connections when assignment removals are mixed (#559)
- test: fix e2e test by disabling new welcome page (#561)
- test: use POSIX join semantics in TestUri.joinPath (#556)
- refactor: increase "Connect to Google Drive" dialog wait timeout in Mount Drive E2E test (#555)
- refactor: `ExperimentStateProvider` to use `SequentialTaskRunner` (#540)