### PR TITLE
refactor: split extension.ts activation into per-feature modules

### DIFF
--- a/src/auth/module.ts
+++ b/src/auth/module.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OAuth2Client } from 'google-auth-library';
+import vscode, { Disposable, ExtensionContext } from 'vscode';
+import { CONFIG } from '../colab-config';
+import { PackageInfo } from '../config/package-info';
+import { GoogleAuthProvider } from './auth-provider';
+import { getOAuth2Flows } from './flows/flows';
+import { login, LoginOptions } from './login';
+import { AuthStorage } from './storage';
+
+/** The result of activating the auth module. */
+export interface AuthModule {
+  /** The {@link GoogleAuthProvider} for downstream wiring. */
+  readonly authProvider: GoogleAuthProvider;
+  /** Disposables that should be pushed into `context.subscriptions`. */
+  readonly disposables: Disposable[];
+}
+
+/**
+ * Builds the {@link GoogleAuthProvider} and its supporting OAuth2 flow
+ * components. The returned `disposables` should be pushed into
+ * `context.subscriptions`.
+ *
+ * @param vs - The VS Code API instance.
+ * @param context - The extension context (for `secrets` access).
+ * @param packageInfo - Information about the installed extension.
+ * @returns The auth provider and its associated disposables.
+ */
+export function createAuthModule(
+  vs: typeof vscode,
+  context: ExtensionContext,
+  packageInfo: PackageInfo,
+): AuthModule {
+  const authClient = new OAuth2Client(
+    CONFIG.ClientId,
+    CONFIG.ClientNotSoSecret,
+  );
+  const authFlows = getOAuth2Flows(vs, packageInfo, authClient);
+  const authProvider = new GoogleAuthProvider(
+    vs,
+    new AuthStorage(context.secrets),
+    authClient,
+    (scopes: string[], options?: LoginOptions) =>
+      login(vs, authFlows, authClient, scopes, options),
+  );
+  const flowsDisposable: Disposable = {
+    dispose: () => {
+      for (const flow of authFlows) {
+        flow.dispose?.();
+      }
+    },
+  };
+  return {
+    authProvider,
+    disposables: [flowsDisposable, authProvider],
+  };
+}

--- a/src/auth/module.unit.test.ts
+++ b/src/auth/module.unit.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import type { ExtensionContext, SecretStorage } from 'vscode';
+import { PackageInfo } from '../config/package-info';
+import { newVsCodeStub } from '../test/helpers/vscode';
+import { createAuthModule } from './module';
+
+describe('createAuthModule', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  function fakeContext(): ExtensionContext {
+    return {
+      secrets: {
+        get: sinon.stub().resolves(undefined),
+        store: sinon.stub().resolves(),
+        delete: sinon.stub().resolves(),
+        onDidChange: sinon.stub(),
+      } as Partial<SecretStorage> as SecretStorage,
+    } as Partial<ExtensionContext> as ExtensionContext;
+  }
+
+  const packageInfo: PackageInfo = {
+    publisher: 'google',
+    name: 'colab',
+    version: '0.0.1-test',
+  };
+
+  it('returns an auth provider and disposables', () => {
+    const vs = newVsCodeStub();
+    const result = createAuthModule(vs.asVsCode(), fakeContext(), packageInfo);
+
+    expect(result.authProvider).to.exist;
+    expect(result.disposables).to.be.an('array').with.length.greaterThan(0);
+  });
+});

--- a/src/colab/commands/register.ts
+++ b/src/colab/commands/register.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vscode, { Disposable } from 'vscode';
+import { GoogleAuthProvider } from '../../auth/auth-provider';
+import { registerCommand } from '../../common/commands';
+import { AssignmentManager } from '../../jupyter/assignments';
+import { ContentsFileSystemProvider } from '../../jupyter/contents/file-system';
+import { telemetry } from '../../telemetry';
+import { CommandSource } from '../../telemetry/api';
+import {
+  COLAB_TOOLBAR,
+  MOUNT_DRIVE,
+  MOUNT_SERVER,
+  OPEN_TERMINAL,
+  REMOVE_SERVER,
+  SIGN_OUT,
+  UPLOAD,
+} from './constants';
+import { upload } from './files';
+import { appendCodeCell, notebookToolbar } from './notebook';
+import { mountServer, removeServer } from './server';
+import { openTerminal } from './terminal';
+
+/** Dependencies required to register the core Colab commands. */
+export interface ColabCommandDeps {
+  /** Used by the sign-out command. */
+  readonly authProvider: GoogleAuthProvider;
+  /** Used by mount/remove/upload/toolbar/terminal commands. */
+  readonly assignmentManager: AssignmentManager;
+  /** Used by the mount-server command to access remote files. */
+  readonly fs: ContentsFileSystemProvider;
+}
+
+/**
+ * Registers the core Colab commands (sign-out, mount, remove, upload, etc.).
+ *
+ * @param vs - The VS Code API instance.
+ * @param deps - The services the command handlers need.
+ * @returns The disposables for each registered command.
+ */
+export function registerColabCommands(
+  vs: typeof vscode,
+  deps: ColabCommandDeps,
+): Disposable[] {
+  const { authProvider, assignmentManager, fs } = deps;
+  return [
+    registerCommand(vs, SIGN_OUT.id, async () => {
+      await authProvider.signOut();
+    }),
+    // TODO: Register the rename server alias command once rename is reflected
+    // in the recent kernels list. See
+    // https://github.com/microsoft/vscode-jupyter/issues/17107.
+    registerCommand(
+      vs,
+      MOUNT_SERVER.id,
+      async (source?: CommandSource, withBackButton?: boolean) => {
+        await mountServer(
+          vs,
+          assignmentManager,
+          fs,
+          source ?? CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
+          withBackButton,
+        );
+      },
+    ),
+    registerCommand(vs, MOUNT_DRIVE.id, async (source?: CommandSource) => {
+      telemetry.logMountDriveSnippet(
+        source ?? CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
+      );
+      await appendCodeCell(
+        vs,
+        [
+          'from google.colab import drive',
+          `drive.mount('/content/drive')`,
+        ].join('\n'),
+        'python',
+      );
+    }),
+    registerCommand(
+      vs,
+      REMOVE_SERVER.id,
+      async (source?: CommandSource, withBackButton?: boolean) => {
+        await removeServer(vs, assignmentManager, withBackButton, source);
+      },
+    ),
+    registerCommand(
+      vs,
+      UPLOAD.id,
+      async (uri: vscode.Uri, uris?: vscode.Uri[]) => {
+        await upload(vs, assignmentManager, uri, uris);
+      },
+    ),
+    registerCommand(vs, COLAB_TOOLBAR.id, async () => {
+      await notebookToolbar(vs, assignmentManager);
+    }),
+    registerCommand(vs, OPEN_TERMINAL.id, async (withBackButton?: boolean) => {
+      await openTerminal(vs, assignmentManager, withBackButton);
+    }),
+  ];
+}

