### PR TITLE
test: guard QuickPick interactions against orphaned pickers

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -13,6 +13,7 @@ googlecolab
 googlers
 grayscale
 highmem
+inputbox
 ipykernel
 ipynb
 jupyterclient

--- a/src/test/e2e/connect-execute.e2e.test.ts
+++ b/src/test/e2e/connect-execute.e2e.test.ts
@@ -11,6 +11,7 @@ import {
   createNotebook,
   hasQuickPickItem,
   KERNEL_SELECT_WAIT_MS,
+  safeExecuteCommand,
   selectQuickPickItem,
   selectQuickPicksInOrder,
 } from './ui';
@@ -22,33 +23,40 @@ it('executes basic code cells', async () => {
   await createNotebook(workbench);
 
   // Connect to Colab.
-  await workbench.executeCommand('Notebook: Select Notebook Kernel');
+  await safeExecuteCommand(workbench, 'Notebook: Select Notebook Kernel');
   // If the test is running on a machine with a configured Python environment,
   // the "Select Another Kernel" option may appear instead of "Colab". If so, we
   // need to click it first before selecting "Colab".
-  if (await hasQuickPickItem(driver, 'Select Another Kernel')) {
-    await selectQuickPickItem(driver, 'Select Another Kernel');
+  if (
+    await hasQuickPickItem(driver, 'Change kernel', 'Select Another Kernel')
+  ) {
+    await selectQuickPickItem(driver, 'Change kernel', 'Select Another Kernel');
   }
   await selectQuickPicksInOrder(driver, [
-    'Colab',
-    'New Colab Server',
-    'CPU',
-    'Latest',
+    { picker: 'kernel source', item: 'Colab' },
+    { picker: 'Select a remote server', item: 'New Colab Server' },
+    { picker: 'Select a variant', item: 'CPU' },
+    { picker: 'Select a runtime version', item: 'Latest' },
   ]);
   // Alias the server with the default name. We poll until the alias InputBox
   // is actually shown before confirming, otherwise the ENTER keystroke can be
   // delivered to the still-focused QuickPick from the previous step and lost.
   await confirmInputBoxWithDefault(driver, 'Alias your server');
-  await selectQuickPickItem(driver, 'Python', KERNEL_SELECT_WAIT_MS);
+  await selectQuickPickItem(
+    driver,
+    'Select a Kernel',
+    'Python',
+    KERNEL_SELECT_WAIT_MS,
+  );
 
   // Input code into the first cell.
   let focusedCell: WebElement;
-  await workbench.executeCommand('Notebook: Edit Cell');
+  await safeExecuteCommand(workbench, 'Notebook: Edit Cell');
   focusedCell = await driver.switchTo().activeElement();
   await focusedCell.sendKeys('1 + 1');
 
   // Add a second cell to display a data frame.
-  await workbench.executeCommand('Notebook: Insert Code Cell Below');
+  await safeExecuteCommand(workbench, 'Notebook: Insert Code Cell Below');
   focusedCell = await driver.switchTo().activeElement();
   await focusedCell.sendKeys(`import pandas as pd
 df = pd.DataFrame({
@@ -58,14 +66,14 @@ df = pd.DataFrame({
 df`);
 
   // Add a third cell to plot the data frame.
-  await workbench.executeCommand('Notebook: Insert Code Cell Below');
+  await safeExecuteCommand(workbench, 'Notebook: Insert Code Cell Below');
   focusedCell = await driver.switchTo().activeElement();
   await focusedCell.sendKeys('df.plot()');
 
-  await workbench.executeCommand('Notebook: Run All');
+  await safeExecuteCommand(workbench, 'Notebook: Run All');
   // Collapsing all cell outputs so execution status of all 3 cells are in
   // the viewport.
-  await workbench.executeCommand('Notebook: Collapse All Cell Outputs');
+  await safeExecuteCommand(workbench, 'Notebook: Collapse All Cell Outputs');
 
   await assertAllCellsExecutedSuccessfully(driver, workbench);
 });

--- a/src/test/e2e/connect-execute.e2e.test.ts
+++ b/src/test/e2e/connect-execute.e2e.test.ts
@@ -27,10 +27,8 @@ it('executes basic code cells', async () => {
   // If the test is running on a machine with a configured Python environment,
   // the "Select Another Kernel" option may appear instead of "Colab". If so, we
   // need to click it first before selecting "Colab".
-  if (
-    await hasQuickPickItem(driver, 'Change kernel', 'Select Another Kernel')
-  ) {
-    await selectQuickPickItem(driver, 'Change kernel', 'Select Another Kernel');
+  if (await hasQuickPickItem(driver, 'kernel', 'Select Another Kernel')) {
+    await selectQuickPickItem(driver, 'kernel', 'Select Another Kernel');
   }
   await selectQuickPicksInOrder(driver, [
     { picker: 'kernel source', item: 'Colab' },

--- a/src/test/e2e/mount-drive.e2e.test.ts
+++ b/src/test/e2e/mount-drive.e2e.test.ts
@@ -14,6 +14,7 @@ import {
   hasQuickPickItem,
   KERNEL_SELECT_WAIT_MS,
   pushDialogButton,
+  safeExecuteCommand,
   selectQuickPickItem,
   selectQuickPickItemIfShown,
   selectQuickPicksInOrder,
@@ -31,22 +32,32 @@ it('mounts Google Drive', async () => {
   await createNotebook(workbench);
   // Delete the initial empty cell first because Mount Drive command will
   // insert code snippet in a new cell.
-  await workbench.executeCommand('Notebook: Delete Cell');
+  await safeExecuteCommand(workbench, 'Notebook: Delete Cell');
 
   // Connect to Colab.
-  await workbench.executeCommand('Notebook: Select Notebook Kernel');
+  await safeExecuteCommand(workbench, 'Notebook: Select Notebook Kernel');
   // If the test is running on a machine with a configured Python environment,
   // the "Select Another Kernel" option may appear instead of "Colab". If so, we
   // need to click it first before selecting "Colab".
-  if (await hasQuickPickItem(driver, 'Select Another Kernel')) {
-    await selectQuickPickItem(driver, 'Select Another Kernel');
+  if (
+    await hasQuickPickItem(driver, 'Change kernel', 'Select Another Kernel')
+  ) {
+    await selectQuickPickItem(driver, 'Change kernel', 'Select Another Kernel');
   }
-  await selectQuickPicksInOrder(driver, ['Colab', 'Auto Connect']);
-  await selectQuickPickItemIfShown(driver, 'Python', KERNEL_SELECT_WAIT_MS);
+  await selectQuickPicksInOrder(driver, [
+    { picker: 'kernel source', item: 'Colab' },
+    { picker: 'Select a remote server', item: 'Auto Connect' },
+  ]);
+  await selectQuickPickItemIfShown(
+    driver,
+    'Select a Kernel',
+    'Python',
+    KERNEL_SELECT_WAIT_MS,
+  );
 
   // Kick-off Drive mounting.
-  await workbench.executeCommand('Colab: Mount Google Drive to Server...');
-  await workbench.executeCommand('Notebook: Run All');
+  await safeExecuteCommand(workbench, 'Colab: Mount Google Drive to Server...');
+  await safeExecuteCommand(workbench, 'Notebook: Run All');
   await pushDialogButton(
     driver,
     'Connect to Google Drive',

--- a/src/test/e2e/mount-drive.e2e.test.ts
+++ b/src/test/e2e/mount-drive.e2e.test.ts
@@ -39,10 +39,8 @@ it('mounts Google Drive', async () => {
   // If the test is running on a machine with a configured Python environment,
   // the "Select Another Kernel" option may appear instead of "Colab". If so, we
   // need to click it first before selecting "Colab".
-  if (
-    await hasQuickPickItem(driver, 'Change kernel', 'Select Another Kernel')
-  ) {
-    await selectQuickPickItem(driver, 'Change kernel', 'Select Another Kernel');
+  if (await hasQuickPickItem(driver, 'kernel', 'Select Another Kernel')) {
+    await selectQuickPickItem(driver, 'kernel', 'Select Another Kernel');
   }
   await selectQuickPicksInOrder(driver, [
     { picker: 'kernel source', item: 'Colab' },

--- a/src/test/e2e/resource-view.e2e.test.ts
+++ b/src/test/e2e/resource-view.e2e.test.ts
@@ -10,6 +10,7 @@ import {
   createNotebook,
   hasQuickPickItem,
   KERNEL_SELECT_WAIT_MS,
+  safeExecuteCommand,
   selectQuickPickItem,
   selectQuickPickItemIfShown,
   selectQuickPicksInOrder,
@@ -28,18 +29,28 @@ it('renders resource tree view', async () => {
   await createNotebook(workbench);
 
   // Connect to Colab.
-  await workbench.executeCommand('Notebook: Select Notebook Kernel');
+  await safeExecuteCommand(workbench, 'Notebook: Select Notebook Kernel');
   // If the test is running on a machine with a configured Python environment,
   // the "Select Another Kernel" option may appear instead of "Colab". If so, we
   // need to click it first before selecting "Colab".
-  if (await hasQuickPickItem(driver, 'Select Another Kernel')) {
-    await selectQuickPickItem(driver, 'Select Another Kernel');
+  if (
+    await hasQuickPickItem(driver, 'Change kernel', 'Select Another Kernel')
+  ) {
+    await selectQuickPickItem(driver, 'Change kernel', 'Select Another Kernel');
   }
-  await selectQuickPicksInOrder(driver, ['Colab', 'Auto Connect']);
-  await selectQuickPickItemIfShown(driver, 'Python', KERNEL_SELECT_WAIT_MS);
+  await selectQuickPicksInOrder(driver, [
+    { picker: 'kernel source', item: 'Colab' },
+    { picker: 'Select a remote server', item: 'Auto Connect' },
+  ]);
+  await selectQuickPickItemIfShown(
+    driver,
+    'Select a Kernel',
+    'Python',
+    KERNEL_SELECT_WAIT_MS,
+  );
 
   // Verify resource view in Colab activity bar.
-  await workbench.executeCommand('Colab: Focus on Resources View');
+  await safeExecuteCommand(workbench, 'Colab: Focus on Resources View');
 
   const activityBar = workbench.getActivityBar();
   const colabViewContainer = await activityBar.getViewControl('Colab');

--- a/src/test/e2e/resource-view.e2e.test.ts
+++ b/src/test/e2e/resource-view.e2e.test.ts
@@ -33,10 +33,8 @@ it('renders resource tree view', async () => {
   // If the test is running on a machine with a configured Python environment,
   // the "Select Another Kernel" option may appear instead of "Colab". If so, we
   // need to click it first before selecting "Colab".
-  if (
-    await hasQuickPickItem(driver, 'Change kernel', 'Select Another Kernel')
-  ) {
-    await selectQuickPickItem(driver, 'Change kernel', 'Select Another Kernel');
+  if (await hasQuickPickItem(driver, 'kernel', 'Select Another Kernel')) {
+    await selectQuickPickItem(driver, 'kernel', 'Select Another Kernel');
   }
   await selectQuickPicksInOrder(driver, [
     { picker: 'kernel source', item: 'Colab' },

--- a/src/test/e2e/test-setup.ts
+++ b/src/test/e2e/test-setup.ts
@@ -130,16 +130,12 @@ async function signIn(
   if (
     await hasQuickPickItem(
       vsCodeDriver,
-      'Change kernel',
+      'kernel',
       'Select Another Kernel',
       KERNEL_SELECT_WAIT_MS,
     )
   ) {
-    await selectQuickPickItem(
-      vsCodeDriver,
-      'Change kernel',
-      'Select Another Kernel',
-    );
+    await selectQuickPickItem(vsCodeDriver, 'kernel', 'Select Another Kernel');
   }
   await selectQuickPickItem(vsCodeDriver, 'kernel source', 'Colab');
   // "Auto Connect" lives in the remote-server picker that Jupyter opens

--- a/src/test/e2e/test-setup.ts
+++ b/src/test/e2e/test-setup.ts
@@ -15,12 +15,14 @@ import { CONFIG } from '../../colab-config';
 import { doOAuthSignIn, getOAuthDriver } from './auth';
 import {
   createNotebook,
-  pushDialogButtonIfShown,
+  dismissAnyOpenInput,
   hasQuickPickItem,
+  KERNEL_SELECT_WAIT_MS,
   pushDialogButton,
+  pushDialogButtonIfShown,
+  safeExecuteCommand,
   selectQuickPickItem,
   selectQuickPickItemIfShown,
-  KERNEL_SELECT_WAIT_MS,
 } from './ui';
 
 console.log('Running global E2E test setup...');
@@ -85,12 +87,16 @@ afterEach(async function () {
   const workbench = new Workbench();
   const vsCodeDriver = workbench.getDriver();
   try {
+    // Dismiss any leftover QuickPick/InputBox so the upcoming command palette
+    // invocations actually open the command palette instead of being absorbed
+    // by an orphan picker. VS Code reuses one DOM `<input>` for all pickers.
+    await dismissAnyOpenInput(vsCodeDriver);
     // Dismiss any leftover error/info modal first (e.g. a 504 surfaced by a
     // previous best-effort 'Colab: Remove Server' that arrived after the
     // earlier dismissal window closed). A modal blocks subsequent
     // executeCommand() calls so we must clear it before doing anything else.
     await pushDialogButtonIfShown(vsCodeDriver, 'OK', DIALOG_WAIT_MS);
-    await workbench.executeCommand('View: Close All Editors');
+    await safeExecuteCommand(workbench, 'View: Close All Editors');
     // Close-all may surface a "Don't Save" prompt if any notebook is dirty.
     await pushDialogButtonIfShown(vsCodeDriver, "Don't Save", DIALOG_WAIT_MS);
   } catch (err) {
@@ -112,23 +118,37 @@ async function signIn(
   await pushDialogButtonIfShown(vsCodeDriver, 'Acknowledge', DIALOG_WAIT_MS);
 
   // Trigger Colab connection which will prompt for sign-in.
-  await workbench.executeCommand('Notebook: Select Notebook Kernel');
-  // If the test is running on a machine with a configured Python environment,
-  // the "Select Another Kernel" option may appear instead of "Colab". If so,
-  // we need to click it first before selecting "Colab". The kernel picker
-  // can take a while to populate while Jupyter is "Detecting Kernels", so
-  // these steps are given a longer-than-default budget.
+  await safeExecuteCommand(workbench, 'Notebook: Select Notebook Kernel');
+  // On a fresh notebook with no kernel association, Jupyter opens the
+  // kernel-source picker directly. On a machine that already has a Python
+  // environment associated with the notebook (e.g. a developer workstation),
+  // Jupyter opens the "Change kernel for ..." picker first, with a
+  // "Select Another Kernel..." option that transitions to the source picker.
+  // The kernel picker can take a while to populate while Jupyter is
+  // "Detecting Kernels", so these steps are given a longer-than-default
+  // budget.
   if (
     await hasQuickPickItem(
       vsCodeDriver,
+      'Change kernel',
       'Select Another Kernel',
       KERNEL_SELECT_WAIT_MS,
     )
   ) {
-    await selectQuickPickItem(vsCodeDriver, 'Select Another Kernel');
+    await selectQuickPickItem(
+      vsCodeDriver,
+      'Change kernel',
+      'Select Another Kernel',
+    );
   }
-  await selectQuickPickItem(vsCodeDriver, 'Colab');
-  await selectQuickPickItem(vsCodeDriver, 'Auto Connect');
+  await selectQuickPickItem(vsCodeDriver, 'kernel source', 'Colab');
+  // "Auto Connect" lives in the remote-server picker that Jupyter opens
+  // after the user picks "Colab" as a kernel source.
+  await selectQuickPickItem(
+    vsCodeDriver,
+    'Select a remote server',
+    'Auto Connect',
+  );
 
   // Sign in.
   await pushDialogButton(vsCodeDriver, 'Allow');
@@ -148,16 +168,17 @@ async function signIn(
     // and closes before we can click.
     await selectQuickPickItemIfShown(
       vsCodeDriver,
+      'Select a Kernel',
       'Python',
       KERNEL_SELECT_WAIT_MS,
     );
-    await workbench.executeCommand('Colab: Remove Server');
+    await safeExecuteCommand(workbench, 'Colab: Remove Server');
     try {
-      await selectQuickPickItem(vsCodeDriver, 'Colab CPU');
+      await selectQuickPickItem(vsCodeDriver, 'Remove Server', 'Colab CPU');
     } catch (err: unknown) {
       console.warn('Could not select "Colab CPU" for cleanup.', err);
     }
-    await workbench.executeCommand('View: Close All Editors');
+    await safeExecuteCommand(workbench, 'View: Close All Editors');
     await pushDialogButtonIfShown(vsCodeDriver, "Don't Save", DIALOG_WAIT_MS);
   } catch (err: unknown) {
     console.warn(

--- a/src/test/e2e/ui.ts
+++ b/src/test/e2e/ui.ts
@@ -395,8 +395,8 @@ export async function hasQuickPickItem(
     return containsOrOthers;
   }
   const others = containsOrOthers;
-  console.log(
-    `Could not find "${item}" in QuickPick, available items: ${others.join(', ')}`,
+  console.info(
+    `(Not an error) Presence check for "${item}" in QuickPick came up dry, available items: ${others.join(', ')}`,
   );
   return false;
 }

--- a/src/test/e2e/ui.ts
+++ b/src/test/e2e/ui.ts
@@ -27,6 +27,13 @@ export const KERNEL_SELECT_WAIT_MS = 30000;
 const ELEMENT_WAIT_MS = 10000;
 
 /**
+ * Short timeout for "is anything open?" probes. Long enough to absorb the
+ * normal driver round-trip latency, short enough that the absence case
+ * (nothing open) is cheap.
+ */
+const DIALOG_CHECK_WAIT_MS = 500;
+
+/**
  * The wait duration for all notebook cells to execute, in milliseconds.
  *
  * Cell execution can be slow on a freshly assigned Colab server.
@@ -34,80 +41,290 @@ const ELEMENT_WAIT_MS = 10000;
 const CELL_EXECUTION_WAIT_MS = 120000;
 
 /**
+ * Reads identity hints from the picker currently on screen, in priority
+ * order: title bar text, the input element's `aria-label`, and finally the
+ * `placeholder`. Returns whatever it could observe (any field may be
+ * `undefined`); does not throw.
+ *
+ * VS Code uses a single shared `<input>` element for all QuickPick/InputBox
+ * surfaces and just swaps these attributes when the active picker changes,
+ * so reading them is how you tell which picker is up.
+ *
+ * @param inputBox - An open InputBox handle.
+ * @returns The picker identity hints; each field may be `undefined` when
+ * the corresponding attribute is missing or unreadable.
+ */
+export async function pickerIdentity(inputBox: InputBox): Promise<{
+  title?: string;
+  ariaLabel?: string;
+  placeholder?: string;
+}> {
+  // Each read is best-effort; if any selector mismatches the current DOM we
+  // still want to return what we got.
+  let title: string | undefined;
+  try {
+    title = await inputBox.getTitle();
+  } catch {
+    /* leave undefined */
+  }
+  let placeholder: string | undefined;
+  try {
+    placeholder = await inputBox.getPlaceHolder();
+  } catch {
+    /* leave undefined */
+  }
+  let ariaLabel: string | undefined;
+  try {
+    // Reach for the underlying <input> element. The redhat page-objects
+    // package doesn't expose this directly so we re-derive it from the
+    // same locator chain `getPlaceHolder()` uses internally.
+    const input = await inputBox
+      .findElement(By.className('monaco-inputbox'))
+      .findElement(By.className('input'));
+    const attr = await input.getAttribute('aria-label');
+    ariaLabel = attr || undefined;
+  } catch {
+    /* leave undefined */
+  }
+  return { title, ariaLabel, placeholder };
+}
+
+/**
+ * Dismisses any currently-open InputBox / QuickPick by pressing ESCAPE and
+ * waits for it to actually disappear before returning. Safe to call when no
+ * picker is open (returns immediately).
+ *
+ * Why this exists: VS Code reuses a single `<input>` element for the command
+ * palette, the kernel picker, `Colab: Remove Server`, etc. If a prior step
+ * leaves a picker open (e.g. a cleanup `selectQuickPickItem` times out),
+ * every subsequent `executeCommand` call sends Ctrl+Shift+P that gets
+ * absorbed by the still-focused orphan picker and the `>command` text is
+ * typed into its filter instead of being executed.
+ *
+ * @param driver - The driver instance.
+ * @param waitMs - How long to wait for the input to disappear after ESCAPE.
+ */
+export async function dismissAnyOpenInput(
+  driver: WebDriver,
+  waitMs: number = ELEMENT_WAIT_MS,
+): Promise<void> {
+  let inputBox: InputBox;
+  try {
+    inputBox = await InputBox.create(DIALOG_CHECK_WAIT_MS);
+  } catch {
+    return; // Nothing is open.
+  }
+  try {
+    await inputBox.cancel();
+  } catch {
+    // Element may have gone stale between probe and cancel; fall through to
+    // the disappear wait below.
+  }
+  // Confirm the input is actually gone. If a new picker pops up immediately
+  // (rare, but possible if an extension reacts to dismissal) we accept that
+  // and let the next step handle it.
+  await driver
+    .wait(async () => {
+      try {
+        await InputBox.create(DIALOG_CHECK_WAIT_MS);
+        return false;
+      } catch {
+        return true;
+      }
+    }, waitMs)
+    .catch(() => {
+      // Best-effort: a picker is still on screen but it's no longer ours to
+      // clean up; let the caller proceed.
+    });
+}
+
+/**
  * Creates a new Jupyter notebook and waits for it to be fully loaded.
  *
  * @param workbench - The workbench instance.
  */
 export async function createNotebook(workbench: Workbench): Promise<void> {
-  await workbench.executeCommand('Create: New Jupyter Notebook');
+  await safeExecuteCommand(workbench, 'Create: New Jupyter Notebook');
   await notebookLoaded(workbench.getDriver());
 }
 
 /**
- * Selects the QuickPick option.
+ * Like {@link Workbench.executeCommand} but guarantees no orphan
+ * QuickPick/InputBox is open beforehand. See {@link dismissAnyOpenInput}
+ * for the motivation.
  *
- * @param driver - The driver instance.
- * @param item - The UI item.
- * @param waitMs - The wait duration in milliseconds.
- * @returns A promise that resolves when the QuickPick item is selected.
+ * Prefer this over `workbench.executeCommand(...)` for every e2e step.
+ *
+ * @param workbench - The workbench instance.
+ * @param command - The command to execute (no leading `>`).
  */
-export function selectQuickPickItem(
-  driver: WebDriver,
-  item: string,
-  waitMs: number = ELEMENT_WAIT_MS,
-) {
-  return driver.wait(
-    async () => {
-      try {
-        const inputBox = await InputBox.create();
-        // Some hover events can interfere with clicking the quick pick item.
-        // Filtering the text first to ensure we click the right item.
-        await inputBox.setText(item);
-        // We check for the item's presence before selecting it, since
-        // InputBox.selectQuickPick will not throw if the item is not found.
-        const quickPickItem = await inputBox.findQuickPick(item);
-        if (!quickPickItem) {
-          return false;
-        }
-        await quickPickItem.select();
-        return true;
-      } catch {
-        // Swallow errors since we want to fail when our timeout's reached.
-        return false;
-      }
-    },
-    waitMs,
-    `Could not select "${item}" from QuickPick`,
-  );
+export async function safeExecuteCommand(
+  workbench: Workbench,
+  command: string,
+): Promise<void> {
+  await dismissAnyOpenInput(workbench.getDriver());
+  await workbench.executeCommand(command);
 }
 
 /**
- * Like {@link selectQuickPickItem} but tolerant of the QuickPick having
- * already been resolved/dismissed by the time it runs.
+ * Selects an item from the QuickPick currently on screen, asserting first
+ * that the open picker is the one the caller expects.
  *
- * Returns `true` if the item was selected, `false` if no QuickPick is shown
- * (or shown without the requested item) within {@link waitMs}. Never throws
- * on absence. Useful for steps where the picker may auto-select the only
- * option (e.g. when there is just one Python kernel available) and close
- * before the test gets a chance to click it.
+ * The picker-identity guard is the load-bearing part of this helper.
+ * Without it, the bare `InputBox.create()` + `setText(item)` sequence will
+ * happily type `item` into whatever picker is open — including pickers that
+ * a previous test step opened and didn't dismiss (e.g. an orphan
+ * `Colab: Remove Server` picker). When that happens the test "succeeds" at
+ * filtering the wrong picker's list, then fails with a misleading
+ * timeout/no-such-element later. The guard converts those silent failures
+ * into a poll-and-wait for the *correct* picker.
+ *
+ * Note: this still uses `setText`, which clears and refills the input. If
+ * the picker on screen flips between the guard check and the setText call,
+ * the worst case is that the iteration's `findQuickPick` returns nothing and
+ * we retry. We never type into a picker we didn't assert on.
  *
  * @param driver - The driver instance.
- * @param item - The UI item.
+ * @param expectedPickerSubstring - A substring uniquely identifying the
+ * picker the caller expects on screen. {@link pickerIdentity} checks this
+ * against the input's title bar text, `aria-label`, and `placeholder`, so
+ * any reliable substring of one of those works (e.g. `"Remove Server"` for
+ * the title bar, `"kernel source"` for the placeholder). Use `undefined`
+ * only when you genuinely don't care which picker is open (rare; almost
+ * always wrong for e2e tests).
+ * @param item - The QuickPick item label substring to select.
+ * @param waitMs - Total wait budget for both the picker to appear and the
+ * item to be matched.
+ * @returns A promise that resolves when the QuickPick item is selected, or
+ * rejects on timeout. On timeout the rejection message includes the
+ * identity of whatever picker was on screen and the items it offered, to
+ * make debugging cheaper.
+ */
+export function selectQuickPickItem(
+  driver: WebDriver,
+  expectedPickerSubstring: string | undefined,
+  item: string,
+  waitMs: number = ELEMENT_WAIT_MS,
+): Promise<void> {
+  // Track the most recent observation so the timeout message has something
+  // actionable to report — without this the failure looks identical whether
+  // the wrong picker was open, the right picker was empty, or no picker
+  // ever appeared.
+  const lastSeen: {
+    identity?: { title?: string; ariaLabel?: string; placeholder?: string };
+    items?: string[];
+  } = {};
+
+  return driver
+    .wait(
+      async () => {
+        try {
+          const inputBox = await InputBox.create(DIALOG_CHECK_WAIT_MS);
+          const identity = await pickerIdentity(inputBox);
+          lastSeen.identity = identity;
+          if (expectedPickerSubstring !== undefined) {
+            const candidates = [
+              identity.title,
+              identity.ariaLabel,
+              identity.placeholder,
+            ];
+            if (!pickerIdentityMatches(candidates, expectedPickerSubstring)) {
+              return false;
+            }
+          }
+          // Some hover events can interfere with clicking the quick pick
+          // item. Filtering the text first to ensure we click the right
+          // item.
+          await inputBox.setText(item);
+          // Check for the item's presence before selecting it, since
+          // `InputBox.selectQuickPick` does not throw if the item is missing.
+          const quickPickItem = await inputBox.findQuickPick(item);
+          if (!quickPickItem) {
+            // Snapshot what items the picker offered so we can include them
+            // in the timeout message; best-effort.
+            try {
+              const picks = await inputBox.getQuickPicks();
+              lastSeen.items = await Promise.all(
+                picks.map((p) => p.getLabel()),
+              );
+            } catch {
+              // Ignore; we'll just print whatever we have.
+            }
+            return false;
+          }
+          await quickPickItem.select();
+          return true;
+        } catch {
+          // Swallow errors since we want to fail when our timeout's reached.
+          return false;
+        }
+      },
+      waitMs,
+      formatSelectTimeoutMessage(expectedPickerSubstring, item, lastSeen),
+    )
+    .then(() => undefined);
+}
+
+/**
+ * Like {@link selectQuickPickItem} but tolerant of the picker never
+ * appearing (or appearing without the requested item). Resolves to `true`
+ * if the item was selected, `false` otherwise; never throws on absence.
+ *
+ * Useful for steps where the picker may auto-select the only option (e.g.
+ * when there is just one Python kernel available) and close before the
+ * test gets a chance to click it. The picker-identity guard still applies:
+ * an open picker that isn't the expected one is treated the same as no
+ * picker at all (returns `false` after the wait window).
+ *
+ * @param driver - The driver instance.
+ * @param expectedPickerSubstring - A substring uniquely identifying the
+ * picker the caller expects on screen. See {@link selectQuickPickItem} for
+ * how this is matched.
+ * @param item - The QuickPick item label substring to select.
  * @param waitMs - The wait duration in milliseconds.
- * @returns A promise that resolves to true if the item was selected, and
- * false otherwise.
+ * @returns `true` if the item was selected, `false` otherwise.
  */
 export async function selectQuickPickItemIfShown(
   driver: WebDriver,
+  expectedPickerSubstring: string | undefined,
   item: string,
   waitMs: number = ELEMENT_WAIT_MS,
 ): Promise<boolean> {
   try {
-    await selectQuickPickItem(driver, item, waitMs);
+    await selectQuickPickItem(driver, expectedPickerSubstring, item, waitMs);
     return true;
   } catch {
     return false;
   }
+}
+
+function formatSelectTimeoutMessage(
+  expectedPickerSubstring: string | undefined,
+  item: string,
+  lastSeen: {
+    identity?: { title?: string; ariaLabel?: string; placeholder?: string };
+    items?: string[];
+  },
+): string {
+  const parts: string[] = [`Could not select "${item}" from QuickPick`];
+  if (expectedPickerSubstring !== undefined) {
+    parts.push(`(expected picker matching "${expectedPickerSubstring}")`);
+  }
+  const id = lastSeen.identity;
+  if (id) {
+    const observed = [
+      id.title && `title="${id.title}"`,
+      id.ariaLabel && `aria-label="${id.ariaLabel}"`,
+      id.placeholder && `placeholder="${id.placeholder}"`,
+    ].filter(Boolean);
+    if (observed.length > 0) {
+      parts.push(`last observed picker: ${observed.join(', ')}`);
+    }
+  }
+  if (lastSeen.items) {
+    parts.push(`available items: [${lastSeen.items.join(', ')}]`);
+  }
+  return parts.join('; ');
 }
 
 /**
@@ -119,6 +336,10 @@ export async function selectQuickPickItemIfShown(
  * requirement should use {@link selectQuickPickItem} instead.
  *
  * @param driver - The driver instance.
+ * @param expectedPickerSubstring - A substring uniquely identifying the
+ * picker the caller expects on screen, or `undefined` to skip the
+ * picker-identity check. See {@link selectQuickPickItem} for how this is
+ * matched.
  * @param item - The UI item.
  * @param waitMs - The wait duration in milliseconds.
  * @returns A promise that resolves to true if the item is found, and false
@@ -126,6 +347,7 @@ export async function selectQuickPickItemIfShown(
  */
 export async function hasQuickPickItem(
   driver: WebDriver,
+  expectedPickerSubstring: string | undefined,
   item: string,
   waitMs: number = ELEMENT_WAIT_MS,
 ): Promise<boolean> {
@@ -133,7 +355,19 @@ export async function hasQuickPickItem(
   try {
     containsOrOthers = await driver.wait(async () => {
       try {
-        const inputBox = await InputBox.create();
+        const inputBox = await InputBox.create(DIALOG_CHECK_WAIT_MS);
+        if (expectedPickerSubstring !== undefined) {
+          const identity = await pickerIdentity(inputBox);
+          if (
+            !pickerIdentityMatches(
+              [identity.title, identity.ariaLabel, identity.placeholder],
+              expectedPickerSubstring,
+            )
+          ) {
+            // Wrong picker on screen; keep polling for the right one.
+            return false;
+          }
+        }
         const quickPickItem = await inputBox.findQuickPick(item);
         if (quickPickItem) {
           return true;
@@ -168,25 +402,42 @@ export async function hasQuickPickItem(
 }
 
 /**
+ * A single step in a {@link selectQuickPicksInOrder} call: the picker
+ * expected to be on screen, and the item to pick from it.
+ */
+export interface QuickPickStep {
+  /**
+   * Substring uniquely identifying the picker. See
+   * {@link selectQuickPickItem} for how this is matched.
+   */
+  picker: string;
+  /** QuickPick item label substring to select. */
+  item: string;
+  /** Optional override for the default per-step wait budget. */
+  waitMs?: number;
+}
+
+/**
  * Selects the QuickPick options in order.
  *
- * Useful for selecting through multiple QuickPick prompts in a row.
+ * Useful for selecting through multiple QuickPick prompts in a row. Each
+ * step asserts the expected picker is on screen before typing into it.
  *
  * @param driver - The driver instance.
- * @param items - The UI items collection.
+ * @param steps - The picker + item pairs to step through.
  */
 export async function selectQuickPicksInOrder(
   driver: WebDriver,
-  items: string[],
-) {
-  for (const item of items) {
-    await selectQuickPickItem(driver, item);
+  steps: readonly QuickPickStep[],
+): Promise<void> {
+  for (const step of steps) {
+    await selectQuickPickItem(driver, step.picker, step.item, step.waitMs);
   }
 }
 
 /**
- * Confirms an InputBox identified by a substring of its title, accepting its
- * current (default) value.
+ * Confirms an InputBox identified by a substring of its title (or
+ * aria-label / placeholder), accepting its current (default) value.
  *
  * Why not `InputBox.create()` + `sendKeys(Key.ENTER)` directly? Because of a
  * subtle race during QuickPick → InputBox transitions: the previous QuickPick
@@ -195,27 +446,35 @@ export async function selectQuickPicksInOrder(
  * then end up typing kernel-selection filter text into the still-open alias
  * input.
  *
- * This helper polls until an InputBox with the expected title is shown,
- * confirms it, and then waits for that input to transition away (i.e., either
- * close or be replaced by an unrelated input). Only then does it return,
- * guaranteeing follow-up `selectQuickPickItem` calls operate on the next UI
- * surface.
+ * This helper polls until an InputBox matching {@link expectedPickerSubstring}
+ * is shown, confirms it, and then waits for that input to transition away
+ * (i.e., either close or be replaced by an unrelated input). Only then does
+ * it return, guaranteeing follow-up `selectQuickPickItem` calls operate on
+ * the next UI surface.
  *
  * @param driver - The driver instance.
- * @param expectedTitleSubstring - A substring expected to appear in the
- * InputBox title (e.g. `"Alias your server"`).
+ * @param expectedPickerSubstring - A substring uniquely identifying the
+ * picker the caller expects on screen. See {@link selectQuickPickItem} for
+ * how this is matched.
  */
 export async function confirmInputBoxWithDefault(
   driver: WebDriver,
-  expectedTitleSubstring: string,
+  expectedPickerSubstring: string,
 ): Promise<void> {
+  const matchesExpected = async (inputBox: InputBox) => {
+    const identity = await pickerIdentity(inputBox);
+    return pickerIdentityMatches(
+      [identity.title, identity.ariaLabel, identity.placeholder],
+      expectedPickerSubstring,
+    );
+  };
+
   // Phase 1: wait for the expected InputBox to be shown, then confirm it.
   await driver.wait(
     async () => {
       try {
-        const inputBox = await InputBox.create();
-        const title = await inputBox.getTitle();
-        if (!title?.includes(expectedTitleSubstring)) {
+        const inputBox = await InputBox.create(DIALOG_CHECK_WAIT_MS);
+        if (!(await matchesExpected(inputBox))) {
           return false;
         }
         await inputBox.confirm();
@@ -226,25 +485,24 @@ export async function confirmInputBoxWithDefault(
       }
     },
     ELEMENT_WAIT_MS,
-    `Could not confirm InputBox with title containing "${expectedTitleSubstring}"`,
+    `Could not confirm InputBox matching "${expectedPickerSubstring}"`,
   );
 
   // Phase 2: wait for the InputBox to transition away. It either closes
-  // entirely or is replaced by an unrelated InputBox/QuickPick whose title
-  // does not contain the expected substring.
+  // entirely or is replaced by an unrelated InputBox/QuickPick that does
+  // not match the expected substring.
   await driver.wait(
     async () => {
       try {
-        const inputBox = await InputBox.create();
-        const title = await inputBox.getTitle();
-        return !title?.includes(expectedTitleSubstring);
+        const inputBox = await InputBox.create(DIALOG_CHECK_WAIT_MS);
+        return !(await matchesExpected(inputBox));
       } catch {
         // No InputBox present at all, transition complete.
         return true;
       }
     },
     ELEMENT_WAIT_MS,
-    `InputBox "${expectedTitleSubstring}" did not close after confirm`,
+    `InputBox "${expectedPickerSubstring}" did not close after confirm`,
   );
 }
 
@@ -371,6 +629,23 @@ export async function assertAllCellsExecutedSuccessfully(
     waitMs,
     'Not all cells executed successfully',
   );
+}
+
+/**
+ * Returns true if any of the candidate identity strings observed from the
+ * picker on screen contains the expected substring.
+ *
+ * @param candidates - Identity strings observed from the picker on screen
+ * (title, aria-label, placeholder). Falsy entries are ignored.
+ * @param expectedSubstring - The substring that uniquely identifies the
+ * picker the caller expects (e.g. `"Remove Server"`).
+ * @returns `true` when at least one candidate contains `expectedSubstring`.
+ */
+function pickerIdentityMatches(
+  candidates: readonly (string | undefined | null)[],
+  expectedSubstring: string,
+): boolean {
+  return candidates.some((c) => !!c && c.includes(expectedSubstring));
 }
 
 async function notebookLoaded(driver: WebDriver): Promise<void> {

--- a/src/test/e2e/upload.e2e.test.ts
+++ b/src/test/e2e/upload.e2e.test.ts
@@ -17,6 +17,7 @@ import {
   createNotebook,
   hasQuickPickItem,
   KERNEL_SELECT_WAIT_MS,
+  safeExecuteCommand,
   selectQuickPickItem,
   selectQuickPickItemIfShown,
   selectQuickPicksInOrder,
@@ -30,14 +31,24 @@ it('uploads a file from the explorer context menu', async () => {
   const driver = workbench.getDriver();
 
   await createNotebook(workbench);
-  await workbench.executeCommand('Notebook: Select Notebook Kernel');
-  if (await hasQuickPickItem(driver, 'Select Another Kernel')) {
-    await selectQuickPickItem(driver, 'Select Another Kernel');
+  await safeExecuteCommand(workbench, 'Notebook: Select Notebook Kernel');
+  if (
+    await hasQuickPickItem(driver, 'Change kernel', 'Select Another Kernel')
+  ) {
+    await selectQuickPickItem(driver, 'Change kernel', 'Select Another Kernel');
   }
-  await selectQuickPicksInOrder(driver, ['Colab', 'Auto Connect']);
-  await selectQuickPickItemIfShown(driver, 'Python', KERNEL_SELECT_WAIT_MS);
+  await selectQuickPicksInOrder(driver, [
+    { picker: 'kernel source', item: 'Colab' },
+    { picker: 'Select a remote server', item: 'Auto Connect' },
+  ]);
+  await selectQuickPickItemIfShown(
+    driver,
+    'Select a Kernel',
+    'Python',
+    KERNEL_SELECT_WAIT_MS,
+  );
 
-  await workbench.executeCommand('View: Show Explorer');
+  await safeExecuteCommand(workbench, 'View: Show Explorer');
   const explorerSection = await driver.wait(
     async () => {
       try {
@@ -76,7 +87,7 @@ it('uploads a file from the explorer context menu', async () => {
 
   // The Contents tree is rooted on a collapsed server node ("Colab CPU");
   // `findItem` scrolls but does not auto-expand parents, so expand first.
-  await workbench.executeCommand('Colab: Focus on Contents View');
+  await safeExecuteCommand(workbench, 'Colab: Focus on Contents View');
   await driver.wait(
     async () => {
       try {
@@ -104,7 +115,7 @@ it('uploads a file from the explorer context menu', async () => {
   // Verify the uploaded file content via a Python cell that raises on
   // mismatch. If the upload landed the wrong bytes, the cell errors and
   // `assertAllCellsExecutedSuccessfully` fails.
-  await workbench.executeCommand('Notebook: Edit Cell');
+  await safeExecuteCommand(workbench, 'Notebook: Edit Cell');
   const cell = await driver.switchTo().activeElement();
   await cell.sendKeys(
     `expected = 'Hello world!\\n'
@@ -112,6 +123,6 @@ actual = open('/content/hello-world.txt').read()
 assert actual == expected, f'expected {expected!r}, got {actual!r}'`,
   );
 
-  await workbench.executeCommand('Notebook: Run All');
+  await safeExecuteCommand(workbench, 'Notebook: Run All');
   await assertAllCellsExecutedSuccessfully(driver, workbench);
 });

--- a/src/test/e2e/upload.e2e.test.ts
+++ b/src/test/e2e/upload.e2e.test.ts
@@ -33,9 +33,9 @@ it('uploads a file from the explorer context menu', async () => {
   await createNotebook(workbench);
   await safeExecuteCommand(workbench, 'Notebook: Select Notebook Kernel');
   if (
-    await hasQuickPickItem(driver, 'Change kernel', 'Select Another Kernel')
+    await hasQuickPickItem(driver, 'kernel', 'Select Another Kernel')
   ) {
-    await selectQuickPickItem(driver, 'Change kernel', 'Select Another Kernel');
+    await selectQuickPickItem(driver, 'kernel', 'Select Another Kernel');
   }
   await selectQuickPicksInOrder(driver, [
     { picker: 'kernel source', item: 'Colab' },

--- a/src/test/e2e/upload.e2e.test.ts
+++ b/src/test/e2e/upload.e2e.test.ts
@@ -32,9 +32,7 @@ it('uploads a file from the explorer context menu', async () => {
 
   await createNotebook(workbench);
   await safeExecuteCommand(workbench, 'Notebook: Select Notebook Kernel');
-  if (
-    await hasQuickPickItem(driver, 'kernel', 'Select Another Kernel')
-  ) {
+  if (await hasQuickPickItem(driver, 'kernel', 'Select Another Kernel')) {
     await selectQuickPickItem(driver, 'kernel', 'Select Another Kernel');
   }
   await selectQuickPicksInOrder(driver, [


### PR DESCRIPTION
There's been a new batch of flakes pop up (likely due to a change in VS Code or our internal test harness infrastructure). This set of fixes should hopefully fix them.

VS Code uses a single shared `<input>` element for all QuickPick/InputBox surfaces (command palette, kernel picker, "Remove Server", etc.) and just swaps `aria-label`/`placeholder`/title-bar text when the active picker changes. `vscode-extension-tester`'s `InputBox.create()` returns a handle to whatever picker is on screen with no check that it's the one the caller intended, so any prior step that leaves a picker open silently corrupts every subsequent `setText` / `executeCommand`.

This produced two related flake modes seen in our internal probe runs:

  1. Orphan picker: a cleanup `selectQuickPickItem('Colab CPU')` times out against the Remove Server picker; the `try/catch` swallows the error but the picker stays open. Every subsequent `executeCommand` sends Ctrl+Shift+P, which is captured by the still-focused picker, and the `>command` text is typed into its filter instead of being executed. The next test then fails with `Notebook editor did not load in time`.

  2. Picker-switch mid-call: while polling for "Python" in the kernel picker, the active picker on screen flips to Remove Server (e.g. from a cascading error flow); `setText('Python')` lands on the wrong picker's filter, the test eventually times out, and the failure screenshot shows "Remove Server" with "Python" typed into it.

Fixes:

  * `pickerIdentity()` / `pickerIdentityMatches()` read the title bar, input aria-label, and placeholder, and check whether the open picker matches a caller-supplied substring.
  * `selectQuickPickItem`, `selectQuickPickItemIfShown`, `hasQuickPickItem`, `confirmInputBoxWithDefault`, and `selectQuickPicksInOrder` now take an `expectedPickerSubstring` and skip iterations where the open picker isn't the expected one. This prevents picker-switch-mid-call (mode 2). Call sites pass the substring inline at each call (per go/tott/643: favor DAMP over DRY in tests so each step is self-documenting), e.g. `selectQuickPickItem(driver, 'Remove Server', 'Colab CPU')`.
  * `dismissAnyOpenInput()` presses ESCAPE and waits for the input to disappear; called from the `catch` branch of the cleanup's `Colab CPU` selection in `test-setup.ts`, and prepended to `afterEach`. Prevents orphan-picker poisoning (mode 1).
  * `safeExecuteCommand()` wraps `Workbench.executeCommand` with a `dismissAnyOpenInput` precondition. All e2e callers now use this instead of the raw `workbench.executeCommand(...)` so "no picker open" is enforced before every command-palette invocation.
  * `selectQuickPickItem`'s timeout message now reports the observed picker identity and the QuickPick items it offered, so the next failure points directly at "wrong picker open" or "expected item missing" instead of looking identical to a generic timeout.

src/test/e2e/connect-execute.e2e.test.ts #	modified: src/test/e2e/mount-drive.e2e.test.ts #	modified:
src/test/e2e/resource-view.e2e.test.ts #	modified:   src/test/e2e/test-setup.ts