### PR TITLE
refactor: increase OAuth sign-in screen wait timeout

### DIFF
--- a/src/test/e2e/auth.ts
+++ b/src/test/e2e/auth.ts
@@ -9,6 +9,7 @@ import { Builder, By, Key, WebDriver, until } from 'vscode-extension-tester';
 import { safeClick } from './ui';
 
 const ELEMENT_WAIT_MS = 10000;
+const SIGN_IN_SCREEN_WAIT_MS = 20000;
 
 /**
  * Performs the OAuth sign-in flow for the Colab extension.
@@ -48,7 +49,7 @@ export async function doOAuthSignIn(
   // Click Continue to sign in to Colab.
   await chromeDriver.wait(
     until.urlContains('accounts.google.com/signin/oauth/id'),
-    ELEMENT_WAIT_MS,
+    SIGN_IN_SCREEN_WAIT_MS,
   );
   await safeClick(
     chromeDriver,


### PR DESCRIPTION
**Why**? I noticed that sometimes (not often), E2E tests fail due to `TimeoutError: Waiting for URL to contain "accounts.google.com/signin/oauth/id"`. All E2E tests are currently prone to this flakiness and even more for `mount_drive` test because it runs OAuth twice (one for Colab and one for Drive auth). Hence increasing this timeout to wait for OAuth sign-in screen from 10 to 20s to reduce overall test flakiness.