### PR TITLE
feat: log telemetry for uploads to Colab servers

### DIFF
--- a/src/colab/commands/files.ts
+++ b/src/colab/commands/files.ts
@@ -8,6 +8,8 @@ import vscode, { QuickPickItem } from 'vscode';
 import { log } from '../../common/logging';
 import { AssignmentManager } from '../../jupyter/assignments';
 import { ColabAssignedServer } from '../../jupyter/servers';
+import { telemetry } from '../../telemetry';
+import { CommandSource, Outcome } from '../../telemetry/api';
 import { buildColabFileUri } from '../files';
 import { UPLOAD } from './constants';
 
@@ -22,6 +24,7 @@ import { UPLOAD } from './constants';
  * @param vs - The VS Code module.
  * @param assignmentManager - The manager responsible for handling server
  * assignments.
+ * @param source - The source of the upload command invocation.
  * @param uri - The primary URI of the file or folder to upload, e.g. the URI of
  * the file which was right-clicked in the file explorer.
  * @param uris - An optional array of all files and folders which should be
@@ -32,66 +35,114 @@ import { UPLOAD } from './constants';
 export async function upload(
   vs: typeof vscode,
   assignmentManager: AssignmentManager,
+  source: CommandSource,
   uri: vscode.Uri,
   uris?: vscode.Uri[],
 ) {
-  const selectedServer = await selectServer(vs, assignmentManager);
-  if (!selectedServer) {
-    return;
-  }
-
-  const inputs = uris && uris.length > 0 ? uris : [uri];
-  const plan = await buildUploadPlan(vs, inputs, selectedServer);
-  const { operations } = plan;
-  let { failCount } = plan;
-
-  const filesToUpload = operations.filter((op) => op.type === 'file');
-  const incrementPerFile =
-    filesToUpload.length > 0 ? 100 / filesToUpload.length : 0;
+  let cancelled = true;
   let successCount = 0;
+  let failCount = 0;
+  let fileCount = 0;
+  let directoryCount = 0;
+  let uploadedBytes = 0;
 
-  if (operations.length > 0) {
-    await vs.window.withProgress(
-      {
-        location: vs.ProgressLocation.Notification,
-        title: `Uploading to ${selectedServer.label}...`,
-        cancellable: false,
-      },
-      async (progress) => {
-        for (const op of operations) {
-          try {
-            if (op.type === 'directory') {
-              await createDirectory(vs, op.dest);
-            } else {
-              const fileName = op.source.path.split('/').pop() ?? '';
-              progress.report({
-                message: `Importing ${fileName}...`,
-                increment: incrementPerFile,
-              });
-              const content = await vs.workspace.fs.readFile(op.source);
-              await vs.workspace.fs.writeFile(op.dest, content);
-              successCount++;
+  try {
+    const selectedServer = await selectServer(vs, assignmentManager);
+    if (!selectedServer) {
+      return;
+    }
+    cancelled = false;
+
+    const inputs = uris && uris.length > 0 ? uris : [uri];
+    const plan = await buildUploadPlan(vs, inputs, selectedServer);
+    const { operations } = plan;
+    failCount = plan.failCount;
+    fileCount = operations.filter((op) => op.type === 'file').length;
+    directoryCount = operations.filter((op) => op.type === 'directory').length;
+
+    const incrementPerFile = fileCount > 0 ? 100 / fileCount : 0;
+
+    if (operations.length > 0) {
+      await vs.window.withProgress(
+        {
+          location: vs.ProgressLocation.Notification,
+          title: `Uploading to ${selectedServer.label}...`,
+          cancellable: false,
+        },
+        async (progress) => {
+          for (const op of operations) {
+            try {
+              if (op.type === 'directory') {
+                await createDirectory(vs, op.dest);
+              } else {
+                const fileName = op.source.path.split('/').pop() ?? '';
+                progress.report({
+                  message: `Importing ${fileName}...`,
+                  increment: incrementPerFile,
+                });
+                const content = await vs.workspace.fs.readFile(op.source);
+                await vs.workspace.fs.writeFile(op.dest, content);
+                successCount++;
+                uploadedBytes += content.byteLength;
+              }
+            } catch (err) {
+              log.error(`Failed to process ${op.dest.toString()}`, err);
+              failCount++;
             }
-          } catch (err) {
-            log.error(`Failed to process ${op.dest.toString()}`, err);
-            failCount++;
           }
-        }
-      },
-    );
-  }
+        },
+      );
+    }
 
-  if (successCount > 0) {
-    const countPart = successCount > 1 ? 'items' : 'item';
-    const msg = `Successfully uploaded ${successCount.toString()} ${countPart} to ${selectedServer.label}`;
-    void vs.window.showInformationMessage(msg);
-  }
+    if (successCount > 0) {
+      const countPart = successCount > 1 ? 'items' : 'item';
+      const msg = `Successfully uploaded ${successCount.toString()} ${countPart} to ${selectedServer.label}`;
+      void vs.window.showInformationMessage(msg);
+    }
 
-  if (failCount > 0) {
-    const countPart = failCount > 1 ? 'items' : 'item';
-    const msg = `Failed to upload ${failCount.toString()} ${countPart}. Check logs for details.`;
-    void vs.window.showErrorMessage(msg);
+    if (failCount > 0) {
+      const countPart = failCount > 1 ? 'items' : 'item';
+      const msg = `Failed to upload ${failCount.toString()} ${countPart}. Check logs for details.`;
+      void vs.window.showErrorMessage(msg);
+    }
+  } finally {
+    const outcome = uploadOutcome(cancelled, successCount, failCount);
+    telemetry.logUpload(source, outcome, {
+      successCount,
+      failCount,
+      fileCount,
+      directoryCount,
+      uploadedBytes,
+    });
   }
+}
+
+/**
+ * Derives the {@link Outcome} of an upload attempt from the success and
+ * failure counts.
+ *
+ * @param cancelled - Whether the user cancelled before any work was
+ * attempted.
+ * @param successCount - The number of files that were successfully uploaded.
+ * @param failCount - The number of files or directories that failed to
+ * upload.
+ * @returns The outcome of the upload attempt.
+ */
+function uploadOutcome(
+  cancelled: boolean,
+  successCount: number,
+  failCount: number,
+): Outcome {
+  if (cancelled) {
+    return Outcome.OUTCOME_CANCELLED;
+  }
+  if (failCount === 0) {
+    return Outcome.OUTCOME_SUCCEEDED;
+  }
+  if (successCount === 0) {
+    return Outcome.OUTCOME_FAILED;
+  }
+  return Outcome.OUTCOME_PARTIAL_SUCCESS;
 }
 
 async function selectServer(

--- a/src/colab/commands/files.ts
+++ b/src/colab/commands/files.ts
@@ -106,7 +106,7 @@ export async function upload(
       void vs.window.showErrorMessage(msg);
     }
   } finally {
-    const outcome = uploadOutcome(cancelled, successCount, failCount);
+    const outcome = deriveUploadOutcome(cancelled, successCount, failCount);
     telemetry.logUpload(source, outcome, {
       successCount,
       failCount,
@@ -128,7 +128,7 @@ export async function upload(
  * upload.
  * @returns The outcome of the upload attempt.
  */
-function uploadOutcome(
+function deriveUploadOutcome(
   cancelled: boolean,
   successCount: number,
   failCount: number,

--- a/src/colab/commands/files.unit.test.ts
+++ b/src/colab/commands/files.unit.test.ts
@@ -5,9 +5,11 @@
  */
 
 import { randomUUID } from 'crypto';
-import sinon, { SinonStubbedInstance } from 'sinon';
+import sinon, { SinonStubbedFunction, SinonStubbedInstance } from 'sinon';
 import { QuickPickItem } from 'vscode';
 import { AssignmentManager } from '../../jupyter/assignments';
+import { telemetry } from '../../telemetry';
+import { CommandSource, Outcome } from '../../telemetry/api';
 import { TestCancellationTokenSource } from '../../test/helpers/cancellation';
 import { TestUri } from '../../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
@@ -70,7 +72,12 @@ describe('File Commands', () => {
         .withArgs('extension')
         .resolves([]);
 
-      await upload(vsCodeStub.asVsCode(), assignmentManagerStub, fileUri);
+      await upload(
+        vsCodeStub.asVsCode(),
+        assignmentManagerStub,
+        CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+        fileUri,
+      );
 
       sinon.assert.calledWith(
         vsCodeStub.window.showWarningMessage,
@@ -86,7 +93,12 @@ describe('File Commands', () => {
       const fileContent = new Uint8Array([1, 2, 3]);
       vsCodeStub.workspace.fs.readFile.resolves(fileContent);
 
-      await upload(vsCodeStub.asVsCode(), assignmentManagerStub, fileUri);
+      await upload(
+        vsCodeStub.asVsCode(),
+        assignmentManagerStub,
+        CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+        fileUri,
+      );
 
       sinon.assert.notCalled(vsCodeStub.window.showQuickPick);
       sinon.assert.calledWith(
@@ -117,7 +129,12 @@ describe('File Commands', () => {
       const fileContent = new Uint8Array([4, 5, 6]);
       vsCodeStub.workspace.fs.readFile.resolves(fileContent);
 
-      await upload(vsCodeStub.asVsCode(), assignmentManagerStub, fileUri);
+      await upload(
+        vsCodeStub.asVsCode(),
+        assignmentManagerStub,
+        CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+        fileUri,
+      );
 
       sinon.assert.calledWith(
         vsCodeStub.workspace.fs.writeFile,
@@ -142,7 +159,12 @@ describe('File Commands', () => {
         .resolves([DEFAULT_SERVER, otherServer]);
       vsCodeStub.window.showQuickPick.resolves(undefined);
 
-      await upload(vsCodeStub.asVsCode(), assignmentManagerStub, fileUri);
+      await upload(
+        vsCodeStub.asVsCode(),
+        assignmentManagerStub,
+        CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+        fileUri,
+      );
 
       sinon.assert.calledOnce(vsCodeStub.window.showQuickPick);
       sinon.assert.notCalled(vsCodeStub.workspace.fs.readFile);
@@ -171,10 +193,13 @@ describe('File Commands', () => {
         );
       });
 
-      await upload(vsCodeStub.asVsCode(), assignmentManagerStub, fileUri, [
+      await upload(
+        vsCodeStub.asVsCode(),
+        assignmentManagerStub,
+        CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
         fileUri,
-        fileUri2,
-      ]);
+        [fileUri, fileUri2],
+      );
 
       sinon.assert.calledWith(
         vsCodeStub.workspace.fs.writeFile,
@@ -230,7 +255,12 @@ describe('File Commands', () => {
         .withArgs(subFileUri)
         .resolves(subContent);
 
-      await upload(vsCodeStub.asVsCode(), assignmentManagerStub, dirUri);
+      await upload(
+        vsCodeStub.asVsCode(),
+        assignmentManagerStub,
+        CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+        dirUri,
+      );
 
       sinon.assert.calledWith(
         vsCodeStub.workspace.fs.createDirectory,
@@ -260,10 +290,13 @@ describe('File Commands', () => {
         .withArgs(badFile)
         .rejects(new Error('Read failed'));
 
-      await upload(vsCodeStub.asVsCode(), assignmentManagerStub, goodFile, [
+      await upload(
+        vsCodeStub.asVsCode(),
+        assignmentManagerStub,
+        CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
         goodFile,
-        badFile,
-      ]);
+        [goodFile, badFile],
+      );
 
       sinon.assert.calledWith(
         vsCodeStub.window.showInformationMessage,
@@ -282,7 +315,12 @@ describe('File Commands', () => {
       const badFile = TestUri.parse('file:///local/bad.txt');
       vsCodeStub.workspace.fs.readFile.rejects(new Error('Fail'));
 
-      await upload(vsCodeStub.asVsCode(), assignmentManagerStub, badFile);
+      await upload(
+        vsCodeStub.asVsCode(),
+        assignmentManagerStub,
+        CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+        badFile,
+      );
 
       sinon.assert.notCalled(vsCodeStub.window.showInformationMessage);
       sinon.assert.calledWith(
@@ -319,7 +357,12 @@ describe('File Commands', () => {
       const fileExistsError = vsCodeStub.FileSystemError.FileExists('Exists');
       vsCodeStub.workspace.fs.createDirectory.rejects(fileExistsError);
 
-      await upload(vsCodeStub.asVsCode(), assignmentManagerStub, dirUri);
+      await upload(
+        vsCodeStub.asVsCode(),
+        assignmentManagerStub,
+        CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+        dirUri,
+      );
 
       sinon.assert.calledWith(
         vsCodeStub.window.showInformationMessage,
@@ -343,12 +386,224 @@ describe('File Commands', () => {
         new Error('Permission denied'),
       );
 
-      await upload(vsCodeStub.asVsCode(), assignmentManagerStub, dirUri);
+      await upload(
+        vsCodeStub.asVsCode(),
+        assignmentManagerStub,
+        CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+        dirUri,
+      );
 
       sinon.assert.calledWith(
         vsCodeStub.window.showErrorMessage,
         'Failed to upload 1 item. Check logs for details.',
       );
+    });
+
+    describe('telemetry', () => {
+      let logStub: SinonStubbedFunction<typeof telemetry.logUpload>;
+
+      beforeEach(() => {
+        logStub = sinon.stub(telemetry, 'logUpload');
+      });
+
+      it('logs OUTCOME_CANCELLED when no servers are assigned', async () => {
+        (assignmentManagerStub.getServers as sinon.SinonStub)
+          .withArgs('extension')
+          .resolves([]);
+
+        await upload(
+          vsCodeStub.asVsCode(),
+          assignmentManagerStub,
+          CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          fileUri,
+        );
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          Outcome.OUTCOME_CANCELLED,
+          {
+            successCount: 0,
+            failCount: 0,
+            fileCount: 0,
+            directoryCount: 0,
+            uploadedBytes: 0,
+          },
+        );
+      });
+
+      it('logs OUTCOME_CANCELLED when the user dismisses the server picker', async () => {
+        const otherServer = {
+          ...DEFAULT_SERVER,
+          id: randomUUID(),
+          endpoint: 'm-s-bar',
+          label: 'bar',
+        };
+        (assignmentManagerStub.getServers as sinon.SinonStub)
+          .withArgs('extension')
+          .resolves([DEFAULT_SERVER, otherServer]);
+        vsCodeStub.window.showQuickPick.resolves(undefined);
+
+        await upload(
+          vsCodeStub.asVsCode(),
+          assignmentManagerStub,
+          CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          fileUri,
+        );
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          Outcome.OUTCOME_CANCELLED,
+          {
+            successCount: 0,
+            failCount: 0,
+            fileCount: 0,
+            directoryCount: 0,
+            uploadedBytes: 0,
+          },
+        );
+      });
+
+      it('logs OUTCOME_SUCCEEDED with counts and bytes for a successful single-file upload', async () => {
+        (assignmentManagerStub.getServers as sinon.SinonStub)
+          .withArgs('extension')
+          .resolves([DEFAULT_SERVER]);
+        const fileContent = new Uint8Array([1, 2, 3, 4, 5]);
+        vsCodeStub.workspace.fs.readFile.resolves(fileContent);
+
+        await upload(
+          vsCodeStub.asVsCode(),
+          assignmentManagerStub,
+          CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          fileUri,
+        );
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          Outcome.OUTCOME_SUCCEEDED,
+          {
+            successCount: 1,
+            failCount: 0,
+            fileCount: 1,
+            directoryCount: 0,
+            uploadedBytes: 5,
+          },
+        );
+      });
+
+      it('logs OUTCOME_PARTIAL_SUCCESS for mixed success and failure', async () => {
+        (assignmentManagerStub.getServers as sinon.SinonStub)
+          .withArgs('extension')
+          .resolves([DEFAULT_SERVER]);
+        const goodFile = TestUri.parse('file:///local/good.txt');
+        const badFile = TestUri.parse('file:///local/bad.txt');
+        vsCodeStub.workspace.fs.readFile
+          .withArgs(goodFile)
+          .resolves(new Uint8Array([1, 2, 3]))
+          .withArgs(badFile)
+          .rejects(new Error('Read failed'));
+
+        await upload(
+          vsCodeStub.asVsCode(),
+          assignmentManagerStub,
+          CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          goodFile,
+          [goodFile, badFile],
+        );
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          Outcome.OUTCOME_PARTIAL_SUCCESS,
+          {
+            successCount: 1,
+            failCount: 1,
+            fileCount: 2,
+            directoryCount: 0,
+            uploadedBytes: 3,
+          },
+        );
+      });
+
+      it('logs OUTCOME_FAILED when every attempted upload fails', async () => {
+        (assignmentManagerStub.getServers as sinon.SinonStub)
+          .withArgs('extension')
+          .resolves([DEFAULT_SERVER]);
+        const badFile = TestUri.parse('file:///local/bad.txt');
+        vsCodeStub.workspace.fs.readFile.rejects(new Error('Read failed'));
+
+        await upload(
+          vsCodeStub.asVsCode(),
+          assignmentManagerStub,
+          CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          badFile,
+        );
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          Outcome.OUTCOME_FAILED,
+          {
+            successCount: 0,
+            failCount: 1,
+            fileCount: 1,
+            directoryCount: 0,
+            uploadedBytes: 0,
+          },
+        );
+      });
+
+      it('logs directory count when uploading a directory', async () => {
+        (assignmentManagerStub.getServers as sinon.SinonStub)
+          .withArgs('extension')
+          .resolves([DEFAULT_SERVER]);
+        const dirUri = TestUri.parse('file:///local/path/to/dir');
+        const subFileUri = TestUri.parse('file:///local/path/to/dir/sub.txt');
+        const subContent = new Uint8Array([9, 9]);
+        vsCodeStub.workspace.fs.stat
+          .withArgs(dirUri)
+          .resolves({
+            type: vsCodeStub.FileType.Directory,
+            ctime: 0,
+            mtime: 0,
+            size: 0,
+          })
+          .withArgs(subFileUri)
+          .resolves({
+            type: vsCodeStub.FileType.File,
+            ctime: 0,
+            mtime: 0,
+            size: 0,
+          });
+        vsCodeStub.workspace.fs.readDirectory
+          .withArgs(dirUri)
+          .resolves([['sub.txt', vsCodeStub.FileType.File]]);
+        vsCodeStub.workspace.fs.readFile
+          .withArgs(subFileUri)
+          .resolves(subContent);
+
+        await upload(
+          vsCodeStub.asVsCode(),
+          assignmentManagerStub,
+          CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          dirUri,
+        );
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          Outcome.OUTCOME_SUCCEEDED,
+          {
+            successCount: 1,
+            failCount: 0,
+            fileCount: 1,
+            directoryCount: 1,
+            uploadedBytes: 2,
+          },
+        );
+      });
     });
   });
 });

--- a/src/colab/commands/register.ts
+++ b/src/colab/commands/register.ts
@@ -90,8 +90,14 @@ export function registerColabCommands(
     registerCommand(
       vs,
       UPLOAD.id,
-      async (uri: vscode.Uri, uris?: vscode.Uri[]) => {
-        await upload(vs, assignmentManager, uri, uris);
+      async (uri: vscode.Uri, uris?: vscode.Uri[], source?: CommandSource) => {
+        await upload(
+          vs,
+          assignmentManager,
+          source ?? CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT,
+          uri,
+          uris,
+        );
       },
     ),
     registerCommand(vs, COLAB_TOOLBAR.id, async () => {

--- a/src/telemetry/api.ts
+++ b/src/telemetry/api.ts
@@ -101,6 +101,10 @@ export type ColabEvent =
   | {
       /** An event representing a click to upgrade to Colab Pro. */
       upgrade_to_pro_event: UpgradeToProEvent;
+    }
+  | {
+      /** An event representing an upload of files or folders to a server. */
+      upload_event: UploadEvent;
     };
 
 /** Enum to represent different command sources/triggers */
@@ -111,12 +115,36 @@ export enum CommandSource {
   COMMAND_SOURCE_COMMAND_PALETTE = 3,
   COMMAND_SOURCE_NOTIFICATION = 4,
   COMMAND_SOURCE_ON_URI = 5,
+  COMMAND_SOURCE_EXPLORER_CONTEXT = 6,
 }
 
 /** Enum to represent different notebook sources */
 export enum NotebookSource {
   NOTEBOOK_SOURCE_UNSPECIFIED = 0,
   NOTEBOOK_SOURCE_DRIVE = 1,
+}
+
+/**
+ * The outcome of a user-initiated operation. Shared across events that have a
+ * success/failure/cancel lifecycle.
+ */
+export enum Outcome {
+  OUTCOME_UNSPECIFIED = 0,
+  /** The operation completed successfully. */
+  OUTCOME_SUCCEEDED = 1,
+  /**
+   * The user cancelled the operation before any work was attempted (e.g.,
+   * dismissed a prompt) or the operation was a no-op.
+   */
+  OUTCOME_CANCELLED = 2,
+  /** The operation was attempted but failed. */
+  OUTCOME_FAILED = 3,
+  /**
+   * The operation was attempted and partially succeeded; some work units
+   * succeeded and some failed. Applicable to events that operate on a batch
+   * of items (e.g., uploads).
+   */
+  OUTCOME_PARTIAL_SUCCESS = 4,
 }
 
 // The authentication flow used for sign in.
@@ -201,6 +229,29 @@ type SignOutEvent = Record<string, never>;
 /** An event representing a click to upgrade to Colab Pro. */
 interface UpgradeToProEvent {
   source: CommandSource;
+}
+
+/** An event representing an upload of files or folders to a Colab server. */
+interface UploadEvent {
+  /** The source of the upload command. */
+  source: CommandSource;
+  /**
+   * The outcome of the upload. `OUTCOME_CANCELLED` covers both the user
+   * dismissing the server picker and there being no servers assigned.
+   * `OUTCOME_PARTIAL_SUCCESS` is used when at least one file uploaded
+   * successfully and at least one other file or directory failed.
+   */
+  outcome: Outcome;
+  /** The number of files that were successfully uploaded. */
+  success_count: number;
+  /** The number of files or directories that failed to upload. */
+  fail_count: number;
+  /** The total number of files (excluding directories) that were attempted. */
+  file_count: number;
+  /** The total number of directories that were attempted. */
+  directory_count: number;
+  /** The total size, in bytes, of all files that were successfully uploaded. */
+  uploaded_bytes: number;
 }
 
 /** The Clearcut log event structure. */

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -16,6 +16,7 @@ import {
   CommandSource,
   AuthFlow,
   NotebookSource,
+  Outcome,
 } from './api';
 import { ClearcutClient } from './client';
 
@@ -127,6 +128,29 @@ export const telemetry = {
   },
   logUpgradeToPro: (source: CommandSource) => {
     log({ upgrade_to_pro_event: { source } });
+  },
+  logUpload: (
+    source: CommandSource,
+    outcome: Outcome,
+    stats: {
+      successCount: number;
+      failCount: number;
+      fileCount: number;
+      directoryCount: number;
+      uploadedBytes: number;
+    },
+  ) => {
+    log({
+      upload_event: {
+        source,
+        outcome,
+        success_count: stats.successCount,
+        fail_count: stats.failCount,
+        file_count: stats.fileCount,
+        directory_count: stats.directoryCount,
+        uploaded_bytes: stats.uploadedBytes,
+      },
+    });
   },
 };
 

--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -17,6 +17,7 @@ import {
   CommandSource,
   AuthFlow,
   NotebookSource,
+  Outcome,
 } from './api';
 import { ClearcutClient } from './client';
 import { initializeTelemetry, telemetry } from '.';
@@ -351,6 +352,31 @@ describe('Telemetry Module', () => {
       sinon.assert.calledOnceWithExactly(logStub, {
         ...baseLog,
         import_notebook_event: { source, notebook_source: notebookSource },
+      });
+    });
+
+    it('logs on upload', () => {
+      const source = CommandSource.COMMAND_SOURCE_EXPLORER_CONTEXT;
+
+      telemetry.logUpload(source, Outcome.OUTCOME_PARTIAL_SUCCESS, {
+        successCount: 3,
+        failCount: 1,
+        fileCount: 4,
+        directoryCount: 2,
+        uploadedBytes: 1024,
+      });
+
+      sinon.assert.calledOnceWithExactly(logStub, {
+        ...baseLog,
+        upload_event: {
+          source,
+          outcome: Outcome.OUTCOME_PARTIAL_SUCCESS,
+          success_count: 3,
+          fail_count: 1,
+          file_count: 4,
+          directory_count: 2,
+          uploaded_bytes: 1024,
+        },
       });
     });
   });


### PR DESCRIPTION
Captures the upload command source, the operation `outcome`, and counts of
successful/failed uploads, attempted files/directories, and total uploaded
bytes. Adds a new `COMMAND_SOURCE_EXPLORER_CONTEXT` enum value to attribute
uploads invoked from the file explorer right-click menu, the only entry point
today.

Adds a top-level `Outcome` enum mirroring the proto, used to distinguish
success, cancellation, full failure, and partial success.

Proto changes: cl/903957584, cl/904046500