### PR TITLE
feat: log telemetry for content browser file operations

### DIFF
--- a/src/colab/content-browser/commands.ts
+++ b/src/colab/content-browser/commands.ts
@@ -194,7 +194,7 @@ export async function renameFile(vs: typeof vscode, contextItem: ContentItem) {
     telemetry.logContentBrowserFileOperation(
       ContentBrowserOperation.OPERATION_RENAME,
       outcome,
-      contentItemTarget(vs, contextItem),
+      contentItemToTarget(vs, contextItem),
     );
   }
 }
@@ -231,7 +231,7 @@ export async function deleteFile(vs: typeof vscode, contextItem: ContentItem) {
     telemetry.logContentBrowserFileOperation(
       ContentBrowserOperation.OPERATION_DELETE,
       outcome,
-      contentItemTarget(vs, contextItem),
+      contentItemToTarget(vs, contextItem),
     );
   }
 }
@@ -270,7 +270,7 @@ function folderOrParent(vs: typeof vscode, item: ContentItem): Uri {
     : item.uri;
 }
 
-function contentItemTarget(
+function contentItemToTarget(
   vs: typeof vscode,
   item: ContentItem,
 ): ContentBrowserTarget {

--- a/src/colab/content-browser/commands.ts
+++ b/src/colab/content-browser/commands.ts
@@ -5,6 +5,12 @@
  */
 
 import vscode, { Uri } from 'vscode';
+import { telemetry } from '../../telemetry';
+import {
+  ContentBrowserOperation,
+  ContentBrowserTarget,
+  Outcome,
+} from '../../telemetry/api';
 import type { ContentItem } from './content-item';
 
 /**
@@ -18,29 +24,45 @@ import type { ContentItem } from './content-item';
  * @param contextItem - The tree view context item.
  */
 export async function newFile(vs: typeof vscode, contextItem: ContentItem) {
-  const destination = folderOrParent(vs, contextItem);
-  const name = await vs.window.showInputBox({
-    title: 'New File',
-    prompt: 'Enter the file name',
-    validateInput: (value) => validateFileOrFolder(vs, destination, value),
-  });
-  if (!name) {
-    return;
-  }
-  const uri = vs.Uri.joinPath(destination, name);
-  const isFolder = name.endsWith('/');
+  let outcome = Outcome.OUTCOME_CANCELLED;
+  let target = ContentBrowserTarget.TARGET_FILE;
   try {
-    if (isFolder) {
-      await vs.workspace.fs.createDirectory(uri);
+    const destination = folderOrParent(vs, contextItem);
+    const name = await vs.window.showInputBox({
+      title: 'New File',
+      prompt: 'Enter the file name',
+      validateInput: (value) => validateFileOrFolder(vs, destination, value),
+    });
+    if (!name) {
       return;
     }
-    await vs.workspace.fs.writeFile(uri, new Uint8Array());
-    await vs.commands.executeCommand('vscode.open', uri);
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : 'unknown error';
-    const type = isFolder ? 'folder' : 'file';
-    void vs.window.showErrorMessage(
-      `Failed to create ${type} "${name}": ${msg}`,
+    const uri = vs.Uri.joinPath(destination, name);
+    const isDirectory = name.endsWith('/');
+    target = isDirectory
+      ? ContentBrowserTarget.TARGET_DIRECTORY
+      : ContentBrowserTarget.TARGET_FILE;
+    try {
+      if (isDirectory) {
+        await vs.workspace.fs.createDirectory(uri);
+        outcome = Outcome.OUTCOME_SUCCEEDED;
+        return;
+      }
+      await vs.workspace.fs.writeFile(uri, new Uint8Array());
+      await vs.commands.executeCommand('vscode.open', uri);
+      outcome = Outcome.OUTCOME_SUCCEEDED;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'unknown error';
+      const type = isDirectory ? 'folder' : 'file';
+      void vs.window.showErrorMessage(
+        `Failed to create ${type} "${name}": ${msg}`,
+      );
+      outcome = Outcome.OUTCOME_FAILED;
+    }
+  } finally {
+    telemetry.logContentBrowserFileOperation(
+      ContentBrowserOperation.OPERATION_NEW_FILE,
+      outcome,
+      target,
     );
   }
 }
@@ -54,22 +76,33 @@ export async function newFile(vs: typeof vscode, contextItem: ContentItem) {
  * @param contextItem - The tree view context item.
  */
 export async function newFolder(vs: typeof vscode, contextItem: ContentItem) {
-  const destination = folderOrParent(vs, contextItem);
-  const name = await vs.window.showInputBox({
-    title: 'New Folder',
-    prompt: 'Enter the folder name',
-    validateInput: (value) => validateFileOrFolder(vs, destination, value),
-  });
-  if (!name) {
-    return;
-  }
-  const uri = vs.Uri.joinPath(destination, name);
+  let outcome = Outcome.OUTCOME_CANCELLED;
   try {
-    await vs.workspace.fs.createDirectory(uri);
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : 'unknown error';
-    void vs.window.showErrorMessage(
-      `Failed to create folder "${name}": ${msg}`,
+    const destination = folderOrParent(vs, contextItem);
+    const name = await vs.window.showInputBox({
+      title: 'New Folder',
+      prompt: 'Enter the folder name',
+      validateInput: (value) => validateFileOrFolder(vs, destination, value),
+    });
+    if (!name) {
+      return;
+    }
+    const uri = vs.Uri.joinPath(destination, name);
+    try {
+      await vs.workspace.fs.createDirectory(uri);
+      outcome = Outcome.OUTCOME_SUCCEEDED;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'unknown error';
+      void vs.window.showErrorMessage(
+        `Failed to create folder "${name}": ${msg}`,
+      );
+      outcome = Outcome.OUTCOME_FAILED;
+    }
+  } finally {
+    telemetry.logContentBrowserFileOperation(
+      ContentBrowserOperation.OPERATION_NEW_FOLDER,
+      outcome,
+      ContentBrowserTarget.TARGET_DIRECTORY,
     );
   }
 }
@@ -123,32 +156,45 @@ export async function download(vs: typeof vscode, contextItem: ContentItem) {
  */
 // TODO: Look into preserving expanded state of renamed folders.
 export async function renameFile(vs: typeof vscode, contextItem: ContentItem) {
-  const oldName = contextItem.uri.path.split('/').pop() ?? '';
-  const destination = vs.Uri.joinPath(contextItem.uri, '..');
-
-  const newName = await vs.window.showInputBox({
-    title: 'Rename',
-    prompt: 'Enter the new name',
-    value: oldName,
-    validateInput: async (value) => {
-      if (value === oldName) {
-        return undefined;
-      }
-      return validateFileOrFolder(vs, destination, value);
-    },
-  });
-
-  if (!newName || newName === oldName) {
-    return;
-  }
-
-  const newUri = vs.Uri.joinPath(destination, newName);
+  let outcome = Outcome.OUTCOME_CANCELLED;
   try {
-    await vs.workspace.fs.rename(contextItem.uri, newUri, { overwrite: false });
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : 'unknown error';
-    void vs.window.showErrorMessage(
-      `Failed to rename "${oldName}" to "${newName}": ${msg}`,
+    const oldName = contextItem.uri.path.split('/').pop() ?? '';
+    const destination = vs.Uri.joinPath(contextItem.uri, '..');
+
+    const newName = await vs.window.showInputBox({
+      title: 'Rename',
+      prompt: 'Enter the new name',
+      value: oldName,
+      validateInput: async (value) => {
+        if (value === oldName) {
+          return undefined;
+        }
+        return validateFileOrFolder(vs, destination, value);
+      },
+    });
+
+    if (!newName || newName === oldName) {
+      return;
+    }
+
+    const newUri = vs.Uri.joinPath(destination, newName);
+    try {
+      await vs.workspace.fs.rename(contextItem.uri, newUri, {
+        overwrite: false,
+      });
+      outcome = Outcome.OUTCOME_SUCCEEDED;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'unknown error';
+      void vs.window.showErrorMessage(
+        `Failed to rename "${oldName}" to "${newName}": ${msg}`,
+      );
+      outcome = Outcome.OUTCOME_FAILED;
+    }
+  } finally {
+    telemetry.logContentBrowserFileOperation(
+      ContentBrowserOperation.OPERATION_RENAME,
+      outcome,
+      contentItemTarget(vs, contextItem),
     );
   }
 }
@@ -160,22 +206,33 @@ export async function renameFile(vs: typeof vscode, contextItem: ContentItem) {
  * @param contextItem - The tree view context item.
  */
 export async function deleteFile(vs: typeof vscode, contextItem: ContentItem) {
-  const name = contextItem.uri.path.split('/').pop() ?? '';
-  const confirmation = await vs.window.showWarningMessage(
-    `Are you sure you want to delete "${name}"?`,
-    { modal: true },
-    'Delete',
-  );
-
-  if (confirmation !== 'Delete') {
-    return;
-  }
-
+  let outcome = Outcome.OUTCOME_CANCELLED;
   try {
-    await vs.workspace.fs.delete(contextItem.uri, { recursive: true });
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : 'unknown error';
-    void vs.window.showErrorMessage(`Failed to delete "${name}": ${msg}`);
+    const name = contextItem.uri.path.split('/').pop() ?? '';
+    const confirmation = await vs.window.showWarningMessage(
+      `Are you sure you want to delete "${name}"?`,
+      { modal: true },
+      'Delete',
+    );
+
+    if (confirmation !== 'Delete') {
+      return;
+    }
+
+    try {
+      await vs.workspace.fs.delete(contextItem.uri, { recursive: true });
+      outcome = Outcome.OUTCOME_SUCCEEDED;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'unknown error';
+      void vs.window.showErrorMessage(`Failed to delete "${name}": ${msg}`);
+      outcome = Outcome.OUTCOME_FAILED;
+    }
+  } finally {
+    telemetry.logContentBrowserFileOperation(
+      ContentBrowserOperation.OPERATION_DELETE,
+      outcome,
+      contentItemTarget(vs, contextItem),
+    );
   }
 }
 
@@ -211,4 +268,13 @@ function folderOrParent(vs: typeof vscode, item: ContentItem): Uri {
   return item.contextValue === 'file'
     ? vs.Uri.joinPath(item.uri, '..')
     : item.uri;
+}
+
+function contentItemTarget(
+  vs: typeof vscode,
+  item: ContentItem,
+): ContentBrowserTarget {
+  return item.type === vs.FileType.Directory
+    ? ContentBrowserTarget.TARGET_DIRECTORY
+    : ContentBrowserTarget.TARGET_FILE;
 }

--- a/src/colab/content-browser/commands.unit.test.ts
+++ b/src/colab/content-browser/commands.unit.test.ts
@@ -5,9 +5,15 @@
  */
 
 import { assert, expect } from 'chai';
-import sinon from 'sinon';
+import sinon, { SinonStubbedFunction } from 'sinon';
 import type vscode from 'vscode';
 import { FileStat } from 'vscode';
+import { telemetry } from '../../telemetry';
+import {
+  ContentBrowserOperation,
+  ContentBrowserTarget,
+  Outcome,
+} from '../../telemetry/api';
 import { TestFileSystemError } from '../../test/helpers/errors';
 import { TestUri } from '../../test/helpers/uri';
 import { FileType, newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
@@ -380,6 +386,268 @@ describe('Server Browser Commands', () => {
         vsStub.window.showErrorMessage,
         'Failed to delete "foo.txt": fail',
       );
+    });
+  });
+
+  describe('telemetry', () => {
+    let logStub: SinonStubbedFunction<
+      typeof telemetry.logContentBrowserFileOperation
+    >;
+
+    beforeEach(() => {
+      logStub = sinon.stub(telemetry, 'logContentBrowserFileOperation');
+    });
+
+    afterEach(() => {
+      logStub.restore();
+    });
+
+    describe('newFile', () => {
+      it('logs OUTCOME_SUCCEEDED with TARGET_FILE when a file is created', async () => {
+        vsStub.window.showInputBox.resolves('new-file.txt');
+        vsStub.workspace.fs.stat.rejects(TestFileSystemError.FileNotFound());
+
+        await newFile(vs, CONTENT_ROOT);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_NEW_FILE,
+          Outcome.OUTCOME_SUCCEEDED,
+          ContentBrowserTarget.TARGET_FILE,
+        );
+      });
+
+      it('logs TARGET_DIRECTORY when name ends with /', async () => {
+        vsStub.window.showInputBox.resolves('new-folder/');
+        vsStub.workspace.fs.stat.rejects(TestFileSystemError.FileNotFound());
+
+        await newFile(vs, CONTENT_ROOT);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_NEW_FILE,
+          Outcome.OUTCOME_SUCCEEDED,
+          ContentBrowserTarget.TARGET_DIRECTORY,
+        );
+      });
+
+      it('logs OUTCOME_CANCELLED when input is dismissed', async () => {
+        vsStub.window.showInputBox.resolves(undefined);
+
+        await newFile(vs, CONTENT_ROOT);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_NEW_FILE,
+          Outcome.OUTCOME_CANCELLED,
+          ContentBrowserTarget.TARGET_FILE,
+        );
+      });
+
+      it('logs OUTCOME_FAILED when writeFile rejects', async () => {
+        vsStub.window.showInputBox.resolves('new-file.txt');
+        vsStub.workspace.fs.stat.rejects(TestFileSystemError.FileNotFound());
+        vsStub.workspace.fs.writeFile.rejects(new Error('fail'));
+
+        await newFile(vs, CONTENT_ROOT);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_NEW_FILE,
+          Outcome.OUTCOME_FAILED,
+          ContentBrowserTarget.TARGET_FILE,
+        );
+      });
+    });
+
+    describe('newFolder', () => {
+      it('logs OUTCOME_SUCCEEDED when a folder is created', async () => {
+        vsStub.window.showInputBox.resolves('new-folder');
+        vsStub.workspace.fs.stat.rejects(TestFileSystemError.FileNotFound());
+
+        await newFolder(vs, CONTENT_ROOT);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_NEW_FOLDER,
+          Outcome.OUTCOME_SUCCEEDED,
+          ContentBrowserTarget.TARGET_DIRECTORY,
+        );
+      });
+
+      it('logs OUTCOME_CANCELLED when input is dismissed', async () => {
+        vsStub.window.showInputBox.resolves(undefined);
+
+        await newFolder(vs, CONTENT_ROOT);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_NEW_FOLDER,
+          Outcome.OUTCOME_CANCELLED,
+          ContentBrowserTarget.TARGET_DIRECTORY,
+        );
+      });
+
+      it('logs OUTCOME_FAILED when createDirectory rejects', async () => {
+        vsStub.window.showInputBox.resolves('new-folder');
+        vsStub.workspace.fs.stat.rejects(TestFileSystemError.FileNotFound());
+        vsStub.workspace.fs.createDirectory.rejects(new Error('fail'));
+
+        await newFolder(vs, CONTENT_ROOT);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_NEW_FOLDER,
+          Outcome.OUTCOME_FAILED,
+          ContentBrowserTarget.TARGET_DIRECTORY,
+        );
+      });
+    });
+
+    describe('renameFile', () => {
+      it('logs OUTCOME_SUCCEEDED when a file is renamed', async () => {
+        vsStub.window.showInputBox.resolves('renamed.txt');
+        vsStub.workspace.fs.stat.rejects(TestFileSystemError.FileNotFound());
+
+        await renameFile(vs, FILE_ITEM);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_RENAME,
+          Outcome.OUTCOME_SUCCEEDED,
+          ContentBrowserTarget.TARGET_FILE,
+        );
+      });
+
+      it('logs OUTCOME_CANCELLED when input is dismissed', async () => {
+        vsStub.window.showInputBox.resolves(undefined);
+
+        await renameFile(vs, FILE_ITEM);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_RENAME,
+          Outcome.OUTCOME_CANCELLED,
+          ContentBrowserTarget.TARGET_FILE,
+        );
+      });
+
+      it('logs OUTCOME_CANCELLED when name is unchanged', async () => {
+        vsStub.window.showInputBox.resolves('foo.txt');
+
+        await renameFile(vs, FILE_ITEM);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_RENAME,
+          Outcome.OUTCOME_CANCELLED,
+          ContentBrowserTarget.TARGET_FILE,
+        );
+      });
+
+      it('logs OUTCOME_FAILED when rename rejects', async () => {
+        vsStub.window.showInputBox.resolves('renamed.txt');
+        vsStub.workspace.fs.stat.rejects(TestFileSystemError.FileNotFound());
+        vsStub.workspace.fs.rename.rejects(new Error('fail'));
+
+        await renameFile(vs, FILE_ITEM);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_RENAME,
+          Outcome.OUTCOME_FAILED,
+          ContentBrowserTarget.TARGET_FILE,
+        );
+      });
+
+      it('logs TARGET_DIRECTORY when renaming a folder', async () => {
+        const folderItem = buildContentItem(
+          'folder',
+          'colab://m-s-foo/content/some-folder',
+        );
+        vsStub.window.showInputBox.resolves('renamed-folder');
+        vsStub.workspace.fs.stat.rejects(TestFileSystemError.FileNotFound());
+
+        await renameFile(vs, folderItem);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_RENAME,
+          Outcome.OUTCOME_SUCCEEDED,
+          ContentBrowserTarget.TARGET_DIRECTORY,
+        );
+      });
+    });
+
+    describe('deleteFile', () => {
+      it('logs OUTCOME_SUCCEEDED when a file is deleted', async () => {
+        // Cast necessary due to overloading.
+        (vsStub.window.showWarningMessage as sinon.SinonStub).resolves(
+          'Delete',
+        );
+
+        await deleteFile(vs, FILE_ITEM);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_DELETE,
+          Outcome.OUTCOME_SUCCEEDED,
+          ContentBrowserTarget.TARGET_FILE,
+        );
+      });
+
+      it('logs OUTCOME_CANCELLED when confirmation is declined', async () => {
+        // Cast necessary due to overloading.
+        (vsStub.window.showWarningMessage as sinon.SinonStub).resolves(
+          undefined,
+        );
+
+        await deleteFile(vs, FILE_ITEM);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_DELETE,
+          Outcome.OUTCOME_CANCELLED,
+          ContentBrowserTarget.TARGET_FILE,
+        );
+      });
+
+      it('logs OUTCOME_FAILED when delete rejects', async () => {
+        // Cast necessary due to overloading.
+        (vsStub.window.showWarningMessage as sinon.SinonStub).resolves(
+          'Delete',
+        );
+        vsStub.workspace.fs.delete.rejects(new Error('fail'));
+
+        await deleteFile(vs, FILE_ITEM);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_DELETE,
+          Outcome.OUTCOME_FAILED,
+          ContentBrowserTarget.TARGET_FILE,
+        );
+      });
+
+      it('logs TARGET_DIRECTORY when deleting a folder', async () => {
+        const folderItem = buildContentItem(
+          'folder',
+          'colab://m-s-foo/content/some-folder',
+        );
+        // Cast necessary due to overloading.
+        (vsStub.window.showWarningMessage as sinon.SinonStub).resolves(
+          'Delete',
+        );
+
+        await deleteFile(vs, folderItem);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          ContentBrowserOperation.OPERATION_DELETE,
+          Outcome.OUTCOME_SUCCEEDED,
+          ContentBrowserTarget.TARGET_DIRECTORY,
+        );
+      });
     });
   });
 });

