### PR TITLE
chore: move `colab/client.ts` to `colab/client/v1`

### DIFF
--- a/src/auth/ephemeral.ts
+++ b/src/auth/ephemeral.ts
@@ -5,8 +5,8 @@
  */
 
 import vscode from 'vscode';
-import { AuthType } from '../colab/api';
-import { ColabClient } from '../colab/client';
+import { ColabClient } from '../colab/client/v1';
+import { AuthType } from '../colab/client/v1/api';
 import { log } from '../common/logging';
 import { ColabAssignedServer } from '../jupyter/servers';
 import { telemetry } from '../telemetry';

--- a/src/auth/ephemeral.unit.test.ts
+++ b/src/auth/ephemeral.unit.test.ts
@@ -7,8 +7,8 @@
 import { expect } from 'chai';
 import sinon, { SinonStubbedInstance } from 'sinon';
 import { Uri } from 'vscode';
-import { AuthType } from '../colab/api';
-import { ColabClient } from '../colab/client';
+import { ColabClient } from '../colab/client/v1';
+import { AuthType } from '../colab/client/v1/api';
 import { ColabAssignedServer } from '../jupyter/servers';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
 import { handleEphemeralAuth } from './ephemeral';

--- a/src/colab/client/v1/api.ts
+++ b/src/colab/client/v1/api.ts
@@ -27,7 +27,7 @@ import { z } from 'zod';
 import {
   Session as GeneratedSession,
   Kernel as GeneratedKernel,
-} from '../jupyter/client/generated';
+} from '../../../jupyter/client/generated';
 
 export enum SubscriptionState {
   UNSUBSCRIBED = 1,

--- a/src/colab/client/v1/index.ts
+++ b/src/colab/client/v1/index.ts
@@ -8,17 +8,26 @@ import { UUID } from 'crypto';
 import * as https from 'https';
 import fetch, { Headers, Request, RequestInit, Response } from 'node-fetch';
 import { z } from 'zod';
-import { fetchAndParse } from '../common/fetch-utils';
-import { traceMethod } from '../common/logging/decorators';
+import { fetchAndParse } from '../../../common/fetch-utils';
+import { traceMethod } from '../../../common/logging/decorators';
 import {
   buildFetchChain,
   createAcceptJsonMiddleware,
   createAuthMiddleware,
   createErrorMiddleware,
-} from '../common/middleware';
-import { Session } from '../jupyter/client/generated';
-import { ColabAssignedServer } from '../jupyter/servers';
-import { uuidToWebSafeBase64 } from '../utils/uuid';
+} from '../../../common/middleware';
+import { Session } from '../../../jupyter/client/generated';
+import { ColabAssignedServer } from '../../../jupyter/servers';
+import { uuidToWebSafeBase64 } from '../../../utils/uuid';
+import { ColabRequestError } from '../../errors';
+import {
+  COLAB_CLIENT_AGENT_HEADER,
+  COLAB_RUNTIME_PROXY_TOKEN_HEADER,
+  COLAB_TUNNEL_HEADER,
+  COLAB_VS_CODE_APP_NAME,
+  COLAB_VS_CODE_EXTENSION_VERSION,
+  COLAB_XSRF_TOKEN_HEADER,
+} from '../../headers';
 import {
   Assignment,
   AuthType,
@@ -47,15 +56,6 @@ import {
   Resources,
   ResourcesSchema,
 } from './api';
-import { ColabRequestError } from './errors';
-import {
-  COLAB_CLIENT_AGENT_HEADER,
-  COLAB_RUNTIME_PROXY_TOKEN_HEADER,
-  COLAB_TUNNEL_HEADER,
-  COLAB_VS_CODE_APP_NAME,
-  COLAB_VS_CODE_EXTENSION_VERSION,
-  COLAB_XSRF_TOKEN_HEADER,
-} from './headers';
 
 const TUN_ENDPOINT = '/tun/m';
 

--- a/src/colab/client/v1/index.unit.test.ts
+++ b/src/colab/client/v1/index.unit.test.ts
@@ -9,10 +9,20 @@ import { expect } from 'chai';
 import fetch, { Response } from 'node-fetch';
 import { SinonStub, SinonMatcher } from 'sinon';
 import * as sinon from 'sinon';
-import { Session } from '../jupyter/client/generated';
-import { ColabAssignedServer } from '../jupyter/servers';
-import { TestUri } from '../test/helpers/uri';
-import { uuidToWebSafeBase64 } from '../utils/uuid';
+import { Session } from '../../../jupyter/client/generated';
+import { ColabAssignedServer } from '../../../jupyter/servers';
+import { TestUri } from '../../../test/helpers/uri';
+import { uuidToWebSafeBase64 } from '../../../utils/uuid';
+import {
+  ACCEPT_JSON_HEADER,
+  AUTHORIZATION_HEADER,
+  COLAB_CLIENT_AGENT_HEADER,
+  COLAB_RUNTIME_PROXY_TOKEN_HEADER,
+  COLAB_TUNNEL_HEADER,
+  COLAB_VS_CODE_APP_NAME,
+  COLAB_VS_CODE_EXTENSION_VERSION,
+  COLAB_XSRF_TOKEN_HEADER,
+} from '../../headers';
 import {
   Assignment,
   Shape,
@@ -33,17 +43,7 @@ import {
   DenylistedError,
   InsufficientQuotaError,
   TooManyAssignmentsError,
-} from './client';
-import {
-  ACCEPT_JSON_HEADER,
-  AUTHORIZATION_HEADER,
-  COLAB_CLIENT_AGENT_HEADER,
-  COLAB_RUNTIME_PROXY_TOKEN_HEADER,
-  COLAB_TUNNEL_HEADER,
-  COLAB_VS_CODE_APP_NAME,
-  COLAB_VS_CODE_EXTENSION_VERSION,
-  COLAB_XSRF_TOKEN_HEADER,
-} from './headers';
+} from '.';
 
 const COLAB_HOST = 'colab.example.com';
 const GOOGLE_APIS_HOST = 'colab.example.googleapis.com';

--- a/src/colab/commands/files.unit.test.ts
+++ b/src/colab/commands/files.unit.test.ts
@@ -13,7 +13,7 @@ import { CommandSource, Outcome } from '../../telemetry/api';
 import { TestCancellationTokenSource } from '../../test/helpers/cancellation';
 import { TestUri } from '../../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
-import { Variant } from '../api';
+import { Variant } from '../client/v1/api';
 import { upload } from './files';
 
 const DEFAULT_SERVER = {

--- a/src/colab/commands/server.unit.test.ts
+++ b/src/colab/commands/server.unit.test.ts
@@ -21,7 +21,7 @@ import {
   buildInputBoxStub,
 } from '../../test/helpers/quick-input';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
-import { Variant } from '../api';
+import { Variant } from '../client/v1/api';
 import { mountServer, removeServer, renameServerAlias } from './server';
 
 describe('Server Commands', () => {

--- a/src/colab/commands/terminal.unit.test.ts
+++ b/src/colab/commands/terminal.unit.test.ts
@@ -7,7 +7,6 @@
 import { randomUUID } from 'crypto';
 import sinon, { SinonStubbedFunction, SinonStubbedInstance } from 'sinon';
 import { ExtensionTerminalOptions, QuickPick, QuickPickItem } from 'vscode';
-import { Variant } from '../../colab/api';
 import { AssignmentManager } from '../../jupyter/assignments';
 import { ColabAssignedServer } from '../../jupyter/servers';
 import { telemetry } from '../../telemetry';
@@ -19,6 +18,7 @@ import {
 import { TestThemeIcon } from '../../test/helpers/theme';
 import { TestUri } from '../../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
+import { Variant } from '../client/v1/api';
 import { openTerminal } from './terminal';
 
 describe('openTerminal command', () => {

--- a/src/colab/connection-refresher.ts
+++ b/src/colab/connection-refresher.ts
@@ -13,7 +13,7 @@ import {
   AssignmentManager,
 } from '../jupyter/assignments';
 import { ColabAssignedServer } from '../jupyter/servers';
-import { NotFoundError } from './client';
+import { NotFoundError } from './client/v1';
 
 /* The buffer we give to refresh the token, before it actually expires. */
 const REFRESH_BUFFER_MS = 5 * 60 * 1000; // 5 minutes.

--- a/src/colab/connection-refresher.unit.test.ts
+++ b/src/colab/connection-refresher.unit.test.ts
@@ -15,8 +15,8 @@ import { ColabAssignedServer } from '../jupyter/servers';
 import { ControllableAsyncToggle } from '../test/helpers/async';
 import { TestEventEmitter } from '../test/helpers/events';
 import { TestUri } from '../test/helpers/uri';
-import { Variant } from './api';
-import { NotFoundError } from './client';
+import { NotFoundError } from './client/v1';
+import { Variant } from './client/v1/api';
 import {
   ConnectionRefreshController,
   ConnectionRefresher,

--- a/src/colab/consumption/notifier.ts
+++ b/src/colab/consumption/notifier.ts
@@ -7,7 +7,7 @@
 import vscode, { Disposable, Event } from 'vscode';
 import { telemetry } from '../../telemetry';
 import { CommandSource, LowBalanceSeverity } from '../../telemetry/api';
-import { ConsumptionUserInfo, SubscriptionTier } from '../api';
+import { ConsumptionUserInfo, SubscriptionTier } from '../client/v1/api';
 import { openColabSignup } from '../commands/external';
 
 const WARN_WHEN_LESS_THAN_MINUTES = 30;

--- a/src/colab/consumption/notifier.unit.test.ts
+++ b/src/colab/consumption/notifier.unit.test.ts
@@ -10,7 +10,7 @@ import { telemetry } from '../../telemetry';
 import { LowBalanceSeverity } from '../../telemetry/api';
 import { TestEventEmitter } from '../../test/helpers/events';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
-import { SubscriptionTier, ConsumptionUserInfo } from '../api';
+import { SubscriptionTier, ConsumptionUserInfo } from '../client/v1/api';
 import { ConsumptionNotifier } from './notifier';
 
 const NOTIFICATION_SEVERITIES = ['warn', 'error'] as const;

--- a/src/colab/consumption/poller.ts
+++ b/src/colab/consumption/poller.ts
@@ -12,8 +12,8 @@ import {
 } from '../../common/task-runner';
 import { Toggleable } from '../../common/toggleable';
 import { AssignmentChangeEvent } from '../../jupyter/assignments';
-import { ConsumptionUserInfo } from '../api';
-import { ColabClient } from '../client';
+import { ColabClient } from '../client/v1';
+import { ConsumptionUserInfo } from '../client/v1/api';
 
 const POLL_INTERVAL_MS = 1000 * 60; // 1 minute.
 const TASK_TIMEOUT_MS = 1000 * 10; // 10 seconds.

--- a/src/colab/consumption/poller.unit.test.ts
+++ b/src/colab/consumption/poller.unit.test.ts
@@ -15,8 +15,12 @@ import { AssignmentChangeEvent } from '../../jupyter/assignments';
 import { Deferred } from '../../test/helpers/async';
 import { TestEventEmitter } from '../../test/helpers/events';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
-import { ConsumptionUserInfo, SubscriptionTier, Variant } from '../api';
-import { ColabClient } from '../client';
+import { ColabClient } from '../client/v1';
+import {
+  ConsumptionUserInfo,
+  SubscriptionTier,
+  Variant,
+} from '../client/v1/api';
 import { ConsumptionPoller, TEST_ONLY } from './poller';
 
 const POLL_INTERVAL_MS = TEST_ONLY.POLL_INTERVAL_MS;

--- a/src/colab/consumption/status-bar.ts
+++ b/src/colab/consumption/status-bar.ts
@@ -7,7 +7,7 @@
 import vscode, { Disposable, Event, StatusBarItem } from 'vscode';
 import { log } from '../../common/logging';
 import { Toggleable } from '../../common/toggleable';
-import { ConsumptionUserInfo, SubscriptionTier } from '../api';
+import { ConsumptionUserInfo, SubscriptionTier } from '../client/v1/api';
 
 /**
  * Monitors {@link ConsumptionUserInfo} and maintains a {@link StatusBarItem}.

--- a/src/colab/consumption/status-bar.unit.test.ts
+++ b/src/colab/consumption/status-bar.unit.test.ts
@@ -13,7 +13,7 @@ import {
   newVsCodeStub,
   StatusBarAlignment,
 } from '../../test/helpers/vscode';
-import { ConsumptionUserInfo, SubscriptionTier } from '../api';
+import { ConsumptionUserInfo, SubscriptionTier } from '../client/v1/api';
 import { ConsumptionStatusBar } from './status-bar';
 
 describe('ConsumptionStatusBar', () => {

--- a/src/colab/content-browser/content-tree.vscode.test.ts
+++ b/src/colab/content-browser/content-tree.vscode.test.ts
@@ -21,7 +21,7 @@ import {
 import { ContentsFileSystemProvider } from '../../jupyter/contents/file-system';
 import { ColabAssignedServer } from '../../jupyter/servers';
 import { TestEventEmitter } from '../../test/helpers/events';
-import { Variant } from '../api';
+import { Variant } from '../client/v1/api';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,

--- a/src/colab/experiment-state.ts
+++ b/src/colab/experiment-state.ts
@@ -8,12 +8,12 @@ import { Disposable } from 'vscode';
 import { log } from '../common/logging';
 import { OverrunPolicy, SequentialTaskRunner } from '../common/task-runner';
 import { Toggleable } from '../common/toggleable';
+import { ColabClient } from './client/v1';
 import {
   ExperimentFlag,
   ExperimentFlagValue,
   EXPERIMENT_FLAG_DEFAULT_VALUES,
-} from './api';
-import { ColabClient } from './client';
+} from './client/v1/api';
 
 /**
  * Gets the value of an experiment flag.

--- a/src/colab/experiment-state.unit.test.ts
+++ b/src/colab/experiment-state.unit.test.ts
@@ -7,8 +7,8 @@
 import { expect } from 'chai';
 import sinon, { SinonFakeTimers, SinonStubbedInstance } from 'sinon';
 import { Deferred } from '../test/helpers/async';
-import { ExperimentFlag, ExperimentFlagValue } from './api';
-import { ColabClient } from './client';
+import { ColabClient } from './client/v1';
+import { ExperimentFlag, ExperimentFlagValue } from './client/v1/api';
 import {
   ExperimentStateProvider,
   getFlag,

--- a/src/colab/files.unit.test.ts
+++ b/src/colab/files.unit.test.ts
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import { describe } from 'mocha';
 import { TestUri } from '../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
-import { Variant } from './api';
+import { Variant } from './client/v1/api';
 import { buildColabFileUri } from './files';
 
 const DEFAULT_SERVER = {

--- a/src/colab/keep-alive.ts
+++ b/src/colab/keep-alive.ts
@@ -15,7 +15,7 @@ import { AssignmentManager } from '../jupyter/assignments';
 import { ProxiedJupyterClient } from '../jupyter/client';
 import { Kernel } from '../jupyter/client/generated';
 import { ColabAssignedServer } from '../jupyter/servers';
-import { ColabClient } from './client';
+import { ColabClient } from './client/v1';
 
 interface Config {
   /**

--- a/src/colab/keep-alive.unit.test.ts
+++ b/src/colab/keep-alive.unit.test.ts
@@ -18,8 +18,8 @@ import {
 } from '../test/helpers/jupyter';
 import { TestUri } from '../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
-import { Variant } from './api';
-import { ColabClient } from './client';
+import { ColabClient } from './client/v1';
+import { Variant } from './client/v1/api';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,

--- a/src/colab/module.ts
+++ b/src/colab/module.ts
@@ -11,7 +11,7 @@ import { CONFIG } from '../colab-config';
 import { Toggleable } from '../common/toggleable';
 import { PackageInfo } from '../config/package-info';
 import { AssignmentManager } from '../jupyter/assignments';
-import { ColabClient } from './client';
+import { ColabClient } from './client/v1';
 import { ConsumptionNotifier } from './consumption/notifier';
 import { ConsumptionPoller } from './consumption/poller';
 import { ConsumptionStatusBar } from './consumption/status-bar';

--- a/src/colab/module.unit.test.ts
+++ b/src/colab/module.unit.test.ts
@@ -14,7 +14,7 @@ import {
   StatusBarAlignment,
   VsCodeStub,
 } from '../test/helpers/vscode';
-import { ColabClient } from './client';
+import { ColabClient } from './client/v1';
 import { ConsumptionPoller } from './consumption/poller';
 import { ConsumptionStatusBar } from './consumption/status-bar';
 import { ExperimentStateProvider } from './experiment-state';

--- a/src/colab/resource-monitor/resource-item.ts
+++ b/src/colab/resource-monitor/resource-item.ts
@@ -6,7 +6,7 @@
 
 import { TreeItem, TreeItemCollapsibleState } from 'vscode';
 import { ColabAssignedServer } from '../../jupyter/servers';
-import { Disk, GpuInfo, Memory } from '../api';
+import { Disk, GpuInfo, Memory } from '../client/v1/api';
 
 /**
  * Types of resources that can be displayed in resource monitor tree view.

--- a/src/colab/resource-monitor/resource-tree.ts
+++ b/src/colab/resource-monitor/resource-tree.ts
@@ -19,8 +19,8 @@ import {
   AssignmentManager,
 } from '../../jupyter/assignments';
 import { ColabAssignedServer } from '../../jupyter/servers';
-import { ExperimentFlag } from '../api';
-import { ColabClient } from '../client';
+import { ColabClient } from '../client/v1';
+import { ExperimentFlag } from '../client/v1/api';
 import { getFlag } from '../experiment-state';
 import { ResourceItem, ResourceType } from './resource-item';
 

--- a/src/colab/resource-monitor/resource-tree.vscode.test.ts
+++ b/src/colab/resource-monitor/resource-tree.vscode.test.ts
@@ -15,8 +15,8 @@ import {
 import { ColabAssignedServer } from '../../jupyter/servers';
 import { Deferred } from '../../test/helpers/async';
 import { TestEventEmitter } from '../../test/helpers/events';
-import { ExperimentFlag, Disk, GpuInfo, Memory } from '../api';
-import { ColabClient } from '../client';
+import { ColabClient } from '../client/v1';
+import { ExperimentFlag, Disk, GpuInfo, Memory } from '../client/v1/api';
 import { TEST_ONLY as FLAGS_TEST_ONLY } from '../experiment-state';
 import { ResourceItem, ResourceType } from './resource-item';
 import { ResourceTreeProvider } from './resource-tree';

--- a/src/colab/server-picker.ts
+++ b/src/colab/server-picker.ts
@@ -14,7 +14,7 @@ import {
   Shape,
   shapeToMachineShape,
   ExperimentFlag,
-} from './api';
+} from './client/v1/api';
 import { getFlag } from './experiment-state';
 
 /** Provides an explanation to the user on updating the server alias. */

--- a/src/colab/server-picker.unit.test.ts
+++ b/src/colab/server-picker.unit.test.ts
@@ -14,7 +14,7 @@ import {
   buildQuickPickStub,
 } from '../test/helpers/quick-input';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
-import { Variant, Shape, ExperimentFlag } from './api';
+import { Variant, Shape, ExperimentFlag } from './client/v1/api';
 import { TEST_ONLY } from './experiment-state';
 import { ServerPicker } from './server-picker';
 

--- a/src/colab/terminal/colab-terminal-websocket.unit.test.ts
+++ b/src/colab/terminal/colab-terminal-websocket.unit.test.ts
@@ -8,9 +8,9 @@ import { randomUUID } from 'crypto';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import WebSocket from 'ws';
-import { Variant } from '../../colab/api';
 import { ColabAssignedServer } from '../../jupyter/servers';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
+import { Variant } from '../client/v1/api';
 import { COLAB_RUNTIME_PROXY_TOKEN_HEADER } from '../headers';
 import { ColabTerminalWebSocket } from './colab-terminal-websocket';
 

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -14,6 +14,14 @@ import fetch, {
 } from 'node-fetch';
 import vscode, { Disposable } from 'vscode';
 import {
+  AcceleratorUnavailableError,
+  ColabClient,
+  DenylistedError,
+  InsufficientQuotaError,
+  NotFoundError,
+  TooManyAssignmentsError,
+} from '../colab/client/v1';
+import {
   Assignment,
   ListedAssignment,
   RuntimeProxyToken,
@@ -22,15 +30,7 @@ import {
   SubscriptionTier,
   Shape,
   isHighMemOnlyAccelerator,
-} from '../colab/api';
-import {
-  AcceleratorUnavailableError,
-  ColabClient,
-  DenylistedError,
-  InsufficientQuotaError,
-  NotFoundError,
-  TooManyAssignmentsError,
-} from '../colab/client';
+} from '../colab/client/v1/api';
 import { REMOVE_SERVER } from '../colab/commands/constants';
 import { ColabRequestError } from '../colab/errors';
 import {

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -14,6 +14,14 @@ import sinon, {
 } from 'sinon';
 import { MessageItem, Uri } from 'vscode';
 import {
+  ColabClient,
+  DenylistedError,
+  InsufficientQuotaError,
+  NotFoundError,
+  TooManyAssignmentsError,
+  AcceleratorUnavailableError,
+} from '../colab/client/v1';
+import {
   Assignment,
   RuntimeProxyToken,
   Shape,
@@ -21,15 +29,7 @@ import {
   SubscriptionTier,
   UserInfo,
   Variant,
-} from '../colab/api';
-import {
-  ColabClient,
-  DenylistedError,
-  InsufficientQuotaError,
-  NotFoundError,
-  TooManyAssignmentsError,
-  AcceleratorUnavailableError,
-} from '../colab/client';
+} from '../colab/client/v1/api';
 import { REMOVE_SERVER } from '../colab/commands/constants';
 import { ColabRequestError } from '../colab/errors';
 import {

--- a/src/jupyter/client/index.unit.test.ts
+++ b/src/jupyter/client/index.unit.test.ts
@@ -8,7 +8,7 @@ import { randomUUID } from 'crypto';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Disposable } from 'vscode';
-import { Variant } from '../../colab/api';
+import { Variant } from '../../colab/client/v1/api';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,

--- a/src/jupyter/colab-proxy-websocket.ts
+++ b/src/jupyter/colab-proxy-websocket.ts
@@ -11,8 +11,8 @@ import vscode, { Disposable } from 'vscode';
 import WebSocket from 'ws';
 import { z } from 'zod';
 import { handleEphemeralAuth } from '../auth/ephemeral';
-import { AuthType } from '../colab/api';
-import { ColabClient } from '../colab/client';
+import { ColabClient } from '../colab/client/v1';
+import { AuthType } from '../colab/client/v1/api';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,

--- a/src/jupyter/colab-proxy-websocket.unit.test.ts
+++ b/src/jupyter/colab-proxy-websocket.unit.test.ts
@@ -10,8 +10,8 @@ import sinon, { SinonStubbedInstance } from 'sinon';
 import { Disposable } from 'vscode';
 import WebSocket from 'ws';
 import { handleEphemeralAuth } from '../auth/ephemeral';
-import { AuthType } from '../colab/api';
-import { ColabClient } from '../colab/client';
+import { ColabClient } from '../colab/client/v1';
+import { AuthType } from '../colab/client/v1/api';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
 import {
   colabProxyWebSocket,

--- a/src/jupyter/contents/file-system.unit.test.ts
+++ b/src/jupyter/contents/file-system.unit.test.ts
@@ -8,7 +8,7 @@ import { randomUUID } from 'crypto';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { FileChangeEvent, Uri, WorkspaceFoldersChangeEvent } from 'vscode';
-import { Variant } from '../../colab/api';
+import { Variant } from '../../colab/client/v1/api';
 import { TestEventEmitter } from '../../test/helpers/events';
 import { TestUri } from '../../test/helpers/uri';
 import {

--- a/src/jupyter/contents/sessions.unit.test.ts
+++ b/src/jupyter/contents/sessions.unit.test.ts
@@ -14,7 +14,7 @@ import {
   WorkspaceConfiguration,
 } from 'vscode';
 import { AuthChangeEvent } from '../../auth/auth-provider';
-import { Variant } from '../../colab/api';
+import { Variant } from '../../colab/client/v1/api';
 import { COLAB_RUNTIME_PROXY_TOKEN_HEADER } from '../../colab/headers';
 import { Deferred } from '../../test/helpers/async';
 import { TestEventEmitter } from '../../test/helpers/events';

--- a/src/jupyter/module.ts
+++ b/src/jupyter/module.ts
@@ -7,7 +7,7 @@
 import { Jupyter } from '@vscode/jupyter-extension';
 import vscode, { Disposable, Extension, ExtensionContext } from 'vscode';
 import { GoogleAuthProvider } from '../auth/auth-provider';
-import { ColabClient } from '../colab/client';
+import { ColabClient } from '../colab/client/v1';
 import { registerColabCommands } from '../colab/commands/register';
 import { ConnectionRefreshController } from '../colab/connection-refresher';
 import { ContentTreeProvider } from '../colab/content-browser/content-tree';

--- a/src/jupyter/module.vscode.test.ts
+++ b/src/jupyter/module.vscode.test.ts
@@ -15,7 +15,7 @@ import vscode, {
   type SecretStorage,
 } from 'vscode';
 import { GoogleAuthProvider } from '../auth/auth-provider';
-import { ColabClient } from '../colab/client';
+import { ColabClient } from '../colab/client/v1';
 import {
   COLAB_TOOLBAR,
   MOUNT_DRIVE,

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -15,8 +15,8 @@ import {
 import { CancellationToken, Disposable, Event, ProviderResult } from 'vscode';
 import vscode from 'vscode';
 import { AuthChangeEvent } from '../auth/auth-provider';
-import { SubscriptionTier } from '../colab/api';
-import { ColabClient, NotFoundError } from '../colab/client';
+import { ColabClient, NotFoundError } from '../colab/client/v1';
+import { SubscriptionTier } from '../colab/client/v1/api';
 import {
   AUTO_CONNECT,
   Command,

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -16,8 +16,8 @@ import { SinonStubbedInstance } from 'sinon';
 import * as sinon from 'sinon';
 import { CancellationToken, CancellationTokenSource } from 'vscode';
 import { AuthChangeEvent } from '../auth/auth-provider';
-import { SubscriptionTier, Variant } from '../colab/api';
-import { ColabClient, NotFoundError } from '../colab/client';
+import { ColabClient, NotFoundError } from '../colab/client/v1';
+import { SubscriptionTier, Variant } from '../colab/client/v1/api';
 import {
   AUTO_CONNECT,
   NEW_SERVER,

--- a/src/jupyter/servers.ts
+++ b/src/jupyter/servers.ts
@@ -9,7 +9,7 @@ import {
   JupyterServer,
   JupyterServerConnectionInformation,
 } from '@vscode/jupyter-extension';
-import { Variant, Shape } from '../colab/api';
+import { Variant, Shape } from '../colab/client/v1/api';
 
 /**
  * Colab's Jupyter server descriptor which includes machine-specific

--- a/src/jupyter/storage.ts
+++ b/src/jupyter/storage.ts
@@ -7,7 +7,7 @@
 import { UUID } from 'crypto';
 import vscode from 'vscode';
 import { z } from 'zod';
-import { Variant } from '../colab/api';
+import { Variant } from '../colab/client/v1/api';
 import { PROVIDER_ID } from '../config/constants';
 import { isUUID } from '../utils/uuid';
 import { ColabAssignedServer } from './servers';

--- a/src/jupyter/storage.unit.test.ts
+++ b/src/jupyter/storage.unit.test.ts
@@ -8,7 +8,7 @@ import { randomUUID } from 'crypto';
 import { assert, expect } from 'chai';
 import sinon, { SinonStubbedInstance } from 'sinon';
 import { SecretStorage } from 'vscode';
-import { Variant } from '../colab/api';
+import { Variant } from '../colab/client/v1/api';
 import { PROVIDER_ID } from '../config/constants';
 import { SecretStorageFake } from '../test/helpers/secret-storage';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';

--- a/src/telemetry/api.ts
+++ b/src/telemetry/api.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthType } from '../colab/api';
+import { AuthType } from '../colab/client/v1/api';
 
 /**
  * API types for logging telemetry events to Clearcut.

--- a/src/telemetry/client.ts
+++ b/src/telemetry/client.ts
@@ -7,7 +7,7 @@
 import fetch, { Request } from 'node-fetch';
 import vscode from 'vscode';
 import { Disposable } from 'vscode';
-import { ExperimentFlag } from '../colab/api';
+import { ExperimentFlag } from '../colab/client/v1/api';
 import { getFlag } from '../colab/experiment-state';
 import { CONTENT_TYPE_JSON_HEADER } from '../colab/headers';
 import { log } from '../common/logging';

--- a/src/telemetry/client.unit.test.ts
+++ b/src/telemetry/client.unit.test.ts
@@ -9,7 +9,7 @@ import fetch, { Response, Request } from 'node-fetch';
 import { SinonFakeTimers } from 'sinon';
 import * as sinon from 'sinon';
 import type vscode from 'vscode';
-import { ExperimentFlag } from '../colab/api';
+import { ExperimentFlag } from '../colab/client/v1/api';
 import { TEST_ONLY as FLAGS_TEST_ONLY } from '../colab/experiment-state';
 import { CONTENT_TYPE_JSON_HEADER } from '../colab/headers';
 import { Deferred } from '../test/helpers/async';

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -9,7 +9,7 @@ import { Disposable } from 'vscode';
 import {
   AuthType,
   SubscriptionTier as ColabSubscriptionTier,
-} from '../colab/api';
+} from '../colab/client/v1/api';
 import { COLAB_EXT_IDENTIFIER } from '../config/constants';
 import { getPackageInfo } from '../config/package-info';
 import { JUPYTER_EXT_IDENTIFIER } from '../jupyter/jupyter-extension';

--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -11,7 +11,7 @@ import { Disposable } from 'vscode';
 import {
   AuthType,
   SubscriptionTier as ColabSubscriptionTier,
-} from '../colab/api';
+} from '../colab/client/v1/api';
 import { COLAB_EXT_IDENTIFIER } from '../config/constants';
 import { JUPYTER_EXT_IDENTIFIER } from '../jupyter/jupyter-extension';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';


### PR DESCRIPTION
Moved the following 3 files to a new `v1` folder:
* `colab/client.ts` ➡️ `colab/client/v1/index.ts`
* `colab/client.unit.test.ts` ➡️ `colab/client/v1/index.unit.test.ts`
* `colab/api.ts` ➡️ `colab/client/v1/api.ts`

> [!NOTE]
> This is to differentiate the existing client invoking private APIs vs. the new client (v2) introduced in https://github.com/googlecolab/colab-vscode/pull/626 invoking public APIs.