### PR TITLE
fix: stop returning empty list when concurrent getChildren calls overlap

### DIFF
--- a/src/colab/resource-monitor/resource-tree.ts
+++ b/src/colab/resource-monitor/resource-tree.ts
@@ -12,7 +12,6 @@ import {
   TreeItem,
 } from 'vscode';
 import { AuthChangeEvent } from '../../auth/auth-provider';
-import { LatestCancelable } from '../../common/async';
 import { log } from '../../common/logging';
 import { OverrunPolicy, SequentialTaskRunner } from '../../common/task-runner';
 import {
@@ -42,7 +41,6 @@ export class ResourceTreeProvider
   private readonly assignmentListener: Disposable;
   private readonly authListener: Disposable;
   private readonly refreshRunner?: SequentialTaskRunner;
-  private readonly getRootChildrenRunner: LatestCancelable<[], ResourceItem[]>;
   // Cache of resource items by server endpoint to avoid invoking resource API
   // too frequently.
   private resourceItemsByEndpoint = new Map<string, ResourceItem[]>();
@@ -65,10 +63,6 @@ export class ResourceTreeProvider
   ) {
     this.assignmentListener = assignmentChange(this.refresh.bind(this));
     this.authListener = authChange(this.handleAuthChange.bind(this));
-    this.getRootChildrenRunner = new LatestCancelable(
-      'getChildren',
-      this.getRootChildren.bind(this),
-    );
 
     // Read poll interval from experiment config once at runner initialization.
     const refreshIntervalMs = getFlag(ExperimentFlag.ResourcePollIntervalMs);
@@ -105,7 +99,6 @@ export class ResourceTreeProvider
     this.authListener.dispose();
     this.assignmentListener.dispose();
     this.resourceItemsByEndpoint.clear();
-    this.getRootChildrenRunner.cancel();
     this.isDisposed = true;
   }
 
@@ -133,6 +126,11 @@ export class ResourceTreeProvider
   /**
    * Gets the children of a {@link ResourceItem} for the tree view.
    *
+   * Each call returns its own snapshot of the current state, intentionally not
+   * coalesced or cancelled when other calls overlap.
+   * {@link TreeDataProvider.onDidChangeTreeData} is the mechanism that signals
+   * VS Code to re-query for fresh data.
+   *
    * @param element - The {@link ResourceItem} element.
    * @returns A promise that resolves to an array of {@link ResourceItem}
    * children.
@@ -153,24 +151,23 @@ export class ResourceTreeProvider
       return this.resourceItemsByEndpoint.get(element.endpoint) ?? [];
     }
 
-    // If no element is passed (requested at root level), execute
-    // getRootChildrenRunner to fetch and return all servers as root items.
-    return (await this.getRootChildrenRunner.run()) ?? [];
+    // If no element is passed (requested at root level), fetch and return
+    // all servers as root items.
+    return this.getRootChildren();
   }
 
   /**
    * Fetches and caches all servers and their resources.
    *
-   * @param signal - Optional {@link AbortSignal} to cancel the operation.
    * @returns A promise that resolves to an array of {@link ResourceItem}
    * representing servers.
    */