--- a/src/colab/commands/register.unit.test.ts
+++ b/src/colab/commands/register.unit.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { GoogleAuthProvider } from '../../auth/auth-provider';
+import { AssignmentManager } from '../../jupyter/assignments';
+import { ContentsFileSystemProvider } from '../../jupyter/contents/file-system';
+import { newVsCodeStub } from '../../test/helpers/vscode';
+import {
+  COLAB_TOOLBAR,
+  MOUNT_DRIVE,
+  MOUNT_SERVER,
+  OPEN_TERMINAL,
+  REMOVE_SERVER,
+  SIGN_OUT,
+  UPLOAD,
+} from './constants';
+import { registerColabCommands } from './register';
+
+describe('registerColabCommands', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('registers all expected colab command IDs', () => {
+    const vs = newVsCodeStub();
+    vs.commands.registerCommand.callsFake(() => ({ dispose: sinon.stub() }));
+    const authProvider = sinon.createStubInstance(GoogleAuthProvider);
+    const assignmentManager = sinon.createStubInstance(AssignmentManager);
+    const fs = sinon.createStubInstance(ContentsFileSystemProvider);
+
+    const disposables = registerColabCommands(vs.asVsCode(), {
+      authProvider,
+      assignmentManager,
+      fs,
+    });
+
+    const registeredIds = vs.commands.registerCommand
+      .getCalls()
+      .map((call) => call.args[0]);
+    expect(registeredIds).to.have.members([
+      SIGN_OUT.id,
+      MOUNT_SERVER.id,
+      MOUNT_DRIVE.id,
+      REMOVE_SERVER.id,
+      UPLOAD.id,
+      COLAB_TOOLBAR.id,
+      OPEN_TERMINAL.id,
+    ]);
+    expect(disposables).to.have.lengthOf(registeredIds.length);
+  });
+});

--- a/src/colab/content-browser/register.ts
+++ b/src/colab/content-browser/register.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vscode, { Disposable } from 'vscode';
+import { registerCommand } from '../../common/commands';
+import { ResourceTreeProvider } from '../resource-monitor/resource-tree';
+import {
+  deleteFile,
+  download,
+  newFile,
+  newFolder,
+  renameFile,
+} from './commands';
+import { ContentItem } from './content-item';
+import { ContentTreeProvider } from './content-tree';
+
+/** Dependencies required to register content-browser commands. */
+export interface ContentBrowserCommandDeps {
+  /** Used by the refresh-content-view command. */
+  readonly contentTree: ContentTreeProvider;
+  /** Used by the refresh-resource-view command. */
+  readonly resourceTree: ResourceTreeProvider;
+}
+
+/**
+ * Registers the content-browser tree view commands (refresh views and the
+ * file CRUD commands).
+ *
+ * @param vs - The VS Code API instance.
+ * @param deps - The tree providers the commands operate on.
+ * @returns The disposables for each registered command.
+ */
+export function registerContentBrowserCommands(
+  vs: typeof vscode,
+  deps: ContentBrowserCommandDeps,
+): Disposable[] {
+  const { contentTree, resourceTree } = deps;
+  return [
+    registerCommand(vs, 'colab.refreshServerContentView', () => {
+      contentTree.refresh();
+    }),
+    registerCommand(vs, 'colab.refreshServerResourceView', () => {
+      resourceTree.refresh();
+    }),
+    registerCommand(vs, 'colab.newFile', (item: ContentItem) => {
+      void newFile(vs, item);
+    }),
+    registerCommand(vs, 'colab.newFolder', (item: ContentItem) => {
+      void newFolder(vs, item);
+    }),
+    registerCommand(vs, 'colab.download', (item: ContentItem) => {
+      void download(vs, item);
+    }),
+    registerCommand(vs, 'colab.renameFile', (item: ContentItem) => {
+      void renameFile(vs, item);
+    }),
+    registerCommand(vs, 'colab.deleteFile', (item: ContentItem) => {
+      void deleteFile(vs, item);
+    }),
+  ];
+}

--- a/src/colab/content-browser/register.unit.test.ts
+++ b/src/colab/content-browser/register.unit.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { newVsCodeStub } from '../../test/helpers/vscode';
+// These providers extend VS Code value classes (TreeItem-shaped trees), so
+// importing them here as values would pull `require('vscode')` into the
+// unit-test bundle (and fail at load time per AGENTS.md). Type-only imports
+// keep them out of the runtime; the deps below are minimal structural fakes.
+import type { ResourceTreeProvider } from '../resource-monitor/resource-tree';
+import type { ContentTreeProvider } from './content-tree';
+import { registerContentBrowserCommands } from './register';
+
+describe('registerContentBrowserCommands', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('registers all expected content browser command IDs', () => {
+    const vs = newVsCodeStub();
+    vs.commands.registerCommand.callsFake(() => ({ dispose: sinon.stub() }));
+    const contentTree = {
+      refresh: sinon.stub(),
+    } as Partial<ContentTreeProvider> as ContentTreeProvider;
+    const resourceTree = {
+      refresh: sinon.stub(),
+    } as Partial<ResourceTreeProvider> as ResourceTreeProvider;
+
+    const disposables = registerContentBrowserCommands(vs.asVsCode(), {
+      contentTree,
+      resourceTree,
+    });
+
+    const registeredIds = vs.commands.registerCommand
+      .getCalls()
+      .map((call) => call.args[0]);
+    expect(registeredIds).to.have.members([
+      'colab.refreshServerContentView',
+      'colab.refreshServerResourceView',
+      'colab.newFile',
+      'colab.newFolder',
+      'colab.download',
+      'colab.renameFile',
+      'colab.deleteFile',
+    ]);
+    expect(disposables).to.have.lengthOf(registeredIds.length);
+  });
+});

--- a/src/colab/module.ts
+++ b/src/colab/module.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vscode, { Disposable } from 'vscode';
+import { GoogleAuthProvider } from '../auth/auth-provider';
+import { REQUIRED_SCOPES } from '../auth/scopes';
+import { CONFIG } from '../colab-config';
+import { Toggleable } from '../common/toggleable';
+import { PackageInfo } from '../config/package-info';
+import { AssignmentManager } from '../jupyter/assignments';
+import { ColabClient } from './client';
+import { ConsumptionNotifier } from './consumption/notifier';
+import { ConsumptionPoller } from './consumption/poller';
+import { ConsumptionStatusBar } from './consumption/status-bar';
+import { ExperimentStateProvider } from './experiment-state';
+
+/**
+ * Builds the {@link ColabClient} bound to the user's auth state.
+ *
+ * @param vs - The VS Code API instance.
+ * @param authProvider - For token retrieval and sign-out on auth failure.
+ * @param packageInfo - Used to set the user-agent on Colab requests.
+ * @returns The constructed Colab client.
+ */
+export function createColabClient(
+  vs: typeof vscode,
+  authProvider: GoogleAuthProvider,
+  packageInfo: PackageInfo,
+): ColabClient {
+  return ColabClient.create(
+    new URL(CONFIG.ColabApiDomain),
+    new URL(CONFIG.ColabGapiDomain),
+    { appName: vs.env.appName, extensionVersion: packageInfo.version },
+    () =>
+      GoogleAuthProvider.getOrCreateSession(vs, REQUIRED_SCOPES).then(
+        (session) => session.accessToken,
+      ),
+    () => authProvider.signOut(),
+  );
+}
+
+/** The result of activating the Colab module's background services. */
+export interface ColabModule {
+  /** Disposables that should be pushed into `context.subscriptions`. */
+  readonly disposables: Disposable[];
+  /** Auth-gated toggles that should be passed to `whileAuthorized`. */
+  readonly toggles: Toggleable[];
+}
+
+/**
+ * Builds the Colab background services that depend on both the Colab client
+ * and the assignment manager: consumption polling/notifier/status bar and the
+ * experiment state provider.
+ *
+ * @param vs - The VS Code API instance.
+ * @param colab - The Colab client used by consumption polling and experiments.
+ * @param assignmentManager - Source of assignment-change events used to
+ * trigger consumption polls.
+ * @returns The disposables and auth-gated toggles produced.
+ */
+export function createColabModule(
+  vs: typeof vscode,
+  colab: ColabClient,
+  assignmentManager: AssignmentManager,
+): ColabModule {
+  const poller = new ConsumptionPoller(
+    vs,
+    colab,
+    assignmentManager.onDidAssignmentsChange,
+  );
+  const notifier = new ConsumptionNotifier(vs, poller.onDidChangeCcuInfo);
+  const statusBar = new ConsumptionStatusBar(vs, poller.onDidChangeCcuInfo);
+  const experimentStateProvider = new ExperimentStateProvider(colab);
+  return {
+    disposables: [poller, notifier, statusBar, experimentStateProvider],
+    toggles: [poller, statusBar, experimentStateProvider],
+  };
+}

