### PR TITLE
build: bump version to 0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "@jupyterlab/services": "^7.5.3",
         "glob": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
Changes since last bump:

- feat: log telemetry for low/depleted CCU balance notifications (#578)
- feat: enrich assign_server_event with outcome and configuration (#577)
- feat: log telemetry for downloads from Colab servers (#576)
- feat: log telemetry for content browser file operations (#575)
- feat: log telemetry for opening a Colab terminal (#574)
- feat: log telemetry for uploads to Colab servers (#573)
- fix: stop returning empty list when concurrent getChildren calls overlap (#588)
- fix: tolerate orphan assignment deletion races in getServers (#587)
- refactor: split extension.ts activation into per-feature modules (#572)
- test: add e2e test for Upload to Colab from explorer context menu (#581)
- chore: reduce e2e flake (#586)
- build(deps): bump uuid from 11.1.0 to 14.0.0 (#582)
- test: reduce e2e flake (#583)
- chore: upgrade actions node24 (#580)
- fix: preserve Request headers in colabProxyFetch (#558)
- feat: Add telemetry for notebook imports, including source of import (command palette vs. URI) (#567)
- refactor: increase OAuth sign-in screen wait timeout (#565)