--- a/src/colab/content-browser/commands.unit.test.ts
+++ b/src/colab/content-browser/commands.unit.test.ts
@@ -403,33 +403,33 @@ describe('Server Browser Commands', () => {
     });
 
     describe('newFile', () => {
-      it('logs OUTCOME_SUCCEEDED with TARGET_FILE when a file is created', async () => {
-        vsStub.window.showInputBox.resolves('new-file.txt');
-        vsStub.workspace.fs.stat.rejects(TestFileSystemError.FileNotFound());
+      const successCases = [
+        {
+          name: 'new-file.txt',
+          target: ContentBrowserTarget.TARGET_FILE,
+          targetLabel: 'TARGET_FILE',
+        },
+        {
+          name: 'new-folder/',
+          target: ContentBrowserTarget.TARGET_DIRECTORY,
+          targetLabel: 'TARGET_DIRECTORY',
+        },
+      ];
+      for (const { name, target, targetLabel } of successCases) {
+        it(`logs OUTCOME_SUCCEEDED with ${targetLabel} when name is "${name}"`, async () => {
+          vsStub.window.showInputBox.resolves(name);
+          vsStub.workspace.fs.stat.rejects(TestFileSystemError.FileNotFound());
 
-        await newFile(vs, CONTENT_ROOT);
+          await newFile(vs, CONTENT_ROOT);
 
-        sinon.assert.calledOnceWithExactly(
-          logStub,
-          ContentBrowserOperation.OPERATION_NEW_FILE,
-          Outcome.OUTCOME_SUCCEEDED,
-          ContentBrowserTarget.TARGET_FILE,
-        );
-      });
-
-      it('logs TARGET_DIRECTORY when name ends with /', async () => {
-        vsStub.window.showInputBox.resolves('new-folder/');
-        vsStub.workspace.fs.stat.rejects(TestFileSystemError.FileNotFound());
-
-        await newFile(vs, CONTENT_ROOT);
-
-        sinon.assert.calledOnceWithExactly(
-          logStub,
-          ContentBrowserOperation.OPERATION_NEW_FILE,
-          Outcome.OUTCOME_SUCCEEDED,
-          ContentBrowserTarget.TARGET_DIRECTORY,
-        );
-      });
+          sinon.assert.calledOnceWithExactly(
+            logStub,
+            ContentBrowserOperation.OPERATION_NEW_FILE,
+            Outcome.OUTCOME_SUCCEEDED,
+            target,
+          );
+        });
+      }
 
       it('logs OUTCOME_CANCELLED when input is dismissed', async () => {
         vsStub.window.showInputBox.resolves(undefined);

--- a/src/telemetry/api.ts
+++ b/src/telemetry/api.ts
@@ -59,6 +59,10 @@ export type ColabEvent =
       colab_toolbar_event: ColabToolbarEvent;
     }
   | {
+      /** An event representing a content browser file or folder operation. */
+      content_browser_file_operation_event: ContentBrowserFileOperationEvent;
+    }
+  | {
       /** An event representing an error. */
       error_event: ErrorEvent;
     }
@@ -152,6 +156,22 @@ export enum Outcome {
   OUTCOME_PARTIAL_SUCCESS = 4,
 }
 
+/** The kind of file operation performed in the content browser tree view. */
+export enum ContentBrowserOperation {
+  OPERATION_UNSPECIFIED = 0,
+  OPERATION_NEW_FILE = 1,
+  OPERATION_NEW_FOLDER = 2,
+  OPERATION_RENAME = 3,
+  OPERATION_DELETE = 4,
+}
+
+/** The kind of target a content browser file operation was performed on. */
+export enum ContentBrowserTarget {
+  TARGET_UNSPECIFIED = 0,
+  TARGET_FILE = 1,
+  TARGET_DIRECTORY = 2,
+}
+
 // The authentication flow used for sign in.
 export enum AuthFlow {
   AUTH_FLOW_UNSPECIFIED = 0,
@@ -172,6 +192,25 @@ type AutoConnectEvent = Record<string, never>;
 
 /** An event representing a Colab toolbar click. */
 type ColabToolbarEvent = Record<string, never>;
+
+/** An event representing a content browser file or folder operation. */
+interface ContentBrowserFileOperationEvent {
+  /** The kind of file operation that was attempted. */
+  operation: ContentBrowserOperation;
+  /**
+   * The outcome of the operation. `OUTCOME_CANCELLED` covers both the user
+   * dismissing the input box and declining the delete confirmation.
+   */
+  outcome: Outcome;
+  /**
+   * The kind of target the operation was performed on. For
+   * `OPERATION_NEW_FOLDER` this is always `TARGET_DIRECTORY`. For
+   * `OPERATION_NEW_FILE` it reflects whether the user typed a trailing slash
+   * to create a folder instead. For `OPERATION_RENAME` and
+   * `OPERATION_DELETE` it reflects the actual target type.
+   */
+  target: ContentBrowserTarget;
+}
 
 /** An event representing an error. */
 interface ErrorEvent {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -15,6 +15,8 @@ import {
   ColabEvent,
   CommandSource,
   AuthFlow,
+  ContentBrowserOperation,
+  ContentBrowserTarget,
   NotebookSource,
   Outcome,
 } from './api';
@@ -79,6 +81,15 @@ export const telemetry = {
   },
   logColabToolbar: () => {
     log({ colab_toolbar_event: {} });
+  },
+  logContentBrowserFileOperation: (
+    operation: ContentBrowserOperation,
+    outcome: Outcome,
+    target: ContentBrowserTarget,
+  ) => {
+    log({
+      content_browser_file_operation_event: { operation, outcome, target },
+    });
   },
   logError: (e: unknown) => {
     if (e instanceof Error) {

--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -16,6 +16,8 @@ import {
   ColabLogEventBase,
   CommandSource,
   AuthFlow,
+  ContentBrowserOperation,
+  ContentBrowserTarget,
   NotebookSource,
   Outcome,
 } from './api';
@@ -273,6 +275,23 @@ describe('Telemetry Module', () => {
       sinon.assert.calledOnceWithExactly(logStub, {
         ...baseLog,
         colab_toolbar_event: {},
+      });
+    });
+
+    it('logs on content browser file operation', () => {
+      telemetry.logContentBrowserFileOperation(
+        ContentBrowserOperation.OPERATION_DELETE,
+        Outcome.OUTCOME_SUCCEEDED,
+        ContentBrowserTarget.TARGET_DIRECTORY,
+      );
+
+      sinon.assert.calledOnceWithExactly(logStub, {
+        ...baseLog,
+        content_browser_file_operation_event: {
+          operation: ContentBrowserOperation.OPERATION_DELETE,
+          outcome: Outcome.OUTCOME_SUCCEEDED,
+          target: ContentBrowserTarget.TARGET_DIRECTORY,
+        },
       });
     });
 


### PR DESCRIPTION
Captures the kind of `Operation` (`OPERATION_NEW_FILE`, `OPERATION_NEW_FOLDER`,
`OPERATION_RENAME`, `OPERATION_DELETE`), the operation `outcome`, and the
`Target` (file or directory). This covers all four Colab content browser tree
view file commands: `colab.newFile`, `colab.newFolder`, `colab.renameFile`, and
`colab.deleteFile`.

A single event with an `Operation` enum keeps both the proto and the production
code compact while still supporting per-operation breakdowns downstream.

Also adds top-level `Outcome`, `ContentBrowserOperation`, and
`ContentBrowserTarget` enums mirroring the proto.

Proto changes: cl/903971078, cl/904046500