--- a/src/colab/module.unit.test.ts
+++ b/src/colab/module.unit.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import type { StatusBarItem } from 'vscode';
+import { GoogleAuthProvider } from '../auth/auth-provider';
+import { AssignmentManager } from '../jupyter/assignments';
+import {
+  newVsCodeStub,
+  StatusBarAlignment,
+  VsCodeStub,
+} from '../test/helpers/vscode';
+import { ColabClient } from './client';
+import { ConsumptionPoller } from './consumption/poller';
+import { ConsumptionStatusBar } from './consumption/status-bar';
+import { ExperimentStateProvider } from './experiment-state';
+import { createColabClient, createColabModule } from './module';
+
+function stubStatusBarItem(vs: VsCodeStub): StatusBarItem {
+  const item: StatusBarItem = {
+    id: 'colab.consumptionStatusBar',
+    alignment: StatusBarAlignment.Right,
+    priority: undefined,
+    name: undefined,
+    text: '',
+    tooltip: undefined,
+    color: undefined,
+    backgroundColor: undefined,
+    command: undefined,
+    accessibilityInformation: undefined,
+    show: sinon.stub(),
+    hide: sinon.stub(),
+    dispose: sinon.stub(),
+  };
+  vs.window.createStatusBarItem.returns(item);
+  return item;
+}
+
+describe('createColabClient', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('returns a ColabClient', () => {
+    const vs = newVsCodeStub();
+    const authProvider = sinon.createStubInstance(GoogleAuthProvider);
+
+    const colabClient = createColabClient(vs.asVsCode(), authProvider, {
+      publisher: 'google',
+      name: 'colab',
+      version: '0.0.1-test',
+    });
+
+    expect(colabClient).to.exist;
+  });
+});
+
+describe('createColabModule', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  function stubAssignmentManager(
+    vs: VsCodeStub,
+  ): sinon.SinonStubbedInstance<AssignmentManager> {
+    const stub = sinon.createStubInstance(AssignmentManager);
+    // `onDidAssignmentsChange` is a constructor-set property, not a method,
+    // so createStubInstance leaves it undefined; install a real Event so
+    // the consumption poller's listener subscription does not blow up.
+    Object.defineProperty(stub, 'onDidAssignmentsChange', {
+      value: new vs.EventEmitter<unknown>().event,
+    });
+    return stub;
+  }
+
+  it('returns disposables and toggles', () => {
+    const vs = newVsCodeStub();
+    stubStatusBarItem(vs);
+    const colabClient = sinon.createStubInstance(ColabClient);
+
+    const result = createColabModule(
+      vs.asVsCode(),
+      colabClient,
+      stubAssignmentManager(vs),
+    );
+
+    expect(result.disposables).to.be.an('array').with.length.greaterThan(0);
+    expect(result.toggles).to.be.an('array').with.length.greaterThan(0);
+  });
+
+  it('exposes the experiment state provider as a toggle', () => {
+    const vs = newVsCodeStub();
+    stubStatusBarItem(vs);
+    const colabClient = sinon.createStubInstance(ColabClient);
+
+    const result = createColabModule(
+      vs.asVsCode(),
+      colabClient,
+      stubAssignmentManager(vs),
+    );
+
+    // Toggles are the auth-gated background services. The notifier is *not*
+    // gated; silencing the poller is enough to stop notifications.
+    expect(result.toggles).to.have.lengthOf(3);
+    expect(
+      result.toggles.some((t) => t instanceof ConsumptionPoller),
+      'expected a ConsumptionPoller toggle',
+    ).to.be.true;
+    expect(
+      result.toggles.some((t) => t instanceof ConsumptionStatusBar),
+      'expected a ConsumptionStatusBar toggle',
+    ).to.be.true;
+    expect(
+      result.toggles.some((t) => t instanceof ExperimentStateProvider),
+      'expected an ExperimentStateProvider toggle',
+    ).to.be.true;
+  });
+});

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vscode, { Disposable } from 'vscode';
+import { withErrorTracking } from '../telemetry/decorators';
+
+/**
+ * Registers a VS Code command whose handler is wrapped with error tracking.
+ *
+ * @param vs - The VS Code API instance.
+ * @param command - The unique identifier for the command.
+ * @param handler - A command handler function.
+ * @returns A disposable which deregisters the command on disposal.
+ */
+export function registerCommand<
+  T extends (...args: Parameters<T>) => ReturnType<T>,
+>(vs: typeof vscode, command: string, handler: T): Disposable {
+  return vs.commands.registerCommand(command, withErrorTracking(handler));
+}

--- a/src/common/commands.unit.test.ts
+++ b/src/common/commands.unit.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { newVsCodeStub } from '../test/helpers/vscode';
+import { registerCommand } from './commands';
+
+describe('registerCommand', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('registers the command with vscode.commands.registerCommand', () => {
+    const vs = newVsCodeStub();
+    const disposable = { dispose: sinon.stub() };
+    vs.commands.registerCommand.returns(disposable);
+    const handler = sinon.stub();
+
+    const result = registerCommand(vs.asVsCode(), 'colab.test', handler);
+
+    expect(result).to.equal(disposable);
+    sinon.assert.calledOnce(vs.commands.registerCommand);
+    expect(vs.commands.registerCommand.firstCall.args[0]).to.equal(
+      'colab.test',
+    );
+    expect(typeof vs.commands.registerCommand.firstCall.args[1]).to.equal(
+      'function',
+    );
+    // The function passed to vscode.commands.registerCommand must NOT be the
+    // raw handler; it must be a wrapper. This is what proves wrapping
+    // happened independently of any behavioral assertion below.
+    expect(vs.commands.registerCommand.firstCall.args[1]).to.not.equal(handler);
+  });
+
+  it('wraps the handler with error tracking', async () => {
+    const vs = newVsCodeStub();
+    let wrappedHandler: ((...args: unknown[]) => unknown) | undefined;
+    vs.commands.registerCommand.callsFake(
+      (_id: string, h: (...args: unknown[]) => unknown) => {
+        wrappedHandler = h;
+        return { dispose: sinon.stub() };
+      },
+    );
+    const handler = sinon.stub().rejects(new Error('boom'));
+
+    registerCommand(vs.asVsCode(), 'colab.test', handler);
+
+    // The wrapped handler should still propagate the rejection (telemetry
+    // logs the error as a side effect; we don't assert on telemetry here).
+    expect(wrappedHandler).to.be.a('function');
+    if (!wrappedHandler) {
+      throw new Error('wrappedHandler was not set');
+    }
+    expect(wrappedHandler).to.not.equal(handler);
+    await expect(wrappedHandler()).to.be.rejectedWith('boom');
+  });
+});

--- a/src/drive/commands/register.ts
+++ b/src/drive/commands/register.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vscode, { Disposable } from 'vscode';
+import { registerCommand } from '../../common/commands';
+import { DriveClient } from '../client';
+import { IMPORT_NOTEBOOK_FROM_URL } from './constants';
+import { importNotebookFromUrl } from './import';
+
+/** Dependencies required to register drive commands. */
+export interface DriveCommandDeps {
+  /** Used by the import-notebook-from-url command. */
+  readonly driveClient: DriveClient;
+}
+
+/**
+ * Registers Drive-related commands.
+ *
+ * @param vs - The VS Code API instance.
+ * @param deps - The drive client used by the commands.
+ * @returns The disposables for each registered command.
+ */
+export function registerDriveCommands(
+  vs: typeof vscode,
+  deps: DriveCommandDeps,
+): Disposable[] {
+  const { driveClient } = deps;
+  return [
+    registerCommand(vs, IMPORT_NOTEBOOK_FROM_URL.id, async (url?: string) => {
+      await importNotebookFromUrl(vs, driveClient, url);
+    }),
+  ];
+}

