### PR TITLE
fix: tolerate orphan assignment deletion races in getServers

### DIFF
--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -32,6 +32,7 @@ import {
   TooManyAssignmentsError,
 } from '../colab/client';
 import { REMOVE_SERVER } from '../colab/commands/constants';
+import { ColabRequestError } from '../colab/errors';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
@@ -256,25 +257,10 @@ export class AssignmentManager implements Disposable {
 
     let unownedServers: UnownedServer[] = [];
     if (from === 'external' || from === 'all') {
-      const storedEndpointSet = new Set(storedServers.map((s) => s.endpoint));
-      unownedServers = await Promise.all(
-        allAssignments
-          .filter((a) => !storedEndpointSet.has(a.endpoint))
-          .map(async (a) => {
-            // For any remote servers created in Colab web UI, assuming there is
-            // only one session per assignment.
-            const sessions = await this.client.listSessions(a.endpoint, signal);
-            const label =
-              sessions.length === 1 && sessions[0].name?.length
-                ? sessions[0].name
-                : UNKNOWN_REMOTE_SERVER_NAME;
-            return {
-              label,
-              endpoint: a.endpoint,
-              variant: a.variant,
-              accelerator: a.accelerator,
-            };
-          }),
+      unownedServers = await this.getUnownedServers(
+        allAssignments,
+        storedServers,
+        signal,
       );
     }
 
@@ -710,6 +696,64 @@ export class AssignmentManager implements Disposable {
         WebSocket: colabProxyWebSocket(this.vs, this.client, colabServer),
       },
     };
+  }
+
+  private async getUnownedServers(
+    allAssignments: ListedAssignment[],
+    storedServers: ColabAssignedServer[],
+    signal?: AbortSignal,
+  ): Promise<UnownedServer[]> {
+    const storedEndpointSet = new Set(storedServers.map((s) => s.endpoint));
+
+    return (
+      await Promise.all(
+        allAssignments
+          .filter((a) => !storedEndpointSet.has(a.endpoint))
+          .map(async (a): Promise<UnownedServer | undefined> => {
+            // For any remote servers created in Colab web UI, assuming there
+            // is only one session per assignment.
+            let label: string;
+            try {
+              const sessions = await this.client.listSessions(
+                a.endpoint,
+                signal,
+              );
+              label =
+                sessions.length === 1 && sessions[0].name?.length
+                  ? sessions[0].name
+                  : UNKNOWN_REMOTE_SERVER_NAME;
+            } catch (error: unknown) {
+              // The assignment may have been removed (e.g. via Colab web UI
+              // or another VS Code instance sharing the account) between
+              // listing assignments and listing its sessions. Drop it from
+              // the result rather than failing the entire call.
+              if (
+                error instanceof ColabRequestError &&
+                error.response.status === 404
+              ) {
+                log.trace(
+                  `Dropping orphan assignment ${a.endpoint} - sessions endpoint returned 404`,
+                  error,
+                );
+                return undefined;
+              }
+              // For any other failure, fail open with a placeholder label so
+              // we still surface the assignment to the user.
+              log.warn(
+                `Failed to list sessions for assignment ${a.endpoint}, falling back to placeholder label`,
+                error,
+              );
+              label = UNKNOWN_REMOTE_SERVER_NAME;
+            }
+            return {
+              label,
+              endpoint: a.endpoint,
+              variant: a.variant,
+              accelerator: a.accelerator,
+            };
+          }),
+      )
+    ).filter((s): s is UnownedServer => s !== undefined);
   }
 
   private async notifyAllAcceleratorsUnavailable(

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -6,7 +6,7 @@
 
 import { randomUUID } from 'crypto';
 import { assert, expect } from 'chai';
-import fetch, { Headers, Request } from 'node-fetch';
+import fetch, { Headers, Request, Response } from 'node-fetch';
 import sinon, { SinonFakeTimers, SinonStubbedInstance } from 'sinon';
 import { MessageItem, Uri } from 'vscode';
 import {
@@ -27,6 +27,7 @@ import {
   AcceleratorUnavailableError,
 } from '../colab/client';
 import { REMOVE_SERVER } from '../colab/commands/constants';
+import { ColabRequestError } from '../colab/errors';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
@@ -706,6 +707,112 @@ describe('AssignmentManager', () => {
         const results = await assignmentManager.getServers('external');
 
         // Then only 2 unowned external servers are returned
+        expect(results).to.deep.equal([
+          {
+            label: 'test-session-name',
+            endpoint: endpointWithName,
+            variant: Variant.DEFAULT,
+            accelerator: '',
+          },
+          {
+            label: 'Untitled',
+            endpoint: endpointWithoutSession,
+            variant: Variant.DEFAULT,
+            accelerator: '',
+          },
+        ]);
+      });
+
+      it('drops orphan unowned servers whose sessions endpoint returns 404', async () => {
+        // Simulates a race where the orphan assignment is deleted (e.g. via
+        // Colab web or another VS Code instance sharing the account) between
+        // listing assignments and listing its sessions.
+        colabClientStub.listAssignments.resolves([
+          assignmentWithName,
+          assignmentWithoutSession,
+        ]);
+        colabClientStub.listSessions.withArgs(endpointWithName).resolves([
+          {
+            ...defaultSession,
+            name: 'test-session-name',
+          },
+        ]);
+        colabClientStub.listSessions
+          .withArgs(endpointWithoutSession)
+          .rejects(
+            new ColabRequestError(
+              new Request('https://example.com'),
+              new Response(undefined, { status: 404 }),
+            ),
+          );
+
+        const results = await assignmentManager.getServers('external');
+
+        expect(results).to.deep.equal([
+          {
+            label: 'test-session-name',
+            endpoint: endpointWithName,
+            variant: Variant.DEFAULT,
+            accelerator: '',
+          },
+        ]);
+      });
+
+      it('falls back to placeholder label when listing sessions throws a non-404', async () => {
+        colabClientStub.listAssignments.resolves([
+          assignmentWithName,
+          assignmentWithoutSession,
+        ]);
+        colabClientStub.listSessions.withArgs(endpointWithName).resolves([
+          {
+            ...defaultSession,
+            name: 'test-session-name',
+          },
+        ]);
+        colabClientStub.listSessions
+          .withArgs(endpointWithoutSession)
+          .rejects(
+            new ColabRequestError(
+              new Request('https://example.com'),
+              new Response(undefined, { status: 500 }),
+            ),
+          );
+
+        const results = await assignmentManager.getServers('external');
+
+        expect(results).to.deep.equal([
+          {
+            label: 'test-session-name',
+            endpoint: endpointWithName,
+            variant: Variant.DEFAULT,
+            accelerator: '',
+          },
+          {
+            label: 'Untitled',
+            endpoint: endpointWithoutSession,
+            variant: Variant.DEFAULT,
+            accelerator: '',
+          },
+        ]);
+      });
+
+      it('falls back to placeholder label when listing sessions throws a non-ColabRequestError', async () => {
+        colabClientStub.listAssignments.resolves([
+          assignmentWithName,
+          assignmentWithoutSession,
+        ]);
+        colabClientStub.listSessions.withArgs(endpointWithName).resolves([
+          {
+            ...defaultSession,
+            name: 'test-session-name',
+          },
+        ]);
+        colabClientStub.listSessions
+          .withArgs(endpointWithoutSession)
+          .rejects(new Error('network kaput'));
+
+        const results = await assignmentManager.getServers('external');
+
         expect(results).to.deep.equal([
           {
             label: 'test-session-name',


### PR DESCRIPTION
When listing servers from external/all, the unowned-assignment branch called `listSessions` for each _unowned_ assignment in parallel. If the assignment was deleted elsewhere (e.g. via Colab web or another VS Code instance sharing the account) between listing assignments and listing its sessions, the call would 404 and reject the entire `Promise.all`, surfacing as an error modal in downstream commands like "Colab: Remove Server".

Now, a 404 drops the orphan from the result (it's already gone server-side), and any other failure fails open with the placeholder label so the assignment is still surfaced to the user.