### PR TITLE
fix: failing `upload file` E2E test

### DIFF
--- a/src/auth/code-manager.ts
+++ b/src/auth/code-manager.ts
@@ -5,16 +5,9 @@
  */
 
 import vscode from 'vscode';
+import { DisposablePromise, waitForTimeout } from '../common/async';
 
 const EXCHANGE_TIMEOUT_MS = 60_000;
-
-/**
- * A promise that can have its underlying resources (like timers or listeners)
- * cleaned up.
- */
-interface DisposablePromise<T> extends vscode.Disposable {
-  promise: Promise<T>;
-}
 
 /**
  * Provides the mechanism to wait for and resolve authorization codes. This
@@ -58,7 +51,10 @@ export class CodeManager implements vscode.Disposable {
     }
 
     const userCancellation = waitForCancellation(token);
-    const timeout = waitForTimeout(EXCHANGE_TIMEOUT_MS);
+    const timeout = waitForTimeout(
+      EXCHANGE_TIMEOUT_MS,
+      'Exchange timeout exceeded',
+    );
 
     try {
       const codePromise = new Promise<string>((resolve, reject) => {
@@ -124,28 +120,5 @@ function waitForCancellation(
     promise,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     dispose: () => listener.dispose(),
-  };
-}
-
-/**
- * Creates a promise that rejects after a specified timeout.
- * Returns a disposable to clear the timer.
- *
- * @param ms - The delay duration in milliseconds.
- * @returns A disposable promise that rejects after the specified timeout.
- */
-function waitForTimeout(ms: number): DisposablePromise<never> {
-  let timeoutId: NodeJS.Timeout;
-  const promise = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(() => {
-      reject(new Error('Exchange timeout exceeded'));
-    }, ms);
-  });
-
-  return {
-    promise,
-    dispose: () => {
-      clearTimeout(timeoutId);
-    },
   };
 }

--- a/src/common/async.ts
+++ b/src/common/async.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import vscode from 'vscode';
 import { log } from './logging';
 
 /**
@@ -90,4 +91,40 @@ export function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
     (typeof value === 'object' || typeof value === 'function') &&
     typeof (value as { then?: unknown }).then === 'function'
   );
+}
+
+/**
+ * A promise that can have its underlying resources (like timers or listeners)
+ * cleaned up.
+ */
+export interface DisposablePromise<T> extends vscode.Disposable {
+  /** The underlying promise that can be awaited. */
+  promise: Promise<T>;
+}
+
+/**
+ * Creates a promise that rejects after a specified timeout.
+ * Returns a disposable to clear the timer.
+ *
+ * @param ms - The delay duration in milliseconds.
+ * @param message - The error message for the timeout.
+ * @returns A disposable promise that rejects after the specified timeout.
+ */
+export function waitForTimeout(
+  ms: number,
+  message: string,
+): DisposablePromise<never> {
+  let timeoutId: NodeJS.Timeout;
+  const promise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(message));
+    }, ms);
+  });
+
+  return {
+    promise,
+    dispose: () => {
+      clearTimeout(timeoutId);
+    },
+  };
 }

--- a/src/common/async.unit.test.ts
+++ b/src/common/async.unit.test.ts
@@ -5,11 +5,11 @@
  */
 
 import { expect } from 'chai';
-import sinon from 'sinon';
+import sinon, { SinonFakeTimers } from 'sinon';
 import { Deferred } from '../test/helpers/async';
 import { ColabLogWatcher } from '../test/helpers/logging';
 import { newVsCodeStub } from '../test/helpers/vscode';
