### PR TITLE
test: update e2e test email selector

### DIFF
--- a/src/test/e2e/auth.ts
+++ b/src/test/e2e/auth.ts
@@ -27,7 +27,7 @@ export async function doOAuthSignIn(
 
   // Input the test account email address.
   const emailInput = await chromeDriver.findElement(
-    By.css("input[type='email']"),
+    By.css("input[aria-label*='email' i]"),
   );
   await emailInput.clear();
   await emailInput.sendKeys(process.env.TEST_ACCOUNT_EMAIL ?? '');


### PR DESCRIPTION
This change updates the email selector in the e2e test to search for the string "email" in the aria-label (case insensitive)

The input type has changed recently, breaking the existing selector