--- a/src/drive/commands/register.unit.test.ts
+++ b/src/drive/commands/register.unit.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { newVsCodeStub } from '../../test/helpers/vscode';
+import { DriveClient } from '../client';
+import { IMPORT_NOTEBOOK_FROM_URL } from './constants';
+import { registerDriveCommands } from './register';
+
+describe('registerDriveCommands', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('registers the import-notebook-from-url command', () => {
+    const vs = newVsCodeStub();
+    vs.commands.registerCommand.callsFake(() => ({ dispose: sinon.stub() }));
+    const driveClient = sinon.createStubInstance(DriveClient);
+
+    const disposables = registerDriveCommands(vs.asVsCode(), {
+      driveClient,
+    });
+
+    const registeredIds = vs.commands.registerCommand
+      .getCalls()
+      .map((call) => call.args[0]);
+    expect(registeredIds).to.deep.equal([IMPORT_NOTEBOOK_FROM_URL.id]);
+    expect(disposables).to.have.lengthOf(1);
+  });
+});

--- a/src/drive/module.ts
+++ b/src/drive/module.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import vscode, { Disposable } from 'vscode';
+import { GoogleAuthProvider } from '../auth/auth-provider';
+import { DRIVE_SCOPES } from '../auth/scopes';
+import { DriveClient } from './client';
+import { registerDriveCommands } from './commands/register';
+
+/** The result of activating the drive module. */
+export interface DriveModule {
+  /**
+   * Command-registration disposables. Push these LAST in
+   * `context.subscriptions` so they are disposed earliest, removing command
+   * handlers before the underlying services tear down.
+   */
+  readonly commandDisposables: Disposable[];
+}
+
+/**
+ * Builds the {@link DriveClient} and registers Drive-related commands.
+ *
+ * @param vs - The VS Code API instance.
+ * @param authProvider - The authentication provider for token retrieval and
+ * sign-out on auth failure.
+ * @returns The disposables produced by command registration.
+ */
+export function createDriveModule(
+  vs: typeof vscode,
+  authProvider: GoogleAuthProvider,
+): DriveModule {
+  const driveClient = DriveClient.create(
+    () =>
+      GoogleAuthProvider.getOrCreateSession(vs, DRIVE_SCOPES).then(
+        (session) => session.accessToken,
+      ),
+    () => authProvider.signOut(),
+  );
+  return {
+    commandDisposables: registerDriveCommands(vs, { driveClient }),
+  };
+}