-import { LatestCancelable } from './async';
+import { LatestCancelable, waitForTimeout } from './async';
 import { LogLevel } from './logging';
 
 describe('LatestCancelable', () => {
@@ -193,5 +193,44 @@ describe('LatestCancelable', () => {
       await expect(result).to.eventually.be.undefined;
       sinon.assert.calledOnce(worker);
     });
+  });
+});
+
+describe('waitForTimeout', () => {
+  let fakeClock: SinonFakeTimers;
+
+  beforeEach(() => {
+    fakeClock = sinon.useFakeTimers({
+      now: new Date(),
+      toFake: [],
+      shouldAdvanceTime: false,
+    });
+  });
+
+  afterEach(() => {
+    fakeClock.restore();
+    sinon.restore();
+  });
+
+  it('rejects the promise after the specified timeout', async () => {
+    const timeoutMs = 1000;
+
+    const timeout = waitForTimeout(timeoutMs, 'Timeout exceeded');
+    expect(timeout.promise).to.not.be.rejected;
+
+    await fakeClock.tickAsync(timeoutMs);
+    await expect(timeout.promise).to.eventually.be.rejectedWith(
+      'Timeout exceeded',
+    );
+  });
+
+  it('clears the timeout on dispose', async () => {
+    const timeoutMs = 1000;
+    const timeout = waitForTimeout(timeoutMs, 'Timeout exceeded');
+
+    timeout.dispose();
+
+    await fakeClock.tickAsync(timeoutMs + 100);
+    expect(timeout.promise).to.not.be.rejected;
   });
 });

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -37,6 +37,7 @@ import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../colab/headers';
+import { waitForTimeout } from '../common/async';
 import { log } from '../common/logging';
 import { telemetry } from '../telemetry';
 import { AssignmentOutcome, CommandSource } from '../telemetry/api';
