### PR TITLE
feat: log telemetry for opening a Colab terminal

### DIFF
--- a/src/colab/commands/notebook.ts
+++ b/src/colab/commands/notebook.ts
@@ -142,6 +142,7 @@ async function getAvailableCommands(
       invoke: () => {
         return vs.commands.executeCommand(
           OPEN_TERMINAL.id,
+          CommandSource.COMMAND_SOURCE_COLAB_TOOLBAR,
           /* withBackButton= */ true,
         );
       },

--- a/src/colab/commands/register.ts
+++ b/src/colab/commands/register.ts
@@ -11,6 +11,7 @@ import { AssignmentManager } from '../../jupyter/assignments';
 import { ContentsFileSystemProvider } from '../../jupyter/contents/file-system';
 import { telemetry } from '../../telemetry';
 import { CommandSource } from '../../telemetry/api';
+import { ContentItem } from '../content-browser/content-item';
 import {
   COLAB_TOOLBAR,
   MOUNT_DRIVE,
@@ -103,8 +104,24 @@ export function registerColabCommands(
     registerCommand(vs, COLAB_TOOLBAR.id, async () => {
       await notebookToolbar(vs, assignmentManager);
     }),
-    registerCommand(vs, OPEN_TERMINAL.id, async (withBackButton?: boolean) => {
-      await openTerminal(vs, assignmentManager, withBackButton);
-    }),
+    registerCommand(
+      vs,
+      OPEN_TERMINAL.id,
+      async (
+        sourceOrContextItem?: CommandSource | ContentItem,
+        withBackButton?: boolean,
+      ) => {
+        // The command can be invoked from the command palette (no args), the
+        // notebook toolbar (passing a CommandSource), or the tree view inline
+        // button (passing a ContentItem as the first argument).
+        const source =
+          typeof sourceOrContextItem === 'number'
+            ? sourceOrContextItem
+            : sourceOrContextItem === undefined
+              ? CommandSource.COMMAND_SOURCE_COMMAND_PALETTE
+              : CommandSource.COMMAND_SOURCE_TREE_VIEW_INLINE;
+        await openTerminal(vs, assignmentManager, source, withBackButton);
+      },
+    ),
   ];
 }

--- a/src/colab/commands/register.unit.test.ts
+++ b/src/colab/commands/register.unit.test.ts
@@ -9,7 +9,10 @@ import * as sinon from 'sinon';
 import { GoogleAuthProvider } from '../../auth/auth-provider';
 import { AssignmentManager } from '../../jupyter/assignments';
 import { ContentsFileSystemProvider } from '../../jupyter/contents/file-system';
+import { telemetry } from '../../telemetry';
+import { CommandSource } from '../../telemetry/api';
 import { newVsCodeStub } from '../../test/helpers/vscode';
+import type { ContentItem } from '../content-browser/content-item';
 import {
   COLAB_TOOLBAR,
   MOUNT_DRIVE,
@@ -52,5 +55,84 @@ describe('registerColabCommands', () => {
       OPEN_TERMINAL.id,
     ]);
     expect(disposables).to.have.lengthOf(registeredIds.length);
+  });
+
+  describe('OPEN_TERMINAL command source discrimination', () => {
+    type OpenTerminalHandler = (
+      sourceOrContextItem?: CommandSource | ContentItem,
+      withBackButton?: boolean,
+    ) => Promise<void>;
+
+    /**
+     * Registers Colab commands and returns the handler bound to
+     * `OPEN_TERMINAL.id`.
+     *
+     * @returns The handler registered for `OPEN_TERMINAL.id`.
+     */
+    function getOpenTerminalHandler(): OpenTerminalHandler {
+      const vs = newVsCodeStub();
+      vs.commands.registerCommand.callsFake(() => ({ dispose: sinon.stub() }));
+      const authProvider = sinon.createStubInstance(GoogleAuthProvider);
+      const assignmentManager = sinon.createStubInstance(AssignmentManager);
+      const fs = sinon.createStubInstance(ContentsFileSystemProvider);
+      // No assigned servers: openTerminal returns early without further
+      // side effects beyond the telemetry call we want to observe.
+      (assignmentManager.getServers as sinon.SinonStub).resolves([]);
+
+      registerColabCommands(vs.asVsCode(), {
+        authProvider,
+        assignmentManager,
+        fs,
+      });
+
+      const call = vs.commands.registerCommand
+        .getCalls()
+        .find((c) => c.args[0] === OPEN_TERMINAL.id);
+      if (!call) {
+        throw new Error('OPEN_TERMINAL command was not registered');
+      }
+      return call.args[1] as OpenTerminalHandler;
+    }
+
+    it('uses the passed CommandSource when invoked from the notebook toolbar', async () => {
+      const logStub = sinon.stub(telemetry, 'logOpenTerminal');
+      const handler = getOpenTerminalHandler();
+
+      await handler(CommandSource.COMMAND_SOURCE_COLAB_TOOLBAR);
+
+      sinon.assert.calledOnceWithExactly(
+        logStub,
+        CommandSource.COMMAND_SOURCE_COLAB_TOOLBAR,
+      );
+    });
+
+    it('uses COMMAND_SOURCE_TREE_VIEW_INLINE when invoked with a ContentItem', async () => {
+      const logStub = sinon.stub(telemetry, 'logOpenTerminal');
+      const handler = getOpenTerminalHandler();
+      // The wrapper discriminates based on the argument's runtime shape; any
+      // non-numeric, non-undefined value takes the tree-view-inline branch.
+      // Avoid constructing a real ContentItem to keep this test free of the
+      // `vscode` runtime dependency.
+      const contextItem = {} as ContentItem;
+
+      await handler(contextItem);
+
+      sinon.assert.calledOnceWithExactly(
+        logStub,
+        CommandSource.COMMAND_SOURCE_TREE_VIEW_INLINE,
+      );
+    });
+
+    it('uses COMMAND_SOURCE_COMMAND_PALETTE when invoked with no arguments', async () => {
+      const logStub = sinon.stub(telemetry, 'logOpenTerminal');
+      const handler = getOpenTerminalHandler();
+
+      await handler();
+
+      sinon.assert.calledOnceWithExactly(
+        logStub,
+        CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
+      );
+    });
   });
 });