--- a/src/drive/module.unit.test.ts
+++ b/src/drive/module.unit.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { GoogleAuthProvider } from '../auth/auth-provider';
+import { newVsCodeStub } from '../test/helpers/vscode';
+import { createDriveModule } from './module';
+
+describe('createDriveModule', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('registers drive commands', () => {
+    const vs = newVsCodeStub();
+    vs.commands.registerCommand.callsFake(() => ({ dispose: sinon.stub() }));
+    const authProvider = sinon.createStubInstance(GoogleAuthProvider);
+
+    const result = createDriveModule(vs.asVsCode(), authProvider);
+
+    expect(result.commandDisposables)
+      .to.be.an('array')
+      .with.length.greaterThan(0);
+    const registeredIds = vs.commands.registerCommand
+      .getCalls()
+      .map((call) => call.args[0]);
+    expect(registeredIds).to.include('colab.importNotebookFromUrl');
+  });
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,66 +5,17 @@
  */
 
 import { Jupyter } from '@vscode/jupyter-extension';
-import { OAuth2Client } from 'google-auth-library';
-import vscode, { Disposable } from 'vscode';
-import { GoogleAuthProvider } from './auth/auth-provider';
-import { getOAuth2Flows } from './auth/flows/flows';
-import { login, LoginOptions } from './auth/login';
-import { DRIVE_SCOPES, REQUIRED_SCOPES } from './auth/scopes';
-import { AuthStorage } from './auth/storage';
-import { ColabClient } from './colab/client';
-import {
-  COLAB_TOOLBAR,
-  UPLOAD,
-  MOUNT_DRIVE,
-  MOUNT_SERVER,
-  REMOVE_SERVER,
-  SIGN_OUT,
-  OPEN_TERMINAL,
-} from './colab/commands/constants';
-import { upload } from './colab/commands/files';
-import { notebookToolbar, appendCodeCell } from './colab/commands/notebook';
-import { mountServer, removeServer } from './colab/commands/server';
-import { openTerminal } from './colab/commands/terminal';
-import { ConnectionRefreshController } from './colab/connection-refresher';
-import { ConsumptionNotifier } from './colab/consumption/notifier';
-import { ConsumptionPoller } from './colab/consumption/poller';
-import { ConsumptionStatusBar } from './colab/consumption/status-bar';
-import {
-  deleteFile,
-  download,
-  newFile,
-  newFolder,
-  renameFile,
-} from './colab/content-browser/commands';
-import { ContentItem } from './colab/content-browser/content-item';
-import { ContentTreeProvider } from './colab/content-browser/content-tree';
-import { ExperimentStateProvider } from './colab/experiment-state';
-import { ServerKeepAliveController } from './colab/keep-alive';
-import { ResourceTreeProvider } from './colab/resource-monitor/resource-tree';
-import { ServerPicker } from './colab/server-picker';
-import { CONFIG } from './colab-config';
+import vscode from 'vscode';
+import { createAuthModule } from './auth/module';
+import { createColabClient, createColabModule } from './colab/module';
 import { initializeLogger, log } from './common/logging';
-import { Toggleable } from './common/toggleable';
 import { getPackageInfo } from './config/package-info';
-import { DriveClient } from './drive/client';
-import {
-  IMPORT_DRIVE_FILE_PATH,
-  IMPORT_NOTEBOOK_FROM_URL,
-} from './drive/commands/constants';
-import {
-  handleImportUriEvents,
-  importNotebookFromUrl,
-} from './drive/commands/import';
-import { AssignmentManager } from './jupyter/assignments';
-import { ContentsFileSystemProvider } from './jupyter/contents/file-system';
-import { JupyterConnectionManager } from './jupyter/contents/sessions';
+import { IMPORT_DRIVE_FILE_PATH } from './drive/commands/constants';
+import { handleImportUriEvents } from './drive/commands/import';
+import { createDriveModule } from './drive/module';
 import { getJupyterApi } from './jupyter/jupyter-extension';
-import { ColabJupyterServerProvider } from './jupyter/provider';
-import { ServerStorage } from './jupyter/storage';
-import { ExtensionUriHandler } from './system/uri';
-import { telemetry } from './telemetry';
-import { CommandSource } from './telemetry/api';
+import { createJupyterModule } from './jupyter/module';
+import { ExtensionUriHandler, registerUriRoutes } from './system/uri';
 import { withErrorTracking } from './telemetry/decorators';
 import { initializeTelemetryWithNotice } from './telemetry/notice';
 import { createProcessErrorHandler } from './telemetry/process-errors';
@@ -93,130 +44,62 @@ async function activateInternal(context: vscode.ExtensionContext) {
   const jupyter = await getJupyterApi(vscode);
   logEnvInfo(jupyter);
   const uriHandler = new ExtensionUriHandler(vscode);
-  const authClient = new OAuth2Client(
-    CONFIG.ClientId,
-    CONFIG.ClientNotSoSecret,
-  );
   const packageInfo = getPackageInfo(context.extension);
-  const authFlows = getOAuth2Flows(vscode, packageInfo, authClient);
-  const authProvider = new GoogleAuthProvider(
+  const auth = createAuthModule(vscode, context, packageInfo);
+  const { authProvider } = auth;
+  const colabClient = createColabClient(vscode, authProvider, packageInfo);
+  const drive = createDriveModule(vscode, authProvider);
+  const jupyterModule = createJupyterModule(
     vscode,
-    new AuthStorage(context.secrets),
-    authClient,
-    (scopes: string[], options?: LoginOptions) =>
-      login(vscode, authFlows, authClient, scopes, options),
-  );
-  const colabClient = ColabClient.create(
-    new URL(CONFIG.ColabApiDomain),
-    new URL(CONFIG.ColabGapiDomain),
-    { appName: vscode.env.appName, extensionVersion: packageInfo.version },
-    () =>
-      GoogleAuthProvider.getOrCreateSession(vscode, REQUIRED_SCOPES).then(
-        (session) => session.accessToken,
-      ),
-    () => authProvider.signOut(),
-  );
-  const driveClient = DriveClient.create(
-    () =>
-      GoogleAuthProvider.getOrCreateSession(vscode, DRIVE_SCOPES).then(
-        (session) => session.accessToken,
-      ),
-    () => authProvider.signOut(),
-  );
-  const serverStorage = new ServerStorage(vscode, context.secrets);
-  const assignmentManager = new AssignmentManager(
-    vscode,
-    colabClient,
-    serverStorage,
-  );
-  const serverProvider = new ColabJupyterServerProvider(
-    vscode,
-    authProvider.onDidChangeSessions,
-    assignmentManager,
-    colabClient,
-    new ServerPicker(vscode, assignmentManager),
-    jupyter.exports,
-  );
-  const jupyterConnections = new JupyterConnectionManager(
-    vscode,
-    authProvider.onDidChangeSessions,
-    assignmentManager,
-  );
-  const fs = new ContentsFileSystemProvider(vscode, jupyterConnections);
-  const serverContentTreeView = new ContentTreeProvider(
-    assignmentManager,
-    authProvider.onDidChangeSessions,
-    assignmentManager.onDidAssignmentsChange,
-    fs.onDidChangeFile,
-  );
-  const serverResourceTreeView = new ResourceTreeProvider(
-    assignmentManager,
-    assignmentManager.onDidAssignmentsChange,
-    authProvider.onDidChangeSessions,
+    context,
+    jupyter,
+    authProvider,
     colabClient,
   );
-  const connections = new ConnectionRefreshController(assignmentManager);
-  const keepServersAlive = new ServerKeepAliveController(
+  const colab = createColabModule(
     vscode,
     colabClient,
-    assignmentManager,
+    jupyterModule.assignmentManager,
   );
-  const consumptionMonitor = watchConsumption(colabClient, assignmentManager);
-  const experimentStateProvider = new ExperimentStateProvider(colabClient);
   await authProvider.initialize();
   // Sending server "keep-alive" pings and monitoring consumption requires
   // issuing authenticated requests to Colab. This can only be done after the
   // user has signed in. We don't block extension activation on completing the
   // heavily asynchronous sign-in flow.
   const whileAuthorizedToggle = authProvider.whileAuthorized(
-    connections,
-    keepServersAlive,
-    ...consumptionMonitor.toggles,
-    experimentStateProvider,
+    ...jupyterModule.toggles,
+    ...colab.toggles,
   );
-  const disposeFs = vscode.workspace.registerFileSystemProvider('colab', fs, {
-    isCaseSensitive: true,
-  });
-  const disposeContentTreeView = vscode.window.createTreeView(
-    'colab-server-content-view',
-    { treeDataProvider: serverContentTreeView },
-  );
-  const disposeResourceTreeView = vscode.window.createTreeView(
-    'colab-server-resource-view',
-    { treeDataProvider: serverResourceTreeView },
+  const routes = registerUriRoutes(
+    uriHandler.onReceivedUri,
+    new Map([
+      [
+        IMPORT_DRIVE_FILE_PATH,
+        (uri) => {
+          handleImportUriEvents(vscode, uri);
+        },
+      ],
+    ]),
   );
 
   context.subscriptions.push(
     logging,
     disposeTelemetry,
     uriHandler,
-    disposeAll(authFlows),
-    authProvider,
-    assignmentManager,
-    experimentStateProvider,
-    serverProvider,
-    jupyterConnections,
-    disposeFs,
-    disposeContentTreeView,
-    disposeResourceTreeView,
-    connections,
-    keepServersAlive,
-    ...consumptionMonitor.disposables,
+    ...auth.disposables,
+    ...jupyterModule.disposables,
+    ...colab.disposables,
     whileAuthorizedToggle,
-    ...registerCommands(
-      authProvider,
-      assignmentManager,
-      serverContentTreeView,
-      serverResourceTreeView,
-      fs,
-      driveClient,
-    ),
-    handleUriEvents(uriHandler.onReceivedUri),
+    // Command disposables are pushed last so they are disposed first, which
+    // removes the command handlers before the underlying services tear down.
+    ...drive.commandDisposables,
+    ...jupyterModule.commandDisposables,
+    routes,
   );
   // Register the URI handler with VS Code *after* all event listeners and
   // commands are set up, to avoid the race condition where the URI that
   // triggered onUri activation is delivered before the listener in
-  // handleUriEvents() is subscribed, causing the first deep link to be lost.
+  // registerUriRoutes() is subscribed, causing the first deep link to be lost.
   context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
 }
 
@@ -226,155 +109,4 @@ function logEnvInfo(jupyter: vscode.Extension<Jupyter>) {
   log.info(`App Host: ${vscode.env.appHost}`);
   const jupyterVersion = getPackageInfo(jupyter).version;
   log.info(`Jupyter extension version: ${jupyterVersion}`);
-}
-
-/**
- * Sets up consumption monitoring.
- *
- * If the user has already signed in, starts immediately. Otherwise, waits until
- * the user signs in.
- *
- * @param colab - The colab client used to poll consumption.
- * @param assignmentManager - The assignment manager to trigger polls on change.
- * @returns An object containing a {@link Toggleable} to control the polling and
- * any disposables created for the monitoring.
- */
-function watchConsumption(
-  colab: ColabClient,
-  assignmentManager: AssignmentManager,
-): {
-  toggles: Toggleable[];
-  disposables: Disposable[];
-} {
-  const poller = new ConsumptionPoller(
-    vscode,
-    colab,
-    assignmentManager.onDidAssignmentsChange,
-  );
-  const notifier = new ConsumptionNotifier(vscode, poller.onDidChangeCcuInfo);
-  const statusBar = new ConsumptionStatusBar(vscode, poller.onDidChangeCcuInfo);
-  return {
-    toggles: [poller, statusBar],
-    disposables: [poller, notifier, statusBar],
-  };
-}
-
-function registerCommands(
-  authProvider: GoogleAuthProvider,
-  assignmentManager: AssignmentManager,
-  contentTreeProvider: ContentTreeProvider,
-  resourceTreeProvider: ResourceTreeProvider,
-  fs: ContentsFileSystemProvider,
-  driveClient: DriveClient,
-): Disposable[] {
-  return [
-    registerCommand(SIGN_OUT.id, async () => {
-      await authProvider.signOut();
-    }),
-    // TODO: Register the rename server alias command once rename is reflected
-    // in the recent kernels list. See https://github.com/microsoft/vscode-jupyter/issues/17107.
-    registerCommand(
-      MOUNT_SERVER.id,
-      async (source?: CommandSource, withBackButton?: boolean) => {
-        await mountServer(
-          vscode,
-          assignmentManager,
-          fs,
-          source ?? CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
-          withBackButton,
-        );
-      },
-    ),
-    registerCommand(MOUNT_DRIVE.id, async (source?: CommandSource) => {
-      telemetry.logMountDriveSnippet(
-        source ?? CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
-      );
-      await appendCodeCell(
-        vscode,
-        [
-          'from google.colab import drive',
-          `drive.mount('/content/drive')`,
-        ].join('\n'),
-        'python',
-      );
-    }),
-    registerCommand(
-      REMOVE_SERVER.id,
-      async (source?: CommandSource, withBackButton?: boolean) => {
-        await removeServer(vscode, assignmentManager, withBackButton, source);
-      },
-    ),
-    registerCommand(UPLOAD.id, async (uri: vscode.Uri, uris?: vscode.Uri[]) => {
-      await upload(vscode, assignmentManager, uri, uris);
-    }),
-    registerCommand(COLAB_TOOLBAR.id, async () => {
-      await notebookToolbar(vscode, assignmentManager);
-    }),
-    registerCommand('colab.refreshServerContentView', () => {
-      contentTreeProvider.refresh();
-    }),
-    registerCommand('colab.refreshServerResourceView', () => {
-      resourceTreeProvider.refresh();
-    }),
-    registerCommand('colab.newFile', (contextItem: ContentItem) => {
-      void newFile(vscode, contextItem);
-    }),
-    registerCommand('colab.newFolder', (contextItem: ContentItem) => {
-      void newFolder(vscode, contextItem);
-    }),
-    registerCommand('colab.download', (contextItem: ContentItem) => {
-      void download(vscode, contextItem);
-    }),
-    registerCommand('colab.renameFile', (contextItem: ContentItem) => {
-      void renameFile(vscode, contextItem);
-    }),
-    registerCommand('colab.deleteFile', (contextItem: ContentItem) => {
-      void deleteFile(vscode, contextItem);
-    }),
-    registerCommand(OPEN_TERMINAL.id, async (withBackButton?: boolean) => {
-      await openTerminal(vscode, assignmentManager, withBackButton);
-    }),
-    registerCommand(IMPORT_NOTEBOOK_FROM_URL.id, async (url?: string) => {
-      await importNotebookFromUrl(vscode, driveClient, url);
-    }),
-  ];
-}
-
-/**
- * Registers a command with the given identifier and handler.
- *
- * @param command - The unique identifier for the command.
- * @param handler - A command handler function.
- * @returns Disposable which deregisters this command on disposal.
- */
-function registerCommand<T extends (...args: Parameters<T>) => ReturnType<T>>(
-  command: string,
-  handler: T,
-): Disposable {
-  return vscode.commands.registerCommand(command, withErrorTracking(handler));
-}
-
-/**
- * Handles incoming URI events to the extension.
- *
- * @param onReceivedUri - Event listener for Uri events
- * @returns Disposable which stops listening to URI events on disposal.
- */
-function handleUriEvents(onReceivedUri: vscode.Event<vscode.Uri>): Disposable {
-  const supportedPaths = [IMPORT_DRIVE_FILE_PATH];
-  return onReceivedUri((uri) => {
-    if (!supportedPaths.includes(uri.path.slice(1))) {
-      return;
-    }
-
-    handleImportUriEvents(vscode, uri);
-  });
-}
-
-function disposeAll(items: { dispose?: () => void }[]): Disposable {
-  return {
-    dispose: () => {
-      items.forEach((item) => item.dispose?.());
-    },
-  };
 }

--- a/src/jupyter/module.ts
+++ b/src/jupyter/module.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Jupyter } from '@vscode/jupyter-extension';
+import vscode, { Disposable, Extension, ExtensionContext } from 'vscode';
+import { GoogleAuthProvider } from '../auth/auth-provider';
+import { ColabClient } from '../colab/client';
+import { registerColabCommands } from '../colab/commands/register';
+import { ConnectionRefreshController } from '../colab/connection-refresher';
+import { ContentTreeProvider } from '../colab/content-browser/content-tree';
+import { registerContentBrowserCommands } from '../colab/content-browser/register';
+import { ServerKeepAliveController } from '../colab/keep-alive';
+import { ResourceTreeProvider } from '../colab/resource-monitor/resource-tree';
+import { ServerPicker } from '../colab/server-picker';
+import { Toggleable } from '../common/toggleable';
+import { AssignmentManager } from './assignments';
+import { ContentsFileSystemProvider } from './contents/file-system';
+import { JupyterConnectionManager } from './contents/sessions';
+import { ColabJupyterServerProvider } from './provider';
+import { ServerStorage } from './storage';
+
+/** The result of activating the Jupyter integration module. */
+export interface JupyterModule {
+  /** Manages the user's assigned Colab Jupyter servers. */
+  readonly assignmentManager: AssignmentManager;
+  /**
+   * Service-level disposables (assignment manager, server provider, jupyter
+   * connections, file-system registration, both tree views, connection
+   * refresher, keep-alive controller). Push these into
+   * `context.subscriptions` before the colab background services so they tear
+   * down in the correct order.
+   */
+  readonly disposables: Disposable[];
+  /**
+   * Command-registration disposables. Push these LAST in
+   * `context.subscriptions` so they are disposed earliest, removing command
+   * handlers before the underlying services tear down.
+   */
+  readonly commandDisposables: Disposable[];
+  /** Auth-gated toggles that should be passed to `whileAuthorized`. */
+  readonly toggles: Toggleable[];
+}
+
+/**
+ * Builds the Jupyter integration: assignment manager, server provider,
+ * connections, file system, both tree views, connection refresher, keep-alive
+ * controller, and registers the Colab + content-browser commands that depend
+ * on these services.
+ *
+ * @param vs - The VS Code API instance.
+ * @param context - The extension context (for `secrets` access).
+ * @param jupyter - The installed Jupyter extension.
+ * @param authProvider - The authentication provider; supplies session-change
+ * events used by several services.
+ * @param colab - The Colab client used by the assignment manager and
+ * resource view.
+ * @returns The services and disposables produced.
+ */
+export function createJupyterModule(
+  vs: typeof vscode,
+  context: ExtensionContext,
+  jupyter: Extension<Jupyter>,
+  authProvider: GoogleAuthProvider,
+  colab: ColabClient,
+): JupyterModule {
+  const serverStorage = new ServerStorage(vs, context.secrets);
+  const assignmentManager = new AssignmentManager(vs, colab, serverStorage);
+  const serverProvider = new ColabJupyterServerProvider(
+    vs,
+    authProvider.onDidChangeSessions,
+    assignmentManager,
+    colab,
+    new ServerPicker(vs, assignmentManager),
+    jupyter.exports,
+  );
+  const jupyterConnections = new JupyterConnectionManager(
+    vs,
+    authProvider.onDidChangeSessions,
+    assignmentManager,
+  );
+  const fs = new ContentsFileSystemProvider(vs, jupyterConnections);
+  const contentTree = new ContentTreeProvider(
+    assignmentManager,
+    authProvider.onDidChangeSessions,
+    assignmentManager.onDidAssignmentsChange,
+    fs.onDidChangeFile,
+  );
+  const resourceTree = new ResourceTreeProvider(
+    assignmentManager,
+    assignmentManager.onDidAssignmentsChange,
+    authProvider.onDidChangeSessions,
+    colab,
+  );
+  const connections = new ConnectionRefreshController(assignmentManager);
+  const keepAlive = new ServerKeepAliveController(vs, colab, assignmentManager);
+
+  const fsDisposable = vs.workspace.registerFileSystemProvider('colab', fs, {
+    isCaseSensitive: true,
+  });
+  const contentTreeView = vs.window.createTreeView(
+    'colab-server-content-view',
+    { treeDataProvider: contentTree },
+  );
+  const resourceTreeView = vs.window.createTreeView(
+    'colab-server-resource-view',
+    { treeDataProvider: resourceTree },
+  );
+
+  const colabCommandDisposables = registerColabCommands(vs, {
+    authProvider,
+    assignmentManager,
+    fs,
+  });
+  const contentBrowserCommandDisposables = registerContentBrowserCommands(vs, {
+    contentTree,
+    resourceTree,
+  });
+
+  return {
+    assignmentManager,
+    disposables: [
+      assignmentManager,
+      serverProvider,
+      jupyterConnections,
+      fsDisposable,
+      contentTreeView,
+      resourceTreeView,
+      connections,
+      keepAlive,
+    ],
+    commandDisposables: [
+      ...colabCommandDisposables,
+      ...contentBrowserCommandDisposables,
+    ],
+    toggles: [connections, keepAlive],
+  };
+}

--- a/src/jupyter/module.vscode.test.ts
+++ b/src/jupyter/module.vscode.test.ts
@@ -1,0 +1,192 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Jupyter } from '@vscode/jupyter-extension';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import vscode, {
+  type Disposable,
+  EventEmitter,
+  type Extension,
+  type ExtensionContext,
+  type SecretStorage,
+} from 'vscode';
+import { GoogleAuthProvider } from '../auth/auth-provider';
+import { ColabClient } from '../colab/client';
+import {
+  COLAB_TOOLBAR,
+  MOUNT_DRIVE,
+  MOUNT_SERVER,
+  OPEN_TERMINAL,
+  REMOVE_SERVER,
+  SIGN_OUT,
+  UPLOAD,
+} from '../colab/commands/constants';
+import { ConnectionRefreshController } from '../colab/connection-refresher';
+import { ServerKeepAliveController } from '../colab/keep-alive';
+import { ContentsFileSystemProvider } from './contents/file-system';
+import { createJupyterModule, JupyterModule } from './module';
+
+describe('createJupyterModule', () => {
+  let result: JupyterModule | undefined;
+  let context: ExtensionContext;
+  let jupyter: Extension<Jupyter>;
+  let authProvider: sinon.SinonStubbedInstance<GoogleAuthProvider>;
+  let colabClient: sinon.SinonStubbedInstance<ColabClient>;
+  let fsStub: sinon.SinonStubbedMember<
+    typeof vscode.workspace.registerFileSystemProvider
+  >;
+  let treeStub: sinon.SinonStubbedMember<typeof vscode.window.createTreeView>;
+  let cmdStub: sinon.SinonStubbedMember<typeof vscode.commands.registerCommand>;
+
+  beforeEach(() => {
+    // ExtensionContext is an interface, so we can't use createStubInstance.
+    // Provide just the `secrets` member that the factory's transitive
+    // constructors read at construction time.
+    context = {
+      secrets: {
+        get: sinon.stub().resolves(undefined),
+        store: sinon.stub().resolves(),
+        delete: sinon.stub().resolves(),
+        onDidChange: sinon.stub(),
+      } satisfies SecretStorage,
+    } as Partial<ExtensionContext> as ExtensionContext;
+    // Using the real jupyter extension would register a real `colab` server
+    // collection with it (a side effect that persists across tests). Stub it.
+    jupyter = {
+      exports: {
+        createJupyterServerCollection: sinon.stub().returns({
+          dispose: sinon.stub(),
+        }),
+      } as Partial<Jupyter> as Jupyter,
+    } as Partial<Extension<Jupyter>> as Extension<Jupyter>;
+    authProvider = sinon.createStubInstance(GoogleAuthProvider);
+    // `onDidChangeSessions` is a constructor-set property, not a method, so
+    // createStubInstance leaves it undefined; install a real Event so that
+    // the factory's listener subscriptions don't blow up.
+    Object.defineProperty(authProvider, 'onDidChangeSessions', {
+      value: new EventEmitter<unknown>().event,
+    });
+    colabClient = sinon.createStubInstance(ColabClient);
+
+    // The integration host already has the activated extension's `colab` FS
+    // provider, the two tree views, and all of the command IDs registered.
+    // To keep the factory exercise from colliding with the real extension,
+    // stub the registration entry points on the real `vscode` module. We can
+    // still assert what the factory tried to register by inspecting these
+    // stubs.
+    const fakeDisposable: Disposable = { dispose: sinon.stub() };
+    fsStub = sinon
+      .stub(vscode.workspace, 'registerFileSystemProvider')
+      .returns(fakeDisposable);
+    treeStub = sinon.stub(vscode.window, 'createTreeView').returns({
+      dispose: sinon.stub(),
+    } as Partial<vscode.TreeView<unknown>> as vscode.TreeView<unknown>);
+    cmdStub = sinon
+      .stub(vscode.commands, 'registerCommand')
+      .returns(fakeDisposable);
+  });
+
+  afterEach(() => {
+    // Order matters: command handlers should deregister before the services
+    // they depend on tear down (matches the order in `extension.ts`).
+    if (result) {
+      result.commandDisposables.forEach((d) => {
+        d.dispose();
+      });
+      result.disposables.forEach((d) => {
+        d.dispose();
+      });
+      result = undefined;
+    }
+    sinon.restore();
+  });
+
+  function activate(): JupyterModule {
+    result = createJupyterModule(
+      vscode,
+      context,
+      jupyter,
+      authProvider,
+      colabClient,
+    );
+    return result;
+  }
+
+  it('returns the assignment manager', () => {
+    const module = activate();
+
+    expect(module.assignmentManager).to.exist;
+  });
+
+  it('registers the colab file system provider with the right options', () => {
+    activate();
+
+    sinon.assert.calledOnce(fsStub);
+    expect(fsStub.firstCall.args[0]).to.equal('colab');
+    expect(fsStub.firstCall.args[1]).to.be.instanceOf(
+      ContentsFileSystemProvider,
+    );
+    expect(fsStub.firstCall.args[2]).to.deep.equal({ isCaseSensitive: true });
+  });
+
+  it('creates the two tree views with the expected IDs', () => {
+    activate();
+
+    const viewIds = treeStub.getCalls().map((call) => call.args[0]);
+    expect(viewIds).to.have.members([
+      'colab-server-content-view',
+      'colab-server-resource-view',
+    ]);
+  });
+
+  it('registers the colab and content-browser commands', () => {
+    activate();
+
+    const registeredIds = cmdStub.getCalls().map((call) => call.args[0]);
+    // Spot-check a representative subset; the full lists are covered by the
+    // per-feature `register.unit.test.ts` files.
+    expect(registeredIds).to.include.members([
+      // Colab commands.
+      SIGN_OUT.id,
+      MOUNT_SERVER.id,
+      MOUNT_DRIVE.id,
+      REMOVE_SERVER.id,
+      UPLOAD.id,
+      COLAB_TOOLBAR.id,
+      OPEN_TERMINAL.id,
+      // Content-browser commands.
+      'colab.refreshServerContentView',
+      'colab.refreshServerResourceView',
+      'colab.newFile',
+      'colab.newFolder',
+      'colab.download',
+      'colab.renameFile',
+      'colab.deleteFile',
+    ]);
+  });
+
+  it('exposes the connection refresher and keep-alive as toggles', () => {
+    const module = activate();
+
+    expect(module.toggles).to.have.lengthOf(2);
+    expect(
+      module.toggles.some((t) => t instanceof ConnectionRefreshController),
+    ).to.equal(true);
+    expect(
+      module.toggles.some((t) => t instanceof ServerKeepAliveController),
+    ).to.equal(true);
+  });
+
+  it('returns non-empty service and command disposable lists', () => {
+    const module = activate();
+
+    expect(module.disposables).to.be.an('array').with.length.greaterThan(0);
+    expect(module.commandDisposables)
+      .to.be.an('array')
+      .with.length.greaterThan(0);
+  });
+});

--- a/src/system/uri.ts
+++ b/src/system/uri.ts
@@ -89,3 +89,32 @@ export class ExtensionUriHandler
     }
   }
 }