@@ -746,11 +747,15 @@ export class AssignmentManager implements Disposable {
             // For any remote servers created in Colab web UI, assuming there
             // is only one session per assignment.
             let label: string;
+            const timeout = waitForTimeout(
+              LIST_SESSIONS_TIMEOUT_MS,
+              `Listing sessions timeout exceeded for endpoint ${a.endpoint}`,
+            );
             try {
-              const sessions = await this.client.listSessions(
-                a.endpoint,
-                signal,
-              );
+              const sessions = await Promise.race([
+                this.client.listSessions(a.endpoint, signal),
+                timeout.promise,
+              ]);
               label =
                 sessions.length === 1 && sessions[0].name?.length
                   ? sessions[0].name
@@ -777,6 +782,8 @@ export class AssignmentManager implements Disposable {
                 error,
               );
               label = UNKNOWN_REMOTE_SERVER_NAME;
+            } finally {
+              timeout.dispose();
             }
             return {
               label,
@@ -864,6 +871,8 @@ export class AssignmentManager implements Disposable {
 enum AssignmentsExceededActions {
   REMOVE_SERVER = 'Remove Server',
 }
+
+const LIST_SESSIONS_TIMEOUT_MS = 3000;
 
 const LEARN_MORE = 'Learn More';
 

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -500,13 +500,21 @@ export class AssignmentManager implements Disposable {
       return;
     }
     const client = ProxiedJupyterClient.withStaticConnection(server);
+    // Best-effort clean up sessions before unassigning the server. Without
+    // this, session won't immediately disconnect if there is a notebook
+    // attached in VS Code. However, we don't want to fail the entire
+    // unassignServer call because the unassign API call will eventually garbage
+    // collect and clean up the session(s) too.
     await Promise.all(
       (await client.sessions.list({ signal })).map((session) =>
         session.id
           ? client.sessions.delete({ session: session.id }, { signal })
           : Promise.resolve(),
       ),
-    );
+    ).catch((err: unknown) => {
+      // Swallow the error as this is best-effort.
+      log.warn('Error occurred while deleting sessions:', err);
+    });
     await this.client.unassign(server.endpoint, signal);
     const removed = await this.storage.remove(server.id);
     if (!removed) {

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -506,13 +506,22 @@ export class AssignmentManager implements Disposable {
     // unassignServer call because the unassign API call will eventually garbage
     // collect and clean up the session(s) too.
     await Promise.all(
-      (await client.sessions.list({ signal })).map((session) =>
-        session.id
-          ? client.sessions.delete({ session: session.id }, { signal })
-          : Promise.resolve(),
-      ),
+      await client.sessions
+        .list({ signal })
+        .catch((err: unknown) => {
+          // Swallow the sessions.list error as this is best-effort.
+          log.warn('Error occurred while listing sessions:', err);
+          return [];
+        })
+        .then((sessions) =>
+          sessions.map((session) =>
+            session.id
+              ? client.sessions.delete({ session: session.id }, { signal })
+              : Promise.resolve(),
+          ),
+        ),
     ).catch((err: unknown) => {
-      // Swallow the error as this is best-effort.
+      // Swallow the sessions.delete errors as this is best-effort.
       log.warn('Error occurred while deleting sessions:', err);
     });
     await this.client.unassign(server.endpoint, signal);

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -963,3 +963,7 @@ function errorToAssignmentOutcome(error: unknown): AssignmentOutcome {
   }
   return AssignmentOutcome.ASSIGNMENT_OUTCOME_OTHER_FAILURE;
 }
+
+export const TEST_ONLY = {
+  LIST_SESSIONS_TIMEOUT_MS,
+};

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -853,7 +853,7 @@ export class AssignmentManager implements Disposable {
     // unassignServer call because the unassign API call will eventually garbage
     // collect and clean up the sessions too.
     const client = ProxiedJupyterClient.withStaticConnection(server);
-    return Promise.all(
+    return Promise.allSettled(
       await client.sessions
         .list({ signal })
         .catch((err: unknown) => {

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -748,7 +748,7 @@ export class AssignmentManager implements Disposable {
             // is only one session per assignment.
             let label: string;
             const timeout = waitForTimeout(
-              LIST_SESSIONS_TIMEOUT_MS,
+              LIST_UNOWNED_SESSIONS_TIMEOUT_MS,
               `Listing sessions timeout exceeded for endpoint ${a.endpoint}`,
             );
             try {
@@ -872,7 +872,7 @@ enum AssignmentsExceededActions {
   REMOVE_SERVER = 'Remove Server',
 }
 
-const LIST_SESSIONS_TIMEOUT_MS = 3000;
+const LIST_UNOWNED_SESSIONS_TIMEOUT_MS = 3000;
 
 const LEARN_MORE = 'Learn More';
 
@@ -965,5 +965,5 @@ function errorToAssignmentOutcome(error: unknown): AssignmentOutcome {
 }
 
 export const TEST_ONLY = {
-  LIST_SESSIONS_TIMEOUT_MS,
+  LIST_UNOWNED_SESSIONS_TIMEOUT_MS,
 };

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -500,31 +500,7 @@ export class AssignmentManager implements Disposable {
     if (!stored) {
       return;
     }
-    const client = ProxiedJupyterClient.withStaticConnection(server);
-    // Best-effort clean up sessions before unassigning the server. Without
-    // this, session won't immediately disconnect if there is a notebook
-    // attached in VS Code. However, we don't want to fail the entire
-    // unassignServer call because the unassign API call will eventually garbage
-    // collect and clean up the session(s) too.
-    await Promise.all(
-      await client.sessions
-        .list({ signal })
-        .catch((err: unknown) => {
-          // Swallow the sessions.list error as this is best-effort.
-          log.warn('Error occurred while listing sessions:', err);
-          return [];
-        })
-        .then((sessions) =>
-          sessions.map((session) =>
-            session.id
-              ? client.sessions.delete({ session: session.id }, { signal })
-              : Promise.resolve(),
-          ),
-        ),
-    ).catch((err: unknown) => {
-      // Swallow the sessions.delete errors as this is best-effort.
-      log.warn('Error occurred while deleting sessions:', err);
-    });
+    await this.deleteSessions(server, signal);
     await this.client.unassign(server.endpoint, signal);
     const removed = await this.storage.remove(server.id);
     if (!removed) {
@@ -866,6 +842,37 @@ export class AssignmentManager implements Disposable {
       );
     }
   }
+
+  private async deleteSessions(
+    server: ColabAssignedServer,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    // Best-effort clean up sessions before unassigning the server. Without
+    // this, sessions won't immediately disconnect if there are notebooks
+    // attached in VS Code. However, we don't want to fail the entire
+    // unassignServer call because the unassign API call will eventually garbage
+    // collect and clean up the sessions too.
+    const client = ProxiedJupyterClient.withStaticConnection(server);
+    return Promise.all(
+      await client.sessions
+        .list({ signal })
+        .catch((err: unknown) => {
+          // Swallow the sessions.list error as this is best-effort.
+          log.warn('Error occurred while listing sessions:', err);
+          return [];
+        })
+        .then((sessions) =>
+          sessions.map((session) =>
+            session.id
+              ? client.sessions.delete({ session: session.id }, { signal })
+              : Promise.resolve(),
+          ),
+        ),
+    ).catch((err: unknown) => {
+      // Swallow the sessions.delete errors as this is best-effort.
+      log.warn('Error occurred while deleting sessions:', err);
+    });
+  }
 }
 
 enum AssignmentsExceededActions {
@@ -963,7 +970,3 @@ function errorToAssignmentOutcome(error: unknown): AssignmentOutcome {
   }
   return AssignmentOutcome.ASSIGNMENT_OUTCOME_OTHER_FAILURE;
 }
-
-export const TEST_ONLY = {
-  LIST_UNOWNED_SESSIONS_TIMEOUT_MS,
-};

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -1605,6 +1605,28 @@ describe('AssignmentManager', () => {
         );
       });
 
+      it('unassigns the server even if listing session fails', async () => {
+        jupyterStub.sessions.list.rejects(new Error('list failed'));
+
+        await assignmentManager.unassignServer(defaultServer);
+
+        const serversAfter = await assignmentManager.getServers('extension');
+        expect(serversAfter).to.be.empty;
+        sinon.assert.calledOnceWithMatch(
+          colabClientStub.unassign,
+          defaultServer.endpoint,
+        );
+        sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+          added: [],
+          removed: [{ server: defaultServer, userInitiated: true }],
+          changed: [],
+        });
+        sinon.assert.calledOnceWithMatch(
+          vsCodeStub.window.showInformationMessage,
+          sinon.match(/notebooks Colab GPU A100 was/),
+        );
+      });
+
       it('unassigns the server even if deleting session fails', async () => {
         const session = {
           id: 'mock-session-id-1',

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -844,20 +844,20 @@ describe('AssignmentManager', () => {
       colabClientStub.listSessions.callsFake(async () => {
         // Block listSessions to trigger the timeout.
         await new Promise((resolve) =>
-          setTimeout(resolve, TEST_ONLY.LIST_SESSIONS_TIMEOUT_MS + 100),
+          setTimeout(resolve, TEST_ONLY.LIST_UNOWNED_SESSIONS_TIMEOUT_MS + 100),
         );
         return [
           {
             ...defaultSession,
-            name: 'test-session-name',
+            name: 'test-session-name-that-does-not-matter',
           },
         ];
       });
 
-      const responsePromise = assignmentManager.getServers('external');
-      await fakeClock.tickAsync(TEST_ONLY.LIST_SESSIONS_TIMEOUT_MS);
+      const resultsPromise = assignmentManager.getServers('external');
+      await fakeClock.tickAsync(TEST_ONLY.LIST_UNOWNED_SESSIONS_TIMEOUT_MS);
 
-      await expect(responsePromise).to.eventually.deep.equal([
+      await expect(resultsPromise).to.eventually.deep.equal([
         {
           label: 'Untitled',
           endpoint: endpointWithName,

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -47,7 +47,11 @@ import { ServerStorageFake } from '../test/helpers/server-storage';
 import { TestUri } from '../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
 import { isUUID } from '../utils/uuid';
-import { AssignmentChangeEvent, AssignmentManager } from './assignments';
+import {
+  AssignmentChangeEvent,
+  AssignmentManager,
+  TEST_ONLY,
+} from './assignments';
 import { ProxiedJupyterClient } from './client';
 import {
   ColabAssignedServer,
@@ -833,6 +837,34 @@ describe('AssignmentManager', () => {
           },
         ]);
       });
+    });
+
+    it('falls back to placeholder label when listing sessions times out', async () => {
+      colabClientStub.listAssignments.resolves([assignmentWithName]);
+      colabClientStub.listSessions.callsFake(async () => {
+        // Block listSessions to trigger the timeout.
+        await new Promise((resolve) =>
+          setTimeout(resolve, TEST_ONLY.LIST_SESSIONS_TIMEOUT_MS + 100),
+        );
+        return [
+          {
+            ...defaultSession,
+            name: 'test-session-name',
+          },
+        ];
+      });
+
+      const responsePromise = assignmentManager.getServers('external');
+      await fakeClock.tickAsync(TEST_ONLY.LIST_SESSIONS_TIMEOUT_MS);
+
+      await expect(responsePromise).to.eventually.deep.equal([
+        {
+          label: 'Untitled',
+          endpoint: endpointWithName,
+          variant: Variant.DEFAULT,
+          accelerator: '',
+        },
+      ]);
     });
 
     describe('from all', () => {

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -47,11 +47,7 @@ import { ServerStorageFake } from '../test/helpers/server-storage';
 import { TestUri } from '../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
 import { isUUID } from '../utils/uuid';
-import {
-  AssignmentChangeEvent,
-  AssignmentManager,
-  TEST_ONLY,
-} from './assignments';
+import { AssignmentChangeEvent, AssignmentManager } from './assignments';
 import { ProxiedJupyterClient } from './client';
 import {
   ColabAssignedServer,
@@ -62,6 +58,7 @@ import { ServerStorage } from './storage';
 
 const NOW = new Date();
 const TOKEN_EXPIRY_MS = 1000 * 60 * 60;
+const LIST_UNOWNED_SESSIONS_TIMEOUT_MS = 3000;
 
 const defaultAssignmentDescriptor: ColabServerDescriptor = {
   label: 'Colab GPU A100',
@@ -844,7 +841,7 @@ describe('AssignmentManager', () => {
       colabClientStub.listSessions.callsFake(async () => {
         // Block listSessions to trigger the timeout.
         await new Promise((resolve) =>
-          setTimeout(resolve, TEST_ONLY.LIST_UNOWNED_SESSIONS_TIMEOUT_MS + 100),
+          setTimeout(resolve, LIST_UNOWNED_SESSIONS_TIMEOUT_MS + 100),
         );
         return [
           {
@@ -855,7 +852,7 @@ describe('AssignmentManager', () => {
       });
 
       const resultsPromise = assignmentManager.getServers('external');
-      await fakeClock.tickAsync(TEST_ONLY.LIST_UNOWNED_SESSIONS_TIMEOUT_MS);
+      await fakeClock.tickAsync(LIST_UNOWNED_SESSIONS_TIMEOUT_MS);
 
       await expect(resultsPromise).to.eventually.deep.equal([
         {

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -1605,7 +1605,7 @@ describe('AssignmentManager', () => {
         );
       });
 
-      it('keeps the server tracked if deleting a session fails', async () => {
+      it('unassigns the server even if deleting session fails', async () => {
         const session = {
           id: 'mock-session-id-1',
           kernel: {
@@ -1622,24 +1622,23 @@ describe('AssignmentManager', () => {
         jupyterStub.sessions.list.resolves([session]);
         jupyterStub.sessions.delete.rejects(new Error('delete failed'));
 
-        await expect(
-          assignmentManager.unassignServer(defaultServer),
-        ).to.be.rejectedWith('delete failed');
+        await assignmentManager.unassignServer(defaultServer);
 
-        const serversAfter =
-          await assignmentManager.getLastKnownAssignedServers();
-        expect(serversAfter).to.deep.equal([
-          {
-            id: defaultServer.id,
-            label: defaultServer.label,
-            variant: defaultServer.variant,
-            accelerator: defaultServer.accelerator,
-            endpoint: defaultServer.endpoint,
-            dateAssigned: defaultServer.dateAssigned,
-          },
-        ]);
-        sinon.assert.notCalled(colabClientStub.unassign);
-        sinon.assert.notCalled(assignmentChangeListener);
+        const serversAfter = await assignmentManager.getServers('extension');
+        expect(serversAfter).to.be.empty;
+        sinon.assert.calledOnceWithMatch(
+          colabClientStub.unassign,
+          defaultServer.endpoint,
+        );
+        sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+          added: [],
+          removed: [{ server: defaultServer, userInitiated: true }],
+          changed: [],
+        });
+        sinon.assert.calledOnceWithMatch(
+          vsCodeStub.window.showInformationMessage,
+          sinon.match(/notebooks Colab GPU A100 was/),
+        );
       });
 
       it('keeps the server tracked if remote unassign fails', async () => {

--- a/src/test/e2e/settings.json
+++ b/src/test/e2e/settings.json
@@ -5,7 +5,7 @@
   "extensions.autoCheckUpdates": false,
   "extensions.autoUpdate": false,
   "extensions.ignoreRecommendations": true,
-  "git.autoRepositoryDetection": false,
+  "git.enabled": false,
   "jupyter.logging.level": "debug",
   "security.workspace.trust.enabled": false,
   "telemetry.telemetryLevel": "off",

--- a/src/test/e2e/settings.json
+++ b/src/test/e2e/settings.json
@@ -5,6 +5,7 @@
   "extensions.autoCheckUpdates": false,
   "extensions.autoUpdate": false,
   "extensions.ignoreRecommendations": true,
+  "git.autoRepositoryDetection": false,
   "jupyter.logging.level": "debug",
   "security.workspace.trust.enabled": false,
   "telemetry.telemetryLevel": "off",

--- a/src/test/e2e/test-setup.ts
+++ b/src/test/e2e/test-setup.ts
@@ -51,7 +51,6 @@ assert.equal(
 );
 
 const DIALOG_WAIT_MS = 3000;
-const REMOVE_SERVER_WAIT_MS = 30000;
 
 before(async function () {
   console.log('Starting global E2E test setup...');
@@ -171,12 +170,7 @@ async function signIn(
     );
     await safeExecuteCommand(workbench, 'Colab: Remove Server');
     try {
-      await selectQuickPickItem(
-        vsCodeDriver,
-        'Remove Server',
-        'Colab CPU',
-        REMOVE_SERVER_WAIT_MS,
-      );
+      await selectQuickPickItem(vsCodeDriver, 'Remove Server', 'Colab CPU');
     } catch (err: unknown) {
       console.warn('Could not select "Colab CPU" for cleanup.', err);
     }

--- a/src/test/e2e/test-setup.ts
+++ b/src/test/e2e/test-setup.ts
@@ -51,6 +51,7 @@ assert.equal(
 );
 
 const DIALOG_WAIT_MS = 3000;
+const REMOVE_SERVER_WAIT_MS = 30000;
 
 before(async function () {
   console.log('Starting global E2E test setup...');
@@ -170,10 +171,14 @@ async function signIn(
     );
     await safeExecuteCommand(workbench, 'Colab: Remove Server');
     try {
-      await selectQuickPickItem(vsCodeDriver, 'Remove Server', 'Colab CPU');
+      await selectQuickPickItem(
+        vsCodeDriver,
+        'Remove Server',
+        'Colab CPU',
+        REMOVE_SERVER_WAIT_MS,
+      );
     } catch (err: unknown) {
       console.warn('Could not select "Colab CPU" for cleanup.', err);
-      await captureScreenshots(vsCodeDriver, chromeDriver);
     }
     await safeExecuteCommand(workbench, 'View: Close All Editors');
     await pushDialogButtonIfShown(vsCodeDriver, "Don't Save", DIALOG_WAIT_MS);

--- a/src/test/e2e/test-setup.ts
+++ b/src/test/e2e/test-setup.ts
@@ -173,6 +173,7 @@ async function signIn(
       await selectQuickPickItem(vsCodeDriver, 'Remove Server', 'Colab CPU');
     } catch (err: unknown) {
       console.warn('Could not select "Colab CPU" for cleanup.', err);
+      await captureScreenshots(vsCodeDriver, chromeDriver);
     }
     await safeExecuteCommand(workbench, 'View: Close All Editors');
     await pushDialogButtonIfShown(vsCodeDriver, "Don't Save", DIALOG_WAIT_MS);


### PR DESCRIPTION
**Why**? The `upload file` E2E test currently fails due to test setup constantly failing to clean up the server. This resulted in a dirty state when `upload file` test runs, causing test to assert the incorrect server.

After debugging extensively, I found the cause of the server cleanup failure was because the `listSessions` calls in `getServers` were stuck for ~3 min and then timed out for unowned servers. I don't know yet why they were stuck (more investigation is needed), but we only needed these `listSessions` calls for fetching the labels for unowned servers, so it's okay to force a failure for each call after a much shorter timeout (I made it 3s for now). For this purpose, I refactored and reused the existing `waitForTimeout` method from `code-manager.ts`.

---

In addition to the above change, I made 2 more improvements that don't directly contribute to the current E2E test failures:
1. Set `git.enabled` to false in E2E tests to get rid of the annoying Git notification dialog.
2. Made `sessions.list` and `sessions.delete` in `unassignServer` best-effort since it's not really mandatory to delete the session(s) before unassigning the server.