--- a/src/colab/commands/terminal.ts
+++ b/src/colab/commands/terminal.ts
@@ -8,6 +8,8 @@ import vscode, { QuickPickItem } from 'vscode';
 import { MultiStepInput } from '../../common/multi-step-quickpick';
 import { AssignmentManager } from '../../jupyter/assignments';
 import { ColabAssignedServer } from '../../jupyter/servers';
+import { telemetry } from '../../telemetry';
+import { CommandSource } from '../../telemetry/api';
 import { ColabPseudoterminal } from '../terminal/colab-pseudoterminal';
 import { ColabTerminalWebSocket } from '../terminal/colab-terminal-websocket';
 import { OPEN_TERMINAL } from './constants';
@@ -21,13 +23,16 @@ import { OPEN_TERMINAL } from './constants';
  *
  * @param vs - The VS Code API instance.
  * @param assignmentManager - The assignment manager instance.
+ * @param source - The source of the open terminal command invocation.
  * @param withBackButton - Whether to show a back button in the UI.
  */
 export async function openTerminal(
   vs: typeof vscode,
   assignmentManager: AssignmentManager,
+  source: CommandSource,
   withBackButton?: boolean,
 ): Promise<void> {
+  telemetry.logOpenTerminal(source);
   const allServers = await assignmentManager.getServers('extension');
 
   if (allServers.length === 0) {

--- a/src/colab/commands/terminal.unit.test.ts
+++ b/src/colab/commands/terminal.unit.test.ts
@@ -5,11 +5,13 @@
  */
 
 import { randomUUID } from 'crypto';
-import sinon, { SinonStubbedInstance } from 'sinon';
+import sinon, { SinonStubbedFunction, SinonStubbedInstance } from 'sinon';
 import { ExtensionTerminalOptions, QuickPick, QuickPickItem } from 'vscode';
 import { Variant } from '../../colab/api';
 import { AssignmentManager } from '../../jupyter/assignments';
 import { ColabAssignedServer } from '../../jupyter/servers';
+import { telemetry } from '../../telemetry';
+import { CommandSource } from '../../telemetry/api';
 import {
   buildQuickPickStub,
   QuickPickStub,
@@ -53,7 +55,11 @@ describe('openTerminal command', () => {
       });
       (assignmentManager.getServers as sinon.SinonStub).resolves([server1]);
 
-      await openTerminal(vsCodeStub.asVsCode(), assignmentManager);
+      await openTerminal(
+        vsCodeStub.asVsCode(),
+        assignmentManager,
+        CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
+      );
 
       sinon.assert.calledWith(
         assignmentManager.getServers as sinon.SinonStub,
@@ -64,7 +70,11 @@ describe('openTerminal command', () => {
     it('shows info message when no servers available', async () => {
       (assignmentManager.getServers as sinon.SinonStub).resolves([]);
 
-      await openTerminal(vsCodeStub.asVsCode(), assignmentManager);
+      await openTerminal(
+        vsCodeStub.asVsCode(),
+        assignmentManager,
+        CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
+      );
 
       sinon.assert.calledOnceWithMatch(
         vsCodeStub.window.showInformationMessage,
@@ -75,7 +85,11 @@ describe('openTerminal command', () => {
     it('does not create terminal when no servers available', async () => {
       (assignmentManager.getServers as sinon.SinonStub).resolves([]);
 
-      await openTerminal(vsCodeStub.asVsCode(), assignmentManager);
+      await openTerminal(
+        vsCodeStub.asVsCode(),
+        assignmentManager,
+        CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
+      );
 
       sinon.assert.notCalled(vsCodeStub.window.createTerminal);
     });
@@ -89,7 +103,11 @@ describe('openTerminal command', () => {
       });
       (assignmentManager.getServers as sinon.SinonStub).resolves([server1]);
 
-      await openTerminal(vsCodeStub.asVsCode(), assignmentManager);
+      await openTerminal(
+        vsCodeStub.asVsCode(),
+        assignmentManager,
+        CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
+      );
 
       sinon.assert.calledOnceWithMatch(
         vsCodeStub.window.createTerminal,
@@ -133,6 +151,7 @@ describe('openTerminal command', () => {
         const openTerminalPromise = openTerminal(
           vsCodeStub.asVsCode(),
           assignmentManager,
+          CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
         );
 
         // Wait for QuickPick to be shown
@@ -153,6 +172,7 @@ describe('openTerminal command', () => {
         const openTerminalPromise = openTerminal(
           vsCodeStub.asVsCode(),
           assignmentManager,
+          CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
         );
         // Wait for QuickPick to be shown
         await quickPickStub.nextShow();
@@ -174,6 +194,65 @@ describe('openTerminal command', () => {
     });
   });
 
+  describe('telemetry', () => {
+    let logStub: SinonStubbedFunction<typeof telemetry.logOpenTerminal>;
+
+    beforeEach(() => {
+      logStub = sinon.stub(telemetry, 'logOpenTerminal');
+    });
+
+    it('logs with the default source when none is provided', async () => {
+      (assignmentManager.getServers as sinon.SinonStub).resolves([]);
+
+      await openTerminal(
+        vsCodeStub.asVsCode(),
+        assignmentManager,
+        CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
+      );
+
+      sinon.assert.calledOnceWithExactly(
+        logStub,
+        CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
+      );
+    });
+
+    it('logs with the provided source', async () => {
+      (assignmentManager.getServers as sinon.SinonStub).resolves([]);
+
+      await openTerminal(
+        vsCodeStub.asVsCode(),
+        assignmentManager,
+        CommandSource.COMMAND_SOURCE_TREE_VIEW_INLINE,
+      );
+
+      sinon.assert.calledOnceWithExactly(
+        logStub,
+        CommandSource.COMMAND_SOURCE_TREE_VIEW_INLINE,
+      );
+    });
+
+    it('logs even when a terminal is opened with the only server', async () => {
+      const server = buildColabAssignedServer({
+        label: 'Server 1',
+        endpoint: 'test-endpoint-1',
+        baseUrl: 'https://server1.example.com',
+        token: 'token1',
+      });
+      (assignmentManager.getServers as sinon.SinonStub).resolves([server]);
+
+      await openTerminal(
+        vsCodeStub.asVsCode(),
+        assignmentManager,
+        CommandSource.COMMAND_SOURCE_COLAB_TOOLBAR,
+      );
+
+      sinon.assert.calledOnceWithExactly(
+        logStub,
+        CommandSource.COMMAND_SOURCE_COLAB_TOOLBAR,
+      );
+    });
+  });
+
   describe('Terminal Creation', () => {
     it('creates terminal with correct name format', async () => {
       const server1 = buildColabAssignedServer({
@@ -184,7 +263,11 @@ describe('openTerminal command', () => {
       });
       (assignmentManager.getServers as sinon.SinonStub).resolves([server1]);
 
-      await openTerminal(vsCodeStub.asVsCode(), assignmentManager);
+      await openTerminal(
+        vsCodeStub.asVsCode(),
+        assignmentManager,
+        CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
+      );
 
       sinon.assert.calledOnceWithMatch(
         vsCodeStub.window.createTerminal,
@@ -210,7 +293,11 @@ describe('openTerminal command', () => {
       const mockTerminal = { show: sinon.stub() };
       vsCodeStub.window.createTerminal.returns(mockTerminal as never);
 
-      await openTerminal(vsCodeStub.asVsCode(), assignmentManager);
+      await openTerminal(
+        vsCodeStub.asVsCode(),
+        assignmentManager,
+        CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
+      );
 
       sinon.assert.calledOnce(mockTerminal.show);
     });

--- a/src/colab/commands/terminal.unit.test.ts
+++ b/src/colab/commands/terminal.unit.test.ts
@@ -201,21 +201,6 @@ describe('openTerminal command', () => {
       logStub = sinon.stub(telemetry, 'logOpenTerminal');
     });
 
-    it('logs with the default source when none is provided', async () => {
-      (assignmentManager.getServers as sinon.SinonStub).resolves([]);
-
-      await openTerminal(
-        vsCodeStub.asVsCode(),
-        assignmentManager,
-        CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
-      );
-
-      sinon.assert.calledOnceWithExactly(
-        logStub,
-        CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
-      );
-    });
-
     it('logs with the provided source', async () => {
       (assignmentManager.getServers as sinon.SinonStub).resolves([]);
 
@@ -228,27 +213,6 @@ describe('openTerminal command', () => {
       sinon.assert.calledOnceWithExactly(
         logStub,
         CommandSource.COMMAND_SOURCE_TREE_VIEW_INLINE,
-      );
-    });
-
-    it('logs even when a terminal is opened with the only server', async () => {
-      const server = buildColabAssignedServer({
-        label: 'Server 1',
-        endpoint: 'test-endpoint-1',
-        baseUrl: 'https://server1.example.com',
-        token: 'token1',
-      });
-      (assignmentManager.getServers as sinon.SinonStub).resolves([server]);
-
-      await openTerminal(
-        vsCodeStub.asVsCode(),
-        assignmentManager,
-        CommandSource.COMMAND_SOURCE_COLAB_TOOLBAR,
-      );
-
-      sinon.assert.calledOnceWithExactly(
-        logStub,
-        CommandSource.COMMAND_SOURCE_COLAB_TOOLBAR,
       );
     });
   });

--- a/src/telemetry/api.ts
+++ b/src/telemetry/api.ts
@@ -83,6 +83,10 @@ export type ColabEvent =
       open_colab_web_event: OpenColabWebEvent;
     }
   | {
+      /** An event representing opening a terminal connected to a Colab server. */
+      open_terminal_event: OpenTerminalEvent;
+    }
+  | {
       /** An event that logs when servers are pruned */
       prune_servers_event: PruneServersEvent;
     }
@@ -116,6 +120,7 @@ export enum CommandSource {
   COMMAND_SOURCE_NOTIFICATION = 4,
   COMMAND_SOURCE_ON_URI = 5,
   COMMAND_SOURCE_EXPLORER_CONTEXT = 6,
+  COMMAND_SOURCE_TREE_VIEW_INLINE = 7,
 }
 
 /** Enum to represent different notebook sources */
@@ -202,6 +207,11 @@ interface MountServerEvent {
 
 /** An event representing a click to open Colab web. */
 interface OpenColabWebEvent {
+  source: CommandSource;
+}
+
+/** An event representing opening a terminal connected to a Colab server. */
+interface OpenTerminalEvent {
   source: CommandSource;
 }
 

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -110,6 +110,9 @@ export const telemetry = {
   logOpenColabWeb: (source: CommandSource) => {
     log({ open_colab_web_event: { source } });
   },
+  logOpenTerminal: (source: CommandSource) => {
+    log({ open_terminal_event: { source } });
+  },
   logPruneServers: (servers: string[]) => {
     log({ prune_servers_event: { servers } });
   },

--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -321,6 +321,17 @@ describe('Telemetry Module', () => {
       });
     });
 
+    it('logs on open terminal', () => {
+      const source = CommandSource.COMMAND_SOURCE_TREE_VIEW_INLINE;
+
+      telemetry.logOpenTerminal(source);
+
+      sinon.assert.calledOnceWithExactly(logStub, {
+        ...baseLog,
+        open_terminal_event: { source },
+      });
+    });
+
     it('logs on upgrade to pro', () => {
       const source = CommandSource.COMMAND_SOURCE_COLAB_TOOLBAR;
 


### PR DESCRIPTION
Captures the source (command palette, notebook toolbar, or tree view inline
button) for every `Open Terminal` invocation. Adds a new
`COMMAND_SOURCE_TREE_VIEW_INLINE` enum value to attribute commands invoked from
inline buttons in the activity bar tree views.

The `OPEN_TERMINAL` command handler can now be invoked with either a
`CommandSource` (when invoked programmatically from the notebook toolbar) or a
`ContentItem` (when invoked from the tree view inline button); the handler
discriminates between the two and falls back to
`COMMAND_SOURCE_COMMAND_PALETTE` when neither is provided.

Proto changes: cl/903967220