-  private async getRootChildren(signal?: AbortSignal): Promise<ResourceItem[]> {
-    const servers = await this.assignments.getServers('extension', signal);
+  private async getRootChildren(): Promise<ResourceItem[]> {
+    const servers = await this.assignments.getServers('extension');
     return Promise.all(
       servers.map(async (s) => {
         try {
-          await this.fetchAndCacheResourceItems(s, signal);
+          await this.fetchAndCacheResourceItems(s);
         } catch (e: unknown) {
           const errLabel = 'Failed to fetch resources';
           log.error(`${errLabel}:`, e);
@@ -186,10 +183,9 @@ export class ResourceTreeProvider
 
   private async fetchAndCacheResourceItems(
     server: ColabAssignedServer,
-    signal?: AbortSignal,
   ): Promise<void> {
     const endpoint = server.endpoint;
-    const resources = await this.client.getResources(server, signal);
+    const resources = await this.client.getResources(server);
     const resourceItems: ResourceItem[] = [];
     resourceItems.push(ResourceItem.fromMemory(endpoint, resources.memory));
     if (resources.gpus.length > 0) {

--- a/src/colab/resource-monitor/resource-tree.vscode.test.ts
+++ b/src/colab/resource-monitor/resource-tree.vscode.test.ts
@@ -266,32 +266,107 @@ describe('ResourceTreeProvider', () => {
       });
     });
 
-    it('aborts previous in-flight getChildren call', async () => {
+    it('returns the real server list to every concurrent caller', async () => {
+      // Regression: previously, a second getChildren call while a first was
+      // in-flight would abort the first via LatestCancelable. The aborted first
+      // call would then resolve with [], which VS Code could cache as the root
+      // children, rendering the welcome view "No assigned Colab servers." even
+      // though servers existed.
+      //
+      // The first getServers stub honours the AbortSignal so the in-flight
+      // worker rejects when LatestCancelable aborts it, faithfully reproducing
+      // how the real getServers/listAssignments forwards the signal into fetch.
       const firstRunStarted = new Deferred<void>();
       const firstRunCompleter = new Deferred<void>();
       (assignmentStub.getServers as sinon.SinonStub)
         .onFirstCall()
-        .callsFake(async () => {
+        .callsFake(async (_from: 'extension', signal?: AbortSignal) => {
           firstRunStarted.resolve();
           await firstRunCompleter.promise;
-          return Promise.reject(new Error('aborted'));
+          if (signal?.aborted) {
+            throw new DOMException('aborted', 'AbortError');
+          }
+          return [DEFAULT_SERVER];
         })
         .onSecondCall()
         .resolves([DEFAULT_SERVER]);
       toggleAuth(AuthState.SIGNED_IN);
 
-      // Kick off first getChildren call and let it hang
+      // Kick off first getChildren call and let it hang.
       const firstGetChildrenPromise = tree.getChildren(undefined);
       await firstRunStarted.promise;
-      // Complete a second getChildren call
-      await expect(tree.getChildren(undefined)).to.eventually.deep.equal([
+      // Kick off a second concurrent getChildren call which should resolve
+      // independently with the real server list.
+      const secondGetChildrenPromise = tree.getChildren(undefined);
+      await expect(secondGetChildrenPromise).to.eventually.deep.equal([
         ResourceItem.fromServer(DEFAULT_SERVER),
       ]);
-      // Unblock the first getChildren call
+      // Unblock the first getChildren call. It must also resolve with the
+      // real server list, never an empty array.
+      firstRunCompleter.resolve();
+      await expect(firstGetChildrenPromise).to.eventually.deep.equal([
+        ResourceItem.fromServer(DEFAULT_SERVER),
+      ]);
+    });
+
+    it('returns servers after back-to-back assignment changes during an in-flight getChildren', async () => {
+      // Regression: two AssignmentChange events firing in quick succession
+      // (e.g. an `added` immediately followed by a `changed`) used to cause the
+      // in-flight getChildren triggered by the first event to be aborted and
+      // resolve to [], which VS Code would render/cache as the empty welcome
+      // view. The next refresh from the second event would produce the real
+      // list, but VS Code wouldn't necessarily re-query. After the fix,
+      // getChildren must always observe the current state when invoked,
+      // regardless of how many change events fire.
+      const firstRunStarted = new Deferred<void>();
+      const firstRunCompleter = new Deferred<void>();
+      (assignmentStub.getServers as sinon.SinonStub)
+        .onFirstCall()
+        .callsFake(async (_from: 'extension', signal?: AbortSignal) => {
+          firstRunStarted.resolve();
+          await firstRunCompleter.promise;
+          if (signal?.aborted) {
+            throw new DOMException('aborted', 'AbortError');
+          }
+          return [DEFAULT_SERVER];
+        })
+        .resolves([DEFAULT_SERVER]);
+      toggleAuth(AuthState.SIGNED_IN);
+
+      // Simulate VS Code calling getChildren in response to the first
+      // assignment change event. Let the call hang mid-fetch.
+      const firstGetChildrenPromise = tree.getChildren(undefined);
+      await firstRunStarted.promise;
+
+      // Two more assignment-change events fire back-to-back while the
+      // first getChildren is still in flight. VS Code will eventually
+      // re-call getChildren in response.
+      assignmentChangeEmitter.fire({
+        added: [DEFAULT_SERVER],
+        changed: [],
+        removed: [],
+      });
+      assignmentChangeEmitter.fire({
+        added: [],
+        changed: [DEFAULT_SERVER],
+        removed: [],
+      });
+
+      // VS Code re-queries after the change events. This call must return
+      // the real server list rather than empty.
+      const refreshedGetChildrenPromise = tree.getChildren(undefined);
+
+      // Unblock the original in-flight call.
       firstRunCompleter.resolve();
 
-      // First getChildren call should return empty since it was aborted
-      await expect(firstGetChildrenPromise).to.eventually.be.empty;
+      // Both the original and the post-refresh call must observe the
+      // real list, never empty.
+      await expect(refreshedGetChildrenPromise).to.eventually.deep.equal([
+        ResourceItem.fromServer(DEFAULT_SERVER),
+      ]);
+      await expect(firstGetChildrenPromise).to.eventually.deep.equal([
+        ResourceItem.fromServer(DEFAULT_SERVER),
+      ]);
     });
   });
 


### PR DESCRIPTION
`ResourceTreeProvider.getChildren` wrapped its root-level fetch in a `LatestCancelable` runner. When two `getChildren` calls overlapped (e.g. back-to-back `AssignmentChange` events fired the change emitter twice while a fetch was in flight), the first call's runner was aborted and resolved to `undefined` -> `getChildren` returned `[]`. VS Code cached that empty result and rendered the welcome view 'No assigned Colab servers.' until the next external event re-queried the tree.

I found this while deflaking the e2e tests.

`TreeDataProvider` semantics require every `getChildren` call to return the current snapshot; freshness is communicated via `onDidChangeTreeData`. `LatestCancelable`'s one-shot caller semantics don't match. Drop the runner and let each `getChildren` call fetch independently.

Added regression tests covering both the concurrent-caller and back-to-back-assignment-change scenarios.