### PR TITLE
test: add e2e test for Upload to Colab from explorer context menu

### DIFF
--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -125,14 +125,24 @@ build_test_cmd() {
 
   base_cmd+=("-o" "./out/test/test/e2e/settings.json")
   base_cmd+=("-m" "./out/test/test/e2e/mocharc.js")
+  # Open a fixture workspace folder so e2e tests have a populated Explorer.
+  # Referenced from the source tree because the build does not copy .txt files
+  # into out/.
+  base_cmd+=("-r" "./src/test/e2e/fixtures/workspace")
 
   # Print each part of the command on a new line.
   printf "%s\n" "${base_cmd[@]}"
+  # The `--` separator terminates the variadic `-r` option and ensures
+  # subsequent paths are parsed as positional `testFiles` arguments.
+  printf "%s\n" "--"
   printf "%s\n" ./out/test/test/e2e/test-setup.js
   printf "%s\n" ./out/test/**/*.e2e.test.js
 
   if [[ ${#AUTH_DRIVER_ARGS[@]} -gt 0 ]]; then
-    printf "%s\n" "--"
+    # No `--` separator needed here: the one above (after `-r`) already
+    # terminated extest option parsing, so auth-driver args trail the test
+    # files as additional positional args. They are not consumed by
+    # commander; `auth.ts` reads them out of `process.argv` directly.
     printf "%s\n" "${AUTH_DRIVER_ARGS[@]}"
   fi
 }

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -139,10 +139,6 @@ build_test_cmd() {
   printf "%s\n" ./out/test/**/*.e2e.test.js
 
   if [[ ${#AUTH_DRIVER_ARGS[@]} -gt 0 ]]; then
-    # No `--` separator needed here: the one above (after `-r`) already
-    # terminated extest option parsing, so auth-driver args trail the test
-    # files as additional positional args. They are not consumed by
-    # commander; `auth.ts` reads them out of `process.argv` directly.
     printf "%s\n" "${AUTH_DRIVER_ARGS[@]}"
   fi
 }

--- a/src/test/e2e/fixtures/workspace/hello-world.txt
+++ b/src/test/e2e/fixtures/workspace/hello-world.txt
@@ -1,0 +1,1 @@
+Hello world!

--- a/src/test/e2e/test-setup.ts
+++ b/src/test/e2e/test-setup.ts
@@ -10,6 +10,7 @@ import { assert } from 'chai';
 import clipboard from 'clipboardy';
 import dotenv from 'dotenv';
 import { VSBrowser, WebDriver, Workbench } from 'vscode-extension-tester';
+import { CodeUtil } from 'vscode-extension-tester/out/util/codeUtil';
 import { CONFIG } from '../../colab-config';
 import { doOAuthSignIn, getOAuthDriver } from './auth';
 import {
@@ -23,6 +24,23 @@ import {
 } from './ui';
 
 console.log('Running global E2E test setup...');
+
+// Patch `CodeUtil.open` to pass `--no-sandbox` to the VS Code CLI it spawns
+// to issue a folder-open IPC request to the running window. Without this
+// flag, the spawned Electron process exits silently on CI runners (e.g.
+// Ubuntu in GitHub Actions) where the chrome-sandbox binary lacks setuid
+// root, and `extest`'s `-r/--open_resource` flag becomes a no-op. The
+// matching `browser.start` flow already passes `--no-sandbox`; this aligns
+// the two. See https://github.com/redhat-developer/vscode-extension-tester/issues/2050.
+//
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const originalOpen = CodeUtil.prototype.open;
+CodeUtil.prototype.open = function (this: CodeUtil, ...paths: string[]) {
+  // Inject `--no-sandbox` as the first "path"; it's parsed as a flag because
+  // it starts with `--`, regardless of position in the argv.
+  originalOpen.call(this, '--no-sandbox', ...paths);
+};
+
 dotenv.config();
 assert.equal(
   CONFIG.Environment,

--- a/src/test/e2e/upload.e2e.test.ts
+++ b/src/test/e2e/upload.e2e.test.ts
@@ -9,8 +9,6 @@ import {
   ContextMenu,
   CustomTreeSection,
   DefaultTreeSection,
-  InputBox,
-  Key,
   SideBarView,
   Workbench,
 } from 'vscode-extension-tester';
@@ -18,8 +16,9 @@ import {
   assertAllCellsExecutedSuccessfully,
   createNotebook,
   hasQuickPickItem,
-  pushDialogButtonIfShown,
+  KERNEL_SELECT_WAIT_MS,
   selectQuickPickItem,
+  selectQuickPickItemIfShown,
   selectQuickPicksInOrder,
 } from './ui';
 
@@ -30,22 +29,13 @@ it('uploads a file from the explorer context menu', async () => {
   const workbench = new Workbench();
   const driver = workbench.getDriver();
 
-  // Close any leftover notebooks from prior tests; otherwise their cells
-  // would be counted by `assertAllCellsExecutedSuccessfully` below and the
-  // expected vs. actual cell-count comparison would never match.
-  await workbench.executeCommand('View: Close All Editors');
-  await pushDialogButtonIfShown(driver, "Don't Save", /* timeoutMs= */ 3000);
-
   await createNotebook(workbench);
   await workbench.executeCommand('Notebook: Select Notebook Kernel');
   if (await hasQuickPickItem(driver, 'Select Another Kernel')) {
     await selectQuickPickItem(driver, 'Select Another Kernel');
   }
   await selectQuickPicksInOrder(driver, ['Colab', 'Auto Connect']);
-  // Alias the server with the default name.
-  const inputBox = await InputBox.create();
-  await inputBox.sendKeys(Key.ENTER);
-  await selectQuickPickItem(driver, 'Python');
+  await selectQuickPickItemIfShown(driver, 'Python', KERNEL_SELECT_WAIT_MS);
 
   await workbench.executeCommand('View: Show Explorer');
   const explorerSection = await driver.wait(
@@ -102,7 +92,7 @@ it('uploads a file from the explorer context menu', async () => {
           await serverItem.expand();
         }
         const child = await serverItem.findChildItem('hello-world.txt');
-        return Boolean(child);
+        return !!child;
       } catch {
         return false;
       }

--- a/src/test/e2e/upload.e2e.test.ts
+++ b/src/test/e2e/upload.e2e.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { assert } from 'chai';
+import {
+  ContextMenu,
+  CustomTreeSection,
+  DefaultTreeSection,
+  InputBox,
+  Key,
+  SideBarView,
+  Workbench,
+} from 'vscode-extension-tester';
+import {
+  assertAllCellsExecutedSuccessfully,
+  createNotebook,
+  hasQuickPickItem,
+  pushDialogButtonIfShown,
+  selectQuickPickItem,
+  selectQuickPicksInOrder,
+} from './ui';
+
+const TREE_ITEM_WAIT_MS = 10000;
+const CONTENTS_VIEW_WAIT_MS = 20000;
+
+it('uploads a file from the explorer context menu', async () => {
+  const workbench = new Workbench();
+  const driver = workbench.getDriver();
+
+  // Close any leftover notebooks from prior tests; otherwise their cells
+  // would be counted by `assertAllCellsExecutedSuccessfully` below and the
+  // expected vs. actual cell-count comparison would never match.
+  await workbench.executeCommand('View: Close All Editors');
+  await pushDialogButtonIfShown(driver, "Don't Save", /* timeoutMs= */ 3000);
+
+  await createNotebook(workbench);
+  await workbench.executeCommand('Notebook: Select Notebook Kernel');
+  if (await hasQuickPickItem(driver, 'Select Another Kernel')) {
+    await selectQuickPickItem(driver, 'Select Another Kernel');
+  }
+  await selectQuickPicksInOrder(driver, ['Colab', 'Auto Connect']);
+  // Alias the server with the default name.
+  const inputBox = await InputBox.create();
+  await inputBox.sendKeys(Key.ENTER);
+  await selectQuickPickItem(driver, 'Python');
+
+  await workbench.executeCommand('View: Show Explorer');
+  const explorerSection = await driver.wait(
+    async () => {
+      try {
+        const sidebar = new SideBarView();
+        const section = await sidebar
+          .getContent()
+          .getSection('workspace', DefaultTreeSection);
+        return section;
+      } catch {
+        return undefined;
+      }
+    },
+    TREE_ITEM_WAIT_MS,
+    'Explorer "workspace" section did not render in time',
+  );
+  if (!explorerSection) {
+    throw new Error('Explorer "workspace" section was not found');
+  }
+  const fileItem = await driver.wait(
+    async () => {
+      try {
+        return await explorerSection.findItem('hello-world.txt');
+      } catch {
+        return undefined;
+      }
+    },
+    TREE_ITEM_WAIT_MS,
+    'hello-world.txt not found in Explorer',
+  );
+  assert(fileItem, 'hello-world.txt should be present in the Explorer');
+
+  const contextMenu: ContextMenu = await fileItem.openContextMenu();
+  const uploadItem = await contextMenu.getItem('Upload to Colab');
+  assert(uploadItem, '"Upload to Colab" should appear in the context menu');
+  await uploadItem.select();
+
+  // The Contents tree is rooted on a collapsed server node ("Colab CPU");
+  // `findItem` scrolls but does not auto-expand parents, so expand first.
+  await workbench.executeCommand('Colab: Focus on Contents View');
+  await driver.wait(
+    async () => {
+      try {
+        const sidebar = new SideBarView();
+        const contentsSection = await sidebar
+          .getContent()
+          .getSection('Contents', CustomTreeSection);
+        const serverItem = await contentsSection.findItem('Colab CPU');
+        if (!serverItem) {
+          return false;
+        }
+        if (!(await serverItem.isExpanded())) {
+          await serverItem.expand();
+        }
+        const child = await serverItem.findChildItem('hello-world.txt');
+        return Boolean(child);
+      } catch {
+        return false;
+      }
+    },
+    CONTENTS_VIEW_WAIT_MS,
+    'hello-world.txt did not appear in the Colab Contents view',
+  );
+
+  // Verify the uploaded file content via a Python cell that raises on
+  // mismatch. If the upload landed the wrong bytes, the cell errors and
+  // `assertAllCellsExecutedSuccessfully` fails.
+  await workbench.executeCommand('Notebook: Edit Cell');
+  const cell = await driver.switchTo().activeElement();
+  await cell.sendKeys(
+    `expected = 'Hello world!\\n'
+actual = open('/content/hello-world.txt').read()
+assert actual == expected, f'expected {expected!r}, got {actual!r}'`,
+  );
+
+  await workbench.executeCommand('Notebook: Run All');
+  await assertAllCellsExecutedSuccessfully(driver, workbench);
+});


### PR DESCRIPTION
Adds an end-to-end test that exercises the full Upload to Colab flow from the VS Code Explorer context menu, verifying the file lands on the connected Colab runtime via two independent signals: it appears in the Colab Contents tree view, and a Python cell that reads the uploaded file and asserts its content executes successfully (the cell raises AssertionError on mismatch, failing the test).

Changes:

- Add `src/test/e2e/fixtures/workspace/hello-world.txt` as a shared workspace fixture, opened in VS Code by the e2e runner so all e2e tests get a populated Explorer.
- Wire `scripts/test_e2e.sh` to launch extest with the fixture folder via the `-r/--open_resource` flag, terminated by `--` so the variadic flag does not consume the test-file positional args.
- Patch `CodeUtil.open` in `test-setup.ts` to inject `--no-sandbox` into the VS Code CLI invocation it spawns. Without this, the spawned Electron process exits silently on CI runners (e.g. Ubuntu in GitHub Actions) where chrome-sandbox lacks setuid root, and the `-r/--open_resource` flag becomes a no-op. See https://github.com/redhat-developer/vscode-extension-tester/issues/2050.
- Add `src/test/e2e/upload.e2e.test.ts` that connects to a Colab server via Auto Connect, right-clicks the fixture in the Explorer to trigger the upload, waits for the file in the Colab Contents view, and runs a Python cell that asserts the uploaded file's contents match the fixture.