### PR TITLE
chore: upgrade actions node24

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         # Assuming node version is provided via env var in the workflow
         node-version: ${{ env.NODE_VERSION }}
@@ -25,19 +25,19 @@ runs:
       shell: bash
     - name: upload screenshots
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: screenshots
         path: /tmp/test-resources/screenshots/
     - name: upload exthost.log
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: exthost_log
         path: /tmp/test-resources/settings/logs/*/window1/exthost/exthost.log
     - name: upload output logs
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: output_logs
         path: /tmp/test-resources/settings/logs/*/window1/exthost/output_logging_*/

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,9 +35,9 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
@@ -49,7 +49,7 @@ jobs:
           COLAB_EXTENSION_CLIENT_ID: "client-id"
           COLAB_EXTENSION_CLIENT_NOT_SO_SECRET: "client-not-so-secret"
       - name: Upload generated config
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: generated-config
           path: src/colab-config.ts
@@ -60,15 +60,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: generateConfig
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
       - run: npm ci
       - name: Download generated config
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: generated-config
           path: src
@@ -86,15 +86,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: generateConfig
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
       - run: npm ci
       - name: Download generated config
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: generated-config
           path: src
@@ -110,15 +110,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: generateConfig
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
       - run: npm ci
       - name: Download generated config
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: generated-config
           path: src
@@ -156,7 +156,7 @@ jobs:
       # Must checkout before running the composite action since it relies on the
       # code being present. Only do this for same-repository PRs invocations.
       - if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run E2E Tests (Same Repository)
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: ./.github/actions/run-e2e


### PR DESCRIPTION
Changes:

- actions/checkout@v4 → @v6
- actions/setup-node@v4 → @v6
- actions/upload-artifact@v4 → @v7
- actions/download-artifact@v4 → @v8

All of these majors run on Node.js 24, which addresses the deprecation notice.

[CI verification](https://github.com/googlecolab/colab-vscode/actions/runs/24905482360)