+
+/**
+ * A handler for a URI matched by its path component.
+ */
+export type UriRouteHandler = (uri: vscode.Uri) => void;
+
+/**
+ * A map from a URI path (without the leading `/`) to its handler.
+ */
+export type UriRoutes = ReadonlyMap<string, UriRouteHandler>;
+
+/**
+ * Subscribes route handlers to the given URI event. The path of each incoming
+ * URI is matched against the keys of `routes` (without the leading `/`); the
+ * matching handler is invoked, if any. Unmatched URIs are ignored.
+ *
+ * @param onReceivedUri - The event source from the extension URI handler.
+ * @param routes - A map from URI path to handler.
+ * @returns A disposable that unsubscribes the listener.
+ */
+export function registerUriRoutes(
+  onReceivedUri: vscode.Event<vscode.Uri>,
+  routes: UriRoutes,
+): vscode.Disposable {
+  return onReceivedUri((uri) => {
+    const path = uri.path.startsWith('/') ? uri.path.slice(1) : uri.path;
+    routes.get(path)?.(uri);
+  });
+}

--- a/src/system/uri.unit.test.ts
+++ b/src/system/uri.unit.test.ts
@@ -10,7 +10,11 @@ import { Uri } from 'vscode';
 import { PackageInfo } from '../config/package-info';
 import { TestUri } from '../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
