### PR TITLE
test: reduce e2e flake

### DIFF
--- a/src/test/e2e/connect-execute.e2e.test.ts
+++ b/src/test/e2e/connect-execute.e2e.test.ts
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Workbench, WebElement, InputBox, Key } from 'vscode-extension-tester';
+import { Workbench, WebElement } from 'vscode-extension-tester';
 import {
   assertAllCellsExecutedSuccessfully,
+  confirmInputBoxWithDefault,
   createNotebook,
   hasQuickPickItem,
   selectQuickPickItem,
@@ -33,9 +34,10 @@ it('executes basic code cells', async () => {
     'CPU',
     'Latest',
   ]);
-  // Alias the server with the default name.
-  const inputBox = await InputBox.create();
-  await inputBox.sendKeys(Key.ENTER);
+  // Alias the server with the default name. We poll until the alias InputBox
+  // is actually shown before confirming, otherwise the ENTER keystroke can be
+  // delivered to the still-focused QuickPick from the previous step and lost.
+  await confirmInputBoxWithDefault(driver, 'Alias your server');
   await selectQuickPickItem(driver, 'Python');
 
   // Input code into the first cell.

--- a/src/test/e2e/mount-drive.e2e.test.ts
+++ b/src/test/e2e/mount-drive.e2e.test.ts
@@ -6,7 +6,7 @@
 
 import { writeFileSync } from 'fs';
 import clipboard from 'clipboardy';
-import { Workbench, VSBrowser, InputBox, Key } from 'vscode-extension-tester';
+import { Workbench, VSBrowser } from 'vscode-extension-tester';
 import { doOAuthSignIn, getOAuthDriver } from './auth';
 import {
   assertAllCellsExecutedSuccessfully,
@@ -17,7 +17,7 @@ import {
   selectQuickPicksInOrder,
 } from './ui';
 
-const CONNECT_DRIVE_DIALOG_WAIT_MS = 20000;
+const CONNECT_DRIVE_DIALOG_WAIT_MS = 30000;
 
 it('mounts Google Drive', async () => {
   const workbench = new Workbench();
@@ -37,9 +37,6 @@ it('mounts Google Drive', async () => {
     await selectQuickPickItem(driver, 'Select Another Kernel');
   }
   await selectQuickPicksInOrder(driver, ['Colab', 'Auto Connect']);
-  // Alias the server with the default name.
-  const inputBox = await InputBox.create();
-  await inputBox.sendKeys(Key.ENTER);
   await selectQuickPickItem(driver, 'Python');
 
   // Kick-off Drive mounting.

--- a/src/test/e2e/resource-view.e2e.test.ts
+++ b/src/test/e2e/resource-view.e2e.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { assert } from 'chai';
-import { Workbench, InputBox, Key } from 'vscode-extension-tester';
+import { Workbench } from 'vscode-extension-tester';
 import {
   createNotebook,
   hasQuickPickItem,
@@ -30,9 +30,6 @@ it('renders resource tree view', async () => {
     await selectQuickPickItem(driver, 'Select Another Kernel');
   }
   await selectQuickPicksInOrder(driver, ['Colab', 'Auto Connect']);
-  // Alias the server with the default name.
-  const inputBox = await InputBox.create();
-  await inputBox.sendKeys(Key.ENTER);
   await selectQuickPickItem(driver, 'Python');
 
   // Verify resource view in Colab activity bar.

--- a/src/test/e2e/test-setup.ts
+++ b/src/test/e2e/test-setup.ts
@@ -28,6 +28,8 @@ assert.equal(
   'Unexpected extension environment. Run `npm run generate:config` with COLAB_EXTENSION_ENVIRONMENT="production".',
 );
 
+const DIALOG_WAIT_MS = 3000;
+
 before(async function () {
   console.log('Starting global E2E test setup...');
   const workbench = new Workbench();
@@ -65,11 +67,7 @@ afterEach(async function () {
   try {
     await workbench.executeCommand('View: Close All Editors');
     // Close-all may surface a "Don't Save" prompt if any notebook is dirty.
-    await pushDialogButtonIfShown(
-      vsCodeDriver,
-      "Don't Save",
-      /* timeoutMs= */ 3000,
-    );
+    await pushDialogButtonIfShown(vsCodeDriver, "Don't Save", DIALOG_WAIT_MS);
   } catch (err) {
     // Best-effort cleanup; never fail the test from afterEach.
     console.warn('Best-effort editor cleanup failed in afterEach:', err);
@@ -86,11 +84,7 @@ async function signIn(
   // Dismiss the telemetry notice modal if it appears. The extension activates
   // asynchronously after notebook creation, so we poll for the dialog. This is
   // a no-op when the notice was already acknowledged (e.g. developer machine).
-  await pushDialogButtonIfShown(
-    vsCodeDriver,
-    'Acknowledge',
-    /* timeoutMs= */ 3000,
-  );
+  await pushDialogButtonIfShown(vsCodeDriver, 'Acknowledge', DIALOG_WAIT_MS);
 
   // Trigger Colab connection which will prompt for sign-in.
   await workbench.executeCommand('Notebook: Select Notebook Kernel');
@@ -125,10 +119,10 @@ async function signIn(
       'Could not select "Colab CPU" for cleanup; attempting to dismiss any error modal.',
       cleanupErr,
     );
-    await pushDialogButtonIfShown(vsCodeDriver, 'OK', /* timeoutMs= */ 3000);
+    await pushDialogButtonIfShown(vsCodeDriver, 'OK', DIALOG_WAIT_MS);
   }
   await workbench.executeCommand('View: Close All Editors');
-  await pushDialogButton(vsCodeDriver, "Don't Save");
+  await pushDialogButtonIfShown(vsCodeDriver, "Don't Save", DIALOG_WAIT_MS);
 }
 
 async function captureScreenshots(

--- a/src/test/e2e/test-setup.ts
+++ b/src/test/e2e/test-setup.ts
@@ -55,6 +55,27 @@ before(async function () {
   console.log('Finished global E2E test setup.');
 });
 
+afterEach(async function () {
+  // Close any editors opened by this test so the next test starts with a
+  // clean workbench. Without this, leftover notebooks/cells from a failing
+  // test bleed into the next test (e.g. cell-count assertions count cells
+  // from the prior notebook).
+  const workbench = new Workbench();
+  const vsCodeDriver = workbench.getDriver();
+  try {
+    await workbench.executeCommand('View: Close All Editors');
+    // Close-all may surface a "Don't Save" prompt if any notebook is dirty.
+    await pushDialogButtonIfShown(
+      vsCodeDriver,
+      "Don't Save",
+      /* timeoutMs= */ 3000,
+    );
+  } catch (err) {
+    // Best-effort cleanup; never fail the test from afterEach.
+    console.warn('Best-effort editor cleanup failed in afterEach:', err);
+  }
+});
+
 async function signIn(
   workbench: Workbench,
   vsCodeDriver: WebDriver,
@@ -93,8 +114,19 @@ async function signIn(
 
   // Cleanup so tests start from a clean slate.
   await selectQuickPickItem(vsCodeDriver, 'Python');
+  // 'Colab: Remove Server' can transiently fail with a backend 404 on the
+  // server's sessions API, surfacing a "Command resulted in an error" modal
+  // instead of the server picker. Treat this best-effort.
   await workbench.executeCommand('Colab: Remove Server');
-  await selectQuickPickItem(vsCodeDriver, 'Colab CPU');
+  try {
+    await selectQuickPickItem(vsCodeDriver, 'Colab CPU');
+  } catch (cleanupErr) {
+    console.warn(
+      'Could not select "Colab CPU" for cleanup; attempting to dismiss any error modal.',
+      cleanupErr,
+    );
+    await pushDialogButtonIfShown(vsCodeDriver, 'OK', /* timeoutMs= */ 3000);
+  }
   await workbench.executeCommand('View: Close All Editors');
   await pushDialogButton(vsCodeDriver, "Don't Save");
 }

--- a/src/test/e2e/ui.ts
+++ b/src/test/e2e/ui.ts
@@ -56,7 +56,7 @@ export function selectQuickPickItem(driver: WebDriver, item: string) {
         }
         await quickPickItem.select();
         return true;
-      } catch (_) {
+      } catch {
         // Swallow errors since we want to fail when our timeout's reached.
         return false;
       }
@@ -85,34 +85,28 @@ export async function hasQuickPickItem(
 ): Promise<boolean> {
   let containsOrOthers: boolean | string[];
   try {
-    containsOrOthers = await driver.wait(
-      async () => {
-        try {
-          const inputBox = await InputBox.create();
-          const quickPickItem = await inputBox.findQuickPick(item);
-          if (quickPickItem) {
-            return true;
-          }
-          const items = await inputBox.getQuickPicks();
-          // A QuickPick was rendered with options other than the one we're
-          // looking for.
-          if (items.length !== 0) {
-            return await Promise.all(
-              items.map(async (i) => await i.getLabel()),
-            );
-          }
-          // No QuickPick items were shown, which likely means the QuickPick is
-          // still loading. Keep waiting.
-          return false;
-        } catch (_) {
-          // Swallow errors so we keep polling until the timeout fires.
-          return false;
+    containsOrOthers = await driver.wait(async () => {
+      try {
+        const inputBox = await InputBox.create();
+        const quickPickItem = await inputBox.findQuickPick(item);
+        if (quickPickItem) {
+          return true;
         }
-      },
-      ELEMENT_WAIT_MS,
-      `Could not find "${item}" in QuickPick`,
-    );
-  } catch (_) {
+        const items = await inputBox.getQuickPicks();
+        // A QuickPick was rendered with options other than the one we're
+        // looking for.
+        if (items.length !== 0) {
+          return await Promise.all(items.map(async (i) => await i.getLabel()));
+        }
+        // No QuickPick items were shown, which likely means the QuickPick is
+        // still loading. Keep waiting.
+        return false;
+      } catch {
+        // Swallow errors so we keep polling until the timeout fires.
+        return false;
+      }
+    }, ELEMENT_WAIT_MS);
+  } catch {
     // No QuickPick (or no items) appeared within the wait window. Treat as
     // "item not present" rather than failing the caller.
     return false;
@@ -180,7 +174,7 @@ export async function confirmInputBoxWithDefault(
         }
         await inputBox.confirm();
         return true;
-      } catch (_) {
+      } catch {
         // Swallow errors so we keep polling until the timeout fires.
         return false;
       }
@@ -198,7 +192,7 @@ export async function confirmInputBoxWithDefault(
         const inputBox = await InputBox.create();
         const title = await inputBox.getTitle();
         return !title?.includes(expectedTitleSubstring);
-      } catch (_) {
+      } catch {
         // No InputBox present at all, transition complete.
         return true;
       }
@@ -252,7 +246,7 @@ export function pushDialogButton(
         const dialog = new ModalDialog();
         await dialog.pushButton(button);
         return true;
-      } catch (_) {
+      } catch {
         // Swallow the error since we want to fail when the timeout's reached.
         return false;
       }

--- a/src/test/e2e/ui.ts
+++ b/src/test/e2e/ui.ts
@@ -15,7 +15,13 @@ import {
 } from 'vscode-extension-tester';
 
 const ELEMENT_WAIT_MS = 10000;
-const CELL_EXECUTION_WAIT_MS = 30000;
+// Cell execution can be slow on a freshly assigned Colab server: the server
+// has to finish booting, the kernel has to start, the websocket has to
+// connect, and only then can the cells execute. 30s was occasionally too
+// tight for cold-start cases (kernel still showing "Connecting to kernel..."
+// when the wait expired). 60s gives a comfortable margin without slowing
+// the happy path (the wait returns as soon as all cells succeed).
+const CELL_EXECUTION_WAIT_MS = 60000;
 
 /**
  * Creates a new Jupyter notebook and waits for it to be fully loaded.
@@ -63,6 +69,11 @@ export function selectQuickPickItem(driver: WebDriver, item: string) {
 /**
  * Checks whether a QuickPick item is present in the current QuickPick options.
  *
+ * This is a non-throwing presence check: it returns `false` (rather than
+ * throwing) if no QuickPick is shown within {@link ELEMENT_WAIT_MS}, or if
+ * a QuickPick is shown but does not contain `item`. Callers that need a
+ * hard requirement should use {@link selectQuickPickItem} instead.
+ *
  * @param driver - The driver instance.
  * @param item - The UI item.
  * @returns A promise that resolves to true if the item is found, and false
@@ -72,31 +83,40 @@ export async function hasQuickPickItem(
   driver: WebDriver,
   item: string,
 ): Promise<boolean> {
-  const containsOrOthers = await driver.wait(
-    async () => {
-      try {
-        const inputBox = await InputBox.create();
-        const quickPickItem = await inputBox.findQuickPick(item);
-        if (quickPickItem) {
-          return true;
+  let containsOrOthers: boolean | string[];
+  try {
+    containsOrOthers = await driver.wait(
+      async () => {
+        try {
+          const inputBox = await InputBox.create();
+          const quickPickItem = await inputBox.findQuickPick(item);
+          if (quickPickItem) {
+            return true;
+          }
+          const items = await inputBox.getQuickPicks();
+          // A QuickPick was rendered with options other than the one we're
+          // looking for.
+          if (items.length !== 0) {
+            return await Promise.all(
+              items.map(async (i) => await i.getLabel()),
+            );
+          }
+          // No QuickPick items were shown, which likely means the QuickPick is
+          // still loading. Keep waiting.
+          return false;
+        } catch (_) {
+          // Swallow errors so we keep polling until the timeout fires.
+          return false;
         }
-        const items = await inputBox.getQuickPicks();
-        // A QuickPick was rendered with options other than the one we're
-        // looking for.
-        if (items.length !== 0) {
-          return await Promise.all(items.map(async (i) => await i.getLabel()));
-        }
-        // No QuickPick items were shown, which likely means the QuickPick is
-        // still loading. Keep waiting.
-        return false;
-      } catch (_) {
-        // Swallow errors since we want to fail when our timeout's reached.
-        return false;
-      }
-    },
-    ELEMENT_WAIT_MS,
-    `Could not find "${item}" in QuickPick`,
-  );
+      },
+      ELEMENT_WAIT_MS,
+      `Could not find "${item}" in QuickPick`,
+    );
+  } catch (_) {
+    // No QuickPick (or no items) appeared within the wait window. Treat as
+    // "item not present" rather than failing the caller.
+    return false;
+  }
   if (typeof containsOrOthers === 'boolean') {
     return containsOrOthers;
   }
@@ -125,6 +145,70 @@ export async function selectQuickPicksInOrder(
 }
 
 /**
+ * Confirms an InputBox identified by a substring of its title, accepting its
+ * current (default) value.
+ *
+ * Why not `InputBox.create()` + `sendKeys(Key.ENTER)` directly? Because of a
+ * subtle race during QuickPick → InputBox transitions: the previous QuickPick
+ * input may still be focused when `InputBox.create()` returns, and the ENTER
+ * keystroke can be lost or delivered to the wrong element. Subsequent calls
+ * then end up typing kernel-selection filter text into the still-open alias
+ * input.
+ *
+ * This helper polls until an InputBox with the expected title is shown,
+ * confirms it, and then waits for that input to transition away (i.e., either
+ * close or be replaced by an unrelated input). Only then does it return,
+ * guaranteeing follow-up `selectQuickPickItem` calls operate on the next UI
+ * surface.
+ *
+ * @param driver - The driver instance.
+ * @param expectedTitleSubstring - A substring expected to appear in the
+ * InputBox title (e.g. `"Alias your server"`).
+ */
+export async function confirmInputBoxWithDefault(
+  driver: WebDriver,
+  expectedTitleSubstring: string,
+): Promise<void> {
+  // Phase 1: wait for the expected InputBox to be shown, then confirm it.
+  await driver.wait(
+    async () => {
+      try {
+        const inputBox = await InputBox.create();
+        const title = await inputBox.getTitle();
+        if (!title?.includes(expectedTitleSubstring)) {
+          return false;
+        }
+        await inputBox.confirm();
+        return true;
+      } catch (_) {
+        // Swallow errors so we keep polling until the timeout fires.
+        return false;
+      }
+    },
+    ELEMENT_WAIT_MS,
+    `Could not confirm InputBox with title containing "${expectedTitleSubstring}"`,
+  );
+
+  // Phase 2: wait for the InputBox to transition away. It either closes
+  // entirely or is replaced by an unrelated InputBox/QuickPick whose title
+  // does not contain the expected substring.
+  await driver.wait(
+    async () => {
+      try {
+        const inputBox = await InputBox.create();
+        const title = await inputBox.getTitle();
+        return !title?.includes(expectedTitleSubstring);
+      } catch (_) {
+        // No InputBox present at all, transition complete.
+        return true;
+      }
+    },
+    ELEMENT_WAIT_MS,
+    `InputBox "${expectedTitleSubstring}" did not close after confirm`,
+  );
+}
+
+/**
  * Attempts to push a button in a modal dialog, if one is present.
  *
  * Polls for up to {@link waitMs} for the dialog to appear. If no dialog is
@@ -143,7 +227,7 @@ export async function pushDialogButtonIfShown(
   try {
     await pushDialogButton(driver, button, waitMs);
   } catch {
-    // Dialog never appeared within the wait window -- nothing to dismiss.
+    // Dialog never appeared within the wait window, nothing to dismiss.
   }
 }
 


### PR DESCRIPTION
- Bump `CELL_EXECUTION_WAIT_MS` and `CONNECT_DRIVE_DIALOG_WAIT_MS` to absorb cold-start on a freshly assigned Colab server. Most of the time its quick, sometimes it's pretty slow and hanging things up.
- connect-execute: replace racy `InputBox.create() + sendKeys(Enter)` on the alias step with `confirmInputBoxWithDefault()` that polls for the expected title, confirms, and waits for the `InputBox` to transition away.
- mount-drive, resource-view: drop the alias step entirely. These tests use Auto Connect, which reuses the existing server and never prompts for an alias; the previous Enter was operating on whatever input was open and only worked by accident.
- test-setup: tolerate transient 'Colab: Remove Server' backend errors during cleanup. Catch the picker timeout and dismiss any error modal instead of failing the whole suite.
- Add a global `afterEach` that closes all editors and dismisses any 'Don't Save' prompt so a failing test's open notebook can't pollute the next test's cell-count assertion.
- Make `hasQuickPickItem` actually non-throwing: catch the outer `driver.wait` timeout so callers using `if (await hasQuickPickItem(...))` don't blow up the suite when no QuickPick renders.

Verified at 20/20 across two consecutive 20-run dispatches.