-import { buildExtensionUri, ExtensionUriHandler } from './uri';
+import {
+  buildExtensionUri,
+  ExtensionUriHandler,
+  registerUriRoutes,
+} from './uri';
 
 it('buildExtensionUri', () => {
   const vs = newVsCodeStub();
@@ -85,5 +89,65 @@ describe('ExtensionUriHandler', () => {
 
     sinon.assert.calledWithExactly(onReceivedUriStub, testUri1);
     sinon.assert.calledWithExactly(onReceivedUriStub, testUri2);
+  });
+});
+
+describe('registerUriRoutes', () => {
+  let vs: VsCodeStub;
+  let handler: ExtensionUriHandler;
+
+  beforeEach(() => {
+    vs = newVsCodeStub();
+    handler = new ExtensionUriHandler(vs.asVsCode());
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    handler.dispose();
+  });
+
+  it('routes a URI to the handler whose path matches', () => {
+    const importHandler = sinon.stub();
+    const otherHandler = sinon.stub();
+    registerUriRoutes(
+      handler.onReceivedUri,
+      new Map([
+        ['import-drive-file', importHandler],
+        ['something-else', otherHandler],
+      ]),
+    );
+    const uri = TestUri.parse('vscode://google.colab/import-drive-file?id=abc');
+
+    handler.handleUri(uri);
+
+    sinon.assert.calledOnceWithExactly(importHandler, uri);
+    sinon.assert.notCalled(otherHandler);
+  });
+
+  it('ignores URIs whose path matches no registered route', () => {
+    const importHandler = sinon.stub();
+    registerUriRoutes(
+      handler.onReceivedUri,
+      new Map([['import-drive-file', importHandler]]),
+    );
+    const uri = TestUri.parse('vscode://google.colab/unknown-path');
+
+    handler.handleUri(uri);
+
+    sinon.assert.notCalled(importHandler);
+  });
+
+  it('stops routing after the registration is disposed', () => {
+    const importHandler = sinon.stub();
+    const reg = registerUriRoutes(
+      handler.onReceivedUri,
+      new Map([['import-drive-file', importHandler]]),
+    );
+    reg.dispose();
+    const uri = TestUri.parse('vscode://google.colab/import-drive-file');
+
+    handler.handleUri(uri);
+
+    sinon.assert.notCalled(importHandler);
   });
 });

--- a/src/test/helpers/vscode.ts
+++ b/src/test/helpers/vscode.ts
@@ -103,6 +103,9 @@ export interface VsCodeStub {
     executeCommand: sinon.SinonStubbedMember<
       typeof vscode.commands.executeCommand
     >;
+    registerCommand: sinon.SinonStubbedMember<
+      typeof vscode.commands.registerCommand
+    >;
   };
   UIKind: typeof UIKind;
   env: {
@@ -154,6 +157,9 @@ export interface VsCodeStub {
     createStatusBarItem: sinon.SinonStubbedMember<
       typeof vscode.window.createStatusBarItem
     >;
+    createTreeView: sinon.SinonStubbedMember<
+      typeof vscode.window.createTreeView
+    >;
   };
   workspace: {
     getConfiguration: sinon.SinonStubbedMember<
@@ -172,6 +178,9 @@ export interface VsCodeStub {
       typeof vscode.workspace.onDidChangeWorkspaceFolders
     >;
     applyEdit: sinon.SinonStubbedMember<typeof vscode.workspace.applyEdit>;
+    registerFileSystemProvider: sinon.SinonStubbedMember<
+      typeof vscode.workspace.registerFileSystemProvider
+    >;
     workspaceFolders: sinon.SinonStubbedMember<
       typeof vscode.workspace.workspaceFolders
     >;
@@ -302,6 +311,7 @@ export function newVsCodeStub(): VsCodeStub {
     StatusBarAlignment: StatusBarAlignment,
     commands: {
       executeCommand: sinon.stub(),
+      registerCommand: sinon.stub(),
     },
     UIKind: UIKind,
     env: {
@@ -327,6 +337,14 @@ export function newVsCodeStub(): VsCodeStub {
       createQuickPick: sinon.stub(),
       createStatusBarItem: sinon.stub(),
       showNotebookDocument: sinon.stub(),
+      createTreeView: sinon
+        .stub<
+          Parameters<typeof vscode.window.createTreeView>,
+          ReturnType<typeof vscode.window.createTreeView>
+        >()
+        .returns({
+          dispose: sinon.stub(),
+        } as Partial<vscode.TreeView<unknown>> as vscode.TreeView<unknown>),
     },
     workspace: {
       getConfiguration: sinon.stub(),
@@ -335,6 +353,12 @@ export function newVsCodeStub(): VsCodeStub {
       onDidChangeConfiguration: sinon.stub(),
       onDidChangeWorkspaceFolders: sinon.stub(),
       applyEdit: sinon.stub(),
+      registerFileSystemProvider: sinon
+        .stub<
+          Parameters<typeof vscode.workspace.registerFileSystemProvider>,
+          ReturnType<typeof vscode.workspace.registerFileSystemProvider>
+        >()
+        .returns({ dispose: sinon.stub() }),
       workspaceFolders: undefined,
       textDocuments: [],
       fs: {


### PR DESCRIPTION
Reduce `src/extension.ts` from ~380 lines to ~100 by extracting service construction, command registration, and URI dispatch into per-feature module factories. Each new factory takes typeof vscode as a parameter, making activation logic that was previously locked in extension.ts (and therefore not unit-testable) reachable from tests.

Test notes:

- Each module factory has a test asserting shape (services present, disposables/toggles non-empty) and identity (specific service classes appear in toggles via instanceof checks; specific command IDs appear in registrations).
- `src/jupyter/module.vscode.test.ts` is an integration test (runs in the VS Code host) so the factory can take the real vscode module as input. This is what lets `ContentTreeProvider`/`ResourceTreeProvider` continue to extend concrete VS Code `TreeItem` types and import vscode values directly. The test stubs `vscode.workspace.registerFileSystemProvider`, `vscode.window.createTreeView`, and `vscode.commands.registerCommand` to avoid colliding with the activated extension's own registrations, while still asserting on the registration arguments.
- Test stub `src/test/helpers/vscode.ts` gains `commands.registerCommand`.