### PR TITLE
feat: migrate `ColabJupyterServerProvider` to invoke public API

### DIFF
--- a/scripts/generate-config.mts
+++ b/scripts/generate-config.mts
@@ -24,6 +24,7 @@ const envConfig = {
 
 let colabApiDomain: string;
 let colabGapiApiDomain: string;
+let colabPublicApiDomain: string;
 try {
   if (!envConfig.env) {
     throw new Error('COLAB_EXTENSION_ENVIRONMENT is not set');
@@ -38,15 +39,20 @@ try {
     case 'production':
       colabApiDomain = 'https://colab.research.google.com';
       colabGapiApiDomain = 'https://colab.pa.googleapis.com';
+      colabPublicApiDomain = 'https://colaboratory.googleapis.com';
       break;
     case 'sandbox':
       colabApiDomain = 'https://colab.sandbox.google.com';
       colabGapiApiDomain = 'https://staging-colab.sandbox.googleapis.com';
+      colabPublicApiDomain =
+        'https://staging-colaboratory.sandbox.googleapis.com';
       break;
     case 'local':
       colabApiDomain = 'https://localhost:8888';
       // It's not feasible to run this locally.
       colabGapiApiDomain = 'https://staging-colab.sandbox.googleapis.com';
+      colabPublicApiDomain =
+        'https://staging-colaboratory.sandbox.googleapis.com';
       break;
     default:
       throw new Error(
@@ -61,6 +67,7 @@ try {
 const config = {
   ColabApiDomain: colabApiDomain,
   ColabGapiDomain: colabGapiApiDomain,
+  ColabPublicApiDomain: colabPublicApiDomain,
   ClientId: envConfig.clientId,
   ClientNotSoSecret: envConfig.clientNotSoSecret,
   Environment: envConfig.env,

--- a/src/colab/client/v1/api.ts
+++ b/src/colab/client/v1/api.ts
@@ -28,6 +28,7 @@ import {
   Session as GeneratedSession,
   Kernel as GeneratedKernel,
 } from '../../../jupyter/client/generated';
+import { SubscriptionTier } from '../../types';
 
 export enum SubscriptionState {
   UNSUBSCRIBED = 1,
@@ -35,12 +36,6 @@ export enum SubscriptionState {
   NON_RECURRING = 3,
   PENDING_ACTIVATION = 4,
   DECLINED = 5,
-}
-
-export enum SubscriptionTier {
-  NONE = 0,
-  PRO = 1,
-  PRO_PLUS = 2,
 }
 
 enum ColabSubscriptionTier {
@@ -580,9 +575,10 @@ export function isHighMemOnlyAccelerator(accelerator?: string): boolean {
 
 /** The experiment flags supported by the Colab extension. */
 export enum ExperimentFlag {
+  EnablePublicApi = 'enable_public_api_vscode',
   EnableTelemetry = 'enable_vscode_telemetry',
-  RuntimeVersionNames = 'runtime_version_names',
   ResourcePollIntervalMs = 'resource_poll_interval_ms',
+  RuntimeVersionNames = 'runtime_version_names',
 }
 
 /** The default values for each experiment flag. */
@@ -590,9 +586,10 @@ export const EXPERIMENT_FLAG_DEFAULT_VALUES: Record<
   ExperimentFlag,
   ExperimentFlagValue
 > = {
+  [ExperimentFlag.EnablePublicApi]: false,
   [ExperimentFlag.EnableTelemetry]: false,
-  [ExperimentFlag.RuntimeVersionNames]: [],
   [ExperimentFlag.ResourcePollIntervalMs]: 10000,
+  [ExperimentFlag.RuntimeVersionNames]: [],
 };
 
 // Define the basic types allowed

--- a/src/colab/client/v1/index.unit.test.ts
+++ b/src/colab/client/v1/index.unit.test.ts
@@ -23,11 +23,11 @@ import {
   COLAB_VS_CODE_EXTENSION_VERSION,
   COLAB_XSRF_TOKEN_HEADER,
 } from '../../headers';
+import { SubscriptionTier } from '../../types';
 import {
   Assignment,
   Shape,
   SubscriptionState,
-  SubscriptionTier,
   Variant,
   Outcome,
   RuntimeProxyToken,

--- a/src/colab/client/v2/index.ts
+++ b/src/colab/client/v2/index.ts
@@ -7,6 +7,7 @@
 import { log } from '../../../common/logging';
 import { telemetry } from '../../../telemetry';
 import { AUTHORIZATION_HEADER, COLAB_CLIENT_AGENT_HEADER } from '../../headers';
+import { SubscriptionTier as CommonSubscriptionTier } from '../../types';
 import {
   ColaboratoryApi,
   Configuration as ColabConfig,
@@ -15,6 +16,7 @@ import {
   Middleware,
   RequestContext,
   ResponseContext,
+  SubscriptionTier,
 } from './generated/colab';
 import {
   ColaboratoryApi as OperationsApi,
@@ -22,17 +24,64 @@ import {
 } from './generated/operations';
 
 /** A client to interact with public Colab API. */
-export class ColabApiClient {
+export interface ColabApiClient {
+  /**
+   * A client instance to access the Colab APIs
+   */
+  colab: ColaboratoryApi;
+
+  /**
+   * A client instance to access the Operations APIs.
+   */
+  operations: OperationsApi;
+}
+
+/**
+ * Creates a new {@link ColabApiClient} instance.
+ *
+ * @param basePath - Base URL for Colab API.
+ * @param getAccessToken - Function to retrieve access token.
+ * @param onAuthError - Optional function to handle authentication errors.
+ * @returns A new {@link ColabApiClient} instance.
+ */
+export function createColabApiClient(
+  basePath: string,
+  getAccessToken: () => Promise<string>,
+  onAuthError?: () => Promise<void>,
+): ColabApiClient {
+  return new ColabApiClientImpl(basePath, getAccessToken, onAuthError);
+}
+
+/**
+ * Normalizes the API {@link SubscriptionTier} to the common
+ * {@link CommonSubscriptionTier}.
+ *
+ * @param tier - Subscription tier returned from public Colab API.
+ * @returns Normalized common subscription tier value.
+ */
+export function normalizeSubscriptionTier(
+  tier?: SubscriptionTier,
+): CommonSubscriptionTier {
+  if (!tier) {
+    throw new Error('Subscription tier is undefined');
+  }
+
+  switch (tier) {
+    case SubscriptionTier.SubscriptionTierFree:
+      return CommonSubscriptionTier.NONE;
+    case SubscriptionTier.SubscriptionTierPro:
+      return CommonSubscriptionTier.PRO;
+    case SubscriptionTier.SubscriptionTierProPlus:
+      return CommonSubscriptionTier.PRO_PLUS;
+    default:
+      throw new Error(`Unknown subscription tier: ${tier}`);
+  }
+}
+
+class ColabApiClientImpl implements ColabApiClient {
   private readonly colabApi: ColaboratoryApi;
   private readonly operationsApi: OperationsApi;
 
-  /**
-   * Creates a new ColabApiClient instance.
-   *
-   * @param basePath - Base URL for Colab API.
-   * @param getAccessToken - Function to retrieve access token.
-   * @param onAuthError - Optional function to handle authentication errors.
-   */
   constructor(
     basePath: string,
     getAccessToken: () => Promise<string>,
@@ -50,20 +99,10 @@ export class ColabApiClient {
     );
   }
 
-  /**
-   * Colab API.
-   *
-   * @returns A client instance to access the Colab APIs.
-   */
   get colab() {
     return this.colabApi;
   }
 
-  /**
-   * Operations API.
-   *
-   * @returns A client instance to access the Operations APIs.
-   */
   get operations() {
     return this.operationsApi;
   }

--- a/src/colab/client/v2/index.unit.test.ts
+++ b/src/colab/client/v2/index.unit.test.ts
@@ -11,13 +11,16 @@ import * as sinon from 'sinon';
 import { SinonStubbedFunction } from 'sinon';
 import { telemetry } from '../../../telemetry';
 import { AUTHORIZATION_HEADER, COLAB_CLIENT_AGENT_HEADER } from '../../headers';
-import { FetchAPI, Key } from './generated/colab';
-import { ColabApiClient, createColabApiClient } from '.';
+import { SubscriptionTier as CommonSubscriptionTier } from '../../types';
+import { FetchAPI, Key, SubscriptionTier } from './generated/colab';
+import {
+  ColabApiClient,
+  createColabApiClient,
+  normalizeSubscriptionTier,
+} from '.';
 
 const COLAB_API_HOST = 'colab.example.com';
 const BEARER_TOKEN = 'test-access-token';
-
-const server = setupServer();
 
 describe('ColabApiClient', () => {
   let client: ColabApiClient;
@@ -25,6 +28,8 @@ describe('ColabApiClient', () => {
   let onAuthErrorStub: sinon.SinonStub<[], Promise<void>>;
   let logErrorStub: SinonStubbedFunction<typeof telemetry.logError>;
   let fetchSpy: sinon.SinonSpy<Parameters<FetchAPI>, ReturnType<FetchAPI>>;
+
+  const server = setupServer();
 
   before(() => {
     // NOTE: server.listen must be called before `createClient` is used to
@@ -1018,5 +1023,39 @@ describe('ColabApiClient', () => {
         }
       });
     });
+  });
+});
+
+describe('normalizeSubscriptionTier', () => {
+  const tests = [
+    {
+      input: SubscriptionTier.SubscriptionTierFree,
+      expected: CommonSubscriptionTier.NONE,
+    },
+    {
+      input: SubscriptionTier.SubscriptionTierPro,
+      expected: CommonSubscriptionTier.PRO,
+    },
+    {
+      input: SubscriptionTier.SubscriptionTierProPlus,
+      expected: CommonSubscriptionTier.PRO_PLUS,
+    },
+  ];
+  tests.forEach(({ input, expected }) => {
+    it(`normalizes ${input}`, () => {
+      expect(normalizeSubscriptionTier(input)).to.equal(expected);
+    });
+  });
+
+  it('throws an error if undefined', () => {
+    expect(() => normalizeSubscriptionTier(undefined)).to.throw(
+      'Subscription tier is undefined',
+    );
+  });
+
+  it('throws an error if unspecified', () => {
+    expect(() =>
+      normalizeSubscriptionTier(SubscriptionTier.SubscriptionTierUnspecified),
+    ).to.throw(/Unknown subscription tier:/);
   });
 });

--- a/src/colab/client/v2/index.unit.test.ts
+++ b/src/colab/client/v2/index.unit.test.ts
@@ -12,7 +12,7 @@ import { SinonStubbedFunction } from 'sinon';
 import { telemetry } from '../../../telemetry';
 import { AUTHORIZATION_HEADER, COLAB_CLIENT_AGENT_HEADER } from '../../headers';
 import { FetchAPI, Key } from './generated/colab';
-import { ColabApiClient } from '.';
+import { ColabApiClient, createColabApiClient } from '.';
 
 const COLAB_API_HOST = 'colab.example.com';
 const BEARER_TOKEN = 'test-access-token';
@@ -44,7 +44,7 @@ describe('ColabApiClient', () => {
     onAuthErrorStub = sinon.stub();
     logErrorStub = sinon.stub(telemetry, 'logError');
     fetchSpy = sinon.spy(globalThis, 'fetch');
-    client = new ColabApiClient(
+    client = createColabApiClient(
       `https://${COLAB_API_HOST}`,
       () => sessionStub(),
       onAuthErrorStub,

--- a/src/colab/consumption/notifier.ts
+++ b/src/colab/consumption/notifier.ts
@@ -7,8 +7,9 @@
 import vscode, { Disposable, Event } from 'vscode';
 import { telemetry } from '../../telemetry';
 import { CommandSource, LowBalanceSeverity } from '../../telemetry/api';
-import { ConsumptionUserInfo, SubscriptionTier } from '../client/v1/api';
+import { ConsumptionUserInfo } from '../client/v1/api';
 import { openColabSignup } from '../commands/external';
+import { SubscriptionTier } from '../types';
 
 const WARN_WHEN_LESS_THAN_MINUTES = 30;
 const DEFAULT_SNOOZE_MINUTES = 10;

--- a/src/colab/consumption/notifier.unit.test.ts
+++ b/src/colab/consumption/notifier.unit.test.ts
@@ -10,7 +10,8 @@ import { telemetry } from '../../telemetry';
 import { LowBalanceSeverity } from '../../telemetry/api';
 import { TestEventEmitter } from '../../test/helpers/events';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
-import { SubscriptionTier, ConsumptionUserInfo } from '../client/v1/api';
+import { ConsumptionUserInfo } from '../client/v1/api';
+import { SubscriptionTier } from '../types';
 import { ConsumptionNotifier } from './notifier';
 
 const NOTIFICATION_SEVERITIES = ['warn', 'error'] as const;

--- a/src/colab/consumption/poller.unit.test.ts
+++ b/src/colab/consumption/poller.unit.test.ts
@@ -16,11 +16,8 @@ import { Deferred } from '../../test/helpers/async';
 import { TestEventEmitter } from '../../test/helpers/events';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
 import { ColabClient } from '../client/v1';
-import {
-  ConsumptionUserInfo,
-  SubscriptionTier,
-  Variant,
-} from '../client/v1/api';
+import { ConsumptionUserInfo, Variant } from '../client/v1/api';
+import { SubscriptionTier } from '../types';
 import { ConsumptionPoller, TEST_ONLY } from './poller';
 
 const POLL_INTERVAL_MS = TEST_ONLY.POLL_INTERVAL_MS;

--- a/src/colab/consumption/status-bar.ts
+++ b/src/colab/consumption/status-bar.ts
@@ -7,7 +7,8 @@
 import vscode, { Disposable, Event, StatusBarItem } from 'vscode';
 import { log } from '../../common/logging';
 import { Toggleable } from '../../common/toggleable';
-import { ConsumptionUserInfo, SubscriptionTier } from '../client/v1/api';
+import { ConsumptionUserInfo } from '../client/v1/api';
+import { SubscriptionTier } from '../types';
 
 /**
  * Monitors {@link ConsumptionUserInfo} and maintains a {@link StatusBarItem}.

--- a/src/colab/consumption/status-bar.unit.test.ts
+++ b/src/colab/consumption/status-bar.unit.test.ts
@@ -13,7 +13,8 @@ import {
   newVsCodeStub,
   StatusBarAlignment,
 } from '../../test/helpers/vscode';
-import { ConsumptionUserInfo, SubscriptionTier } from '../client/v1/api';
+import { ConsumptionUserInfo } from '../client/v1/api';
+import { SubscriptionTier } from '../types';
 import { ConsumptionStatusBar } from './status-bar';
 
 describe('ConsumptionStatusBar', () => {

--- a/src/colab/module.ts
+++ b/src/colab/module.ts
@@ -12,34 +12,48 @@ import { Toggleable } from '../common/toggleable';
 import { PackageInfo } from '../config/package-info';
 import { AssignmentManager } from '../jupyter/assignments';
 import { ColabClient } from './client/v1';
+import { ColabApiClient, createColabApiClient } from './client/v2';
 import { ConsumptionNotifier } from './consumption/notifier';
 import { ConsumptionPoller } from './consumption/poller';
 import { ConsumptionStatusBar } from './consumption/status-bar';
 import { ExperimentStateProvider } from './experiment-state';
 
 /**
- * Builds the {@link ColabClient} bound to the user's auth state.
+ * Builds the {@link ColabClient} and {@link ColabApiClient} bound to the user's
+ * auth state.
  *
  * @param vs - The VS Code API instance.
  * @param authProvider - For token retrieval and sign-out on auth failure.
  * @param packageInfo - Used to set the user-agent on Colab requests.
  * @returns The constructed Colab client.
  */
-export function createColabClient(
+export function createColabClients(
   vs: typeof vscode,
   authProvider: GoogleAuthProvider,
   packageInfo: PackageInfo,
-): ColabClient {
-  return ColabClient.create(
-    new URL(CONFIG.ColabApiDomain),
-    new URL(CONFIG.ColabGapiDomain),
-    { appName: vs.env.appName, extensionVersion: packageInfo.version },
-    () =>
-      GoogleAuthProvider.getOrCreateSession(vs, REQUIRED_SCOPES).then(
-        (session) => session.accessToken,
-      ),
-    () => authProvider.signOut(),
-  );
+): {
+  colabClient: ColabClient;
+  colabApiClient: ColabApiClient;
+} {
+  const getAccessToken = () =>
+    GoogleAuthProvider.getOrCreateSession(vs, REQUIRED_SCOPES).then(
+      (session) => session.accessToken,
+    );
+  const onAuthError = () => authProvider.signOut();
+  return {
+    colabClient: ColabClient.create(
+      new URL(CONFIG.ColabApiDomain),
+      new URL(CONFIG.ColabGapiDomain),
+      { appName: vs.env.appName, extensionVersion: packageInfo.version },
+      getAccessToken,
+      onAuthError,
+    ),
+    colabApiClient: createColabApiClient(
+      CONFIG.ColabPublicApiDomain,
+      getAccessToken,
+      onAuthError,
+    ),
+  };
 }
 
 /** The result of activating the Colab module's background services. */

--- a/src/colab/module.unit.test.ts
+++ b/src/colab/module.unit.test.ts
@@ -40,22 +40,27 @@ function stubStatusBarItem(vs: VsCodeStub): StatusBarItem {
   return item;
 }
 
-describe('createColabClient', () => {
+describe('createColabClients', () => {
   afterEach(() => {
     sinon.restore();
   });
 
-  it('returns a ColabClient', () => {
+  it('returns a ColabClient and ColabApiClient', () => {
     const vs = newVsCodeStub();
     const authProvider = sinon.createStubInstance(GoogleAuthProvider);
 
-    const colabClient = createColabClients(vs.asVsCode(), authProvider, {
-      publisher: 'google',
-      name: 'colab',
-      version: '0.0.1-test',
-    });
+    const { colabClient, colabApiClient } = createColabClients(
+      vs.asVsCode(),
+      authProvider,
+      {
+        publisher: 'google',
+        name: 'colab',
+        version: '0.0.1-test',
+      },
+    );
 
     expect(colabClient).to.exist;
+    expect(colabApiClient).to.exist;
   });
 });
 

--- a/src/colab/module.unit.test.ts
+++ b/src/colab/module.unit.test.ts
@@ -18,7 +18,7 @@ import { ColabClient } from './client/v1';
 import { ConsumptionPoller } from './consumption/poller';
 import { ConsumptionStatusBar } from './consumption/status-bar';
 import { ExperimentStateProvider } from './experiment-state';
-import { createColabClient, createColabModule } from './module';
+import { createColabClients, createColabModule } from './module';
 
 function stubStatusBarItem(vs: VsCodeStub): StatusBarItem {
   const item: StatusBarItem = {
@@ -49,7 +49,7 @@ describe('createColabClient', () => {
     const vs = newVsCodeStub();
     const authProvider = sinon.createStubInstance(GoogleAuthProvider);
 
-    const colabClient = createColabClient(vs.asVsCode(), authProvider, {
+    const colabClient = createColabClients(vs.asVsCode(), authProvider, {
       publisher: 'google',
       name: 'colab',
       version: '0.0.1-test',

--- a/src/colab/types.ts
+++ b/src/colab/types.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Common API types for interacting with Colab backend.
+ */
+
+export enum SubscriptionTier {
+  NONE = 0,
+  PRO = 1,
+  PRO_PLUS = 2,
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@
 import { Jupyter } from '@vscode/jupyter-extension';
 import vscode from 'vscode';
 import { createAuthModule } from './auth/module';
-import { createColabClient, createColabModule } from './colab/module';
+import { createColabClients, createColabModule } from './colab/module';
 import { initializeLogger, log } from './common/logging';
 import { getPackageInfo } from './config/package-info';
 import { IMPORT_DRIVE_FILE_PATH } from './drive/commands/constants';
@@ -47,7 +47,11 @@ async function activateInternal(context: vscode.ExtensionContext) {
   const packageInfo = getPackageInfo(context.extension);
   const auth = createAuthModule(vscode, context, packageInfo);
   const { authProvider } = auth;
-  const colabClient = createColabClient(vscode, authProvider, packageInfo);
+  const { colabClient, colabApiClient } = createColabClients(
+    vscode,
+    authProvider,
+    packageInfo,
+  );
   const drive = createDriveModule(vscode, authProvider);
   const jupyterModule = createJupyterModule(
     vscode,
@@ -55,6 +59,7 @@ async function activateInternal(context: vscode.ExtensionContext) {
     jupyter,
     authProvider,
     colabClient,
+    colabApiClient,
   );
   const colab = createColabModule(
     vscode,

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -27,7 +27,6 @@ import {
   RuntimeProxyToken,
   Variant,
   variantToMachineType,
-  SubscriptionTier,
   Shape,
   isHighMemOnlyAccelerator,
 } from '../colab/client/v1/api';
@@ -37,6 +36,7 @@ import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../colab/headers';
+import { SubscriptionTier } from '../colab/types';
 import { waitForTimeout } from '../common/async';
 import { log } from '../common/logging';
 import { telemetry } from '../telemetry';

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -26,7 +26,6 @@ import {
   RuntimeProxyToken,
   Shape,
   SubscriptionState,
-  SubscriptionTier,
   UserInfo,
   Variant,
 } from '../colab/client/v1/api';
@@ -36,6 +35,7 @@ import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../colab/headers';
+import { SubscriptionTier } from '../colab/types';
 import { telemetry } from '../telemetry';
 import { AssignmentOutcome, CommandSource } from '../telemetry/api';
 import { TestEventEmitter } from '../test/helpers/events';

--- a/src/jupyter/module.ts
+++ b/src/jupyter/module.ts
@@ -8,6 +8,7 @@ import { Jupyter } from '@vscode/jupyter-extension';
 import vscode, { Disposable, Extension, ExtensionContext } from 'vscode';
 import { GoogleAuthProvider } from '../auth/auth-provider';
 import { ColabClient } from '../colab/client/v1';
+import { ColabApiClient } from '../colab/client/v2';
 import { registerColabCommands } from '../colab/commands/register';
 import { ConnectionRefreshController } from '../colab/connection-refresher';
 import { ContentTreeProvider } from '../colab/content-browser/content-tree';
@@ -55,8 +56,10 @@ export interface JupyterModule {
  * @param jupyter - The installed Jupyter extension.
  * @param authProvider - The authentication provider; supplies session-change
  * events used by several services.
- * @param colab - The Colab client used by the assignment manager and
+ * @param colabClient - The Colab client used by the assignment manager and
  * resource view.
+ * @param colabApiClient - The new Colab public API client to eventually replace
+ * the existing colabClient.
  * @returns The services and disposables produced.
  */
 export function createJupyterModule(
@@ -64,15 +67,21 @@ export function createJupyterModule(
   context: ExtensionContext,
   jupyter: Extension<Jupyter>,
   authProvider: GoogleAuthProvider,
-  colab: ColabClient,
+  colabClient: ColabClient,
+  colabApiClient: ColabApiClient,
 ): JupyterModule {
   const serverStorage = new ServerStorage(vs, context.secrets);
-  const assignmentManager = new AssignmentManager(vs, colab, serverStorage);
+  const assignmentManager = new AssignmentManager(
+    vs,
+    colabClient,
+    serverStorage,
+  );
   const serverProvider = new ColabJupyterServerProvider(
     vs,
     authProvider.onDidChangeSessions,
     assignmentManager,
-    colab,
+    colabClient,
+    colabApiClient,
     new ServerPicker(vs, assignmentManager),
     jupyter.exports,
   );
@@ -92,10 +101,14 @@ export function createJupyterModule(
     assignmentManager,
     assignmentManager.onDidAssignmentsChange,
     authProvider.onDidChangeSessions,
-    colab,
+    colabClient,
   );
   const connections = new ConnectionRefreshController(assignmentManager);
-  const keepAlive = new ServerKeepAliveController(vs, colab, assignmentManager);
+  const keepAlive = new ServerKeepAliveController(
+    vs,
+    colabClient,
+    assignmentManager,
+  );
 
   const fsDisposable = vs.workspace.registerFileSystemProvider('colab', fs, {
     isCaseSensitive: true,

--- a/src/jupyter/module.vscode.test.ts
+++ b/src/jupyter/module.vscode.test.ts
@@ -16,6 +16,9 @@ import vscode, {
 } from 'vscode';
 import { GoogleAuthProvider } from '../auth/auth-provider';
 import { ColabClient } from '../colab/client/v1';
+import { ColabApiClient } from '../colab/client/v2';
+import { ColaboratoryApi } from '../colab/client/v2/generated/colab';
+import { ColaboratoryApi as OperationsApi } from '../colab/client/v2/generated/operations';
 import {
   COLAB_TOOLBAR,
   MOUNT_DRIVE,
@@ -36,6 +39,7 @@ describe('createJupyterModule', () => {
   let jupyter: Extension<Jupyter>;
   let authProvider: sinon.SinonStubbedInstance<GoogleAuthProvider>;
   let colabClient: sinon.SinonStubbedInstance<ColabClient>;
+  let colabApiClient: sinon.SinonStubbedInstance<ColabApiClient>;
   let fsStub: sinon.SinonStubbedMember<
     typeof vscode.workspace.registerFileSystemProvider
   >;
@@ -71,6 +75,10 @@ describe('createJupyterModule', () => {
       value: new EventEmitter<unknown>().event,
     });
     colabClient = sinon.createStubInstance(ColabClient);
+    colabApiClient = {
+      colab: sinon.createStubInstance(ColaboratoryApi),
+      operations: sinon.createStubInstance(OperationsApi),
+    };
 
     // The integration host already has the activated extension's `colab` FS
     // provider, the two tree views, and all of the command IDs registered.
@@ -112,6 +120,7 @@ describe('createJupyterModule', () => {
       jupyter,
       authProvider,
       colabClient,
+      colabApiClient,
     );
     return result;
   }

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -202,7 +202,7 @@ export class ColabJupyterServerProvider
         if (tier === SubscriptionTier.NONE) {
           commands.push(UPGRADE_TO_PRO);
         }
-      } catch (_) {
+      } catch {
         // Including the command to upgrade to pro is non-critical. If it fails,
         // just return the commands without it.
       }

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -16,7 +16,8 @@ import { CancellationToken, Disposable, Event, ProviderResult } from 'vscode';
 import vscode from 'vscode';
 import { AuthChangeEvent } from '../auth/auth-provider';
 import { ColabClient, NotFoundError } from '../colab/client/v1';
-import { SubscriptionTier } from '../colab/client/v1/api';
+import { ExperimentFlag } from '../colab/client/v1/api';
+import { ColabApiClient, normalizeSubscriptionTier } from '../colab/client/v2';
 import {
   AUTO_CONNECT,
   Command,
@@ -27,7 +28,9 @@ import {
 } from '../colab/commands/constants';
 import { openColabSignup, openColabWeb } from '../colab/commands/external';
 import { buildIconLabel, stripIconLabel } from '../colab/commands/utils';
+import { getFlag } from '../colab/experiment-state';
 import { ServerPicker } from '../colab/server-picker';
+import { SubscriptionTier } from '../colab/types';
 import { LatestCancelable } from '../common/async';
 import { traceMethod } from '../common/logging/decorators';
 import { InputFlowAction } from '../common/multi-step-quickpick';
@@ -66,7 +69,8 @@ export class ColabJupyterServerProvider
    * @param vs - The VS Code API instance.
    * @param authEvent - The authentication event emitter.
    * @param assignmentManager - The assignment manager instance.
-   * @param client - The API client instance.
+   * @param colabClient - The old Colab private API client instance.
+   * @param colabApiClient - The new Colab public API client instance.
    * @param serverPicker - The Server picker.
    * @param jupyter - The Jupyter API provider.
    */
@@ -74,7 +78,8 @@ export class ColabJupyterServerProvider
     private readonly vs: typeof vscode,
     authEvent: Event<AuthChangeEvent>,
     private readonly assignmentManager: AssignmentManager,
-    private readonly client: ColabClient,
+    private readonly colabClient: ColabClient,
+    private readonly colabApiClient: ColabApiClient,
     private readonly serverPicker: ServerPicker,
     jupyter: Jupyter,
   ) {
@@ -186,7 +191,14 @@ export class ColabJupyterServerProvider
     commands.push(AUTO_CONNECT, NEW_SERVER, OPEN_COLAB_WEB);
     if (this.isAuthorized) {
       try {
-        const tier = (await this.client.getUserInfo()).subscriptionTier;
+        const enablePublicApi = getFlag(ExperimentFlag.EnablePublicApi);
+        let tier: SubscriptionTier;
+        if (enablePublicApi) {
+          const subs = await this.colabApiClient.colab.getSubscription();
+          tier = normalizeSubscriptionTier(subs.tier);
+        } else {
+          tier = (await this.colabClient.getUserInfo()).subscriptionTier;
+        }
         if (tier === SubscriptionTier.NONE) {
           commands.push(UPGRADE_TO_PRO);
         }

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -17,7 +17,7 @@ import * as sinon from 'sinon';
 import { CancellationToken, CancellationTokenSource } from 'vscode';
 import { AuthChangeEvent } from '../auth/auth-provider';
 import { ColabClient, NotFoundError } from '../colab/client/v1';
-import { Variant } from '../colab/client/v1/api';
+import { ExperimentFlag, Variant } from '../colab/client/v1/api';
 import { ColabApiClient } from '../colab/client/v2';
 import { ColaboratoryApi } from '../colab/client/v2/generated/colab';
 import { ColaboratoryApi as OperationsApi } from '../colab/client/v2/generated/operations';
@@ -29,6 +29,7 @@ import {
   UPGRADE_TO_PRO,
 } from '../colab/commands/constants';
 import { buildIconLabel } from '../colab/commands/utils';
+import { TEST_ONLY as EXPERIMENT_TEST } from '../colab/experiment-state';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
@@ -181,6 +182,7 @@ describe('ColabJupyterServerProvider', () => {
   });
 
   afterEach(() => {
+    EXPERIMENT_TEST.resetFlagsForTest();
     sinon.restore();
   });
 
@@ -325,80 +327,116 @@ describe('ColabJupyterServerProvider', () => {
           toggleAuth(AuthState.SIGNED_IN);
         });
 
-        it('excludes upgrade to pro command when getting the subscription tier fails', async () => {
-          colabClientStub.getUserInfo.rejects(new Error('foo'));
-          const commands = await serverProvider.provideCommands(
-            undefined,
-            cancellationToken,
-          );
+        const tests = [
+          { name: 'with Public API enabled', enablePublicApi: true },
+          { name: 'with Public API disabled', enablePublicApi: false },
+        ];
+        tests.forEach(({ name, enablePublicApi }) => {
+          describe(name, () => {
+            beforeEach(() => {
+              EXPERIMENT_TEST.setFlagForTest(
+                ExperimentFlag.EnablePublicApi,
+                enablePublicApi,
+              );
+            });
 
-          assert.isDefined(commands);
-          expect(commands.map((c) => c.label)).to.deep.equal([
-            buildIconLabel(AUTO_CONNECT),
-            buildIconLabel(NEW_SERVER),
-            buildIconLabel(OPEN_COLAB_WEB),
-          ]);
-        });
+            it('excludes upgrade to pro command when getting the subscription tier fails', async () => {
+              if (enablePublicApi) {
+                (
+                  colabApiClientStub.colab.getSubscription as sinon.SinonStub
+                ).rejects(new Error('foo'));
+              } else {
+                colabClientStub.getUserInfo.rejects(new Error('foo'));
+              }
+              const commands = await serverProvider.provideCommands(
+                undefined,
+                cancellationToken,
+              );
 
-        it('excludes upgrade to pro command for users with pro', async () => {
-          colabClientStub.getUserInfo.resolves({
-            subscriptionTier: SubscriptionTier.PRO,
-            eligibleAccelerators: [],
-            ineligibleAccelerators: [],
+              assert.isDefined(commands);
+              expect(commands.map((c) => c.label)).to.deep.equal([
+                buildIconLabel(AUTO_CONNECT),
+                buildIconLabel(NEW_SERVER),
+                buildIconLabel(OPEN_COLAB_WEB),
+              ]);
+            });
+
+            it('excludes upgrade to pro command for users with pro', async () => {
+              if (enablePublicApi) {
+                (
+                  colabApiClientStub.colab.getSubscription as sinon.SinonStub
+                ).resolves({ tier: 'SUBSCRIPTION_TIER_PRO' });
+              } else {
+                colabClientStub.getUserInfo.resolves({
+                  subscriptionTier: SubscriptionTier.PRO,
+                  eligibleAccelerators: [],
+                  ineligibleAccelerators: [],
+                });
+              }
+              const commands = await serverProvider.provideCommands(
+                undefined,
+                cancellationToken,
+              );
+
+              assert.isDefined(commands);
+              expect(commands.map((c) => c.label)).to.deep.equal([
+                buildIconLabel(AUTO_CONNECT),
+                buildIconLabel(NEW_SERVER),
+                buildIconLabel(OPEN_COLAB_WEB),
+              ]);
+            });
+
+            it('excludes upgrade to pro command for users with pro-plus', async () => {
+              if (enablePublicApi) {
+                (
+                  colabApiClientStub.colab.getSubscription as sinon.SinonStub
+                ).resolves({ tier: 'SUBSCRIPTION_TIER_PRO_PLUS' });
+              } else {
+                colabClientStub.getUserInfo.resolves({
+                  subscriptionTier: SubscriptionTier.PRO_PLUS,
+                  eligibleAccelerators: [],
+                  ineligibleAccelerators: [],
+                });
+              }
+              const commands = await serverProvider.provideCommands(
+                undefined,
+                cancellationToken,
+              );
+
+              assert.isDefined(commands);
+              expect(commands.map((c) => c.label)).to.deep.equal([
+                buildIconLabel(AUTO_CONNECT),
+                buildIconLabel(NEW_SERVER),
+                buildIconLabel(OPEN_COLAB_WEB),
+              ]);
+            });
+
+            it('returns commands to auto-connect, create a server, open Colab web and upgrade to pro for free users', async () => {
+              if (enablePublicApi) {
+                (
+                  colabApiClientStub.colab.getSubscription as sinon.SinonStub
+                ).resolves({ tier: 'SUBSCRIPTION_TIER_FREE' });
+              } else {
+                colabClientStub.getUserInfo.resolves({
+                  subscriptionTier: SubscriptionTier.NONE,
+                  eligibleAccelerators: [],
+                  ineligibleAccelerators: [],
+                });
+              }
+              const commands = await serverProvider.provideCommands(
+                undefined,
+                cancellationToken,
+              );
+
+              assert.isDefined(commands);
+              expect(commands.map((c) => c.label)).to.deep.equal([
+                buildIconLabel(AUTO_CONNECT),
+                buildIconLabel(NEW_SERVER),
+                buildIconLabel(OPEN_COLAB_WEB),
+                buildIconLabel(UPGRADE_TO_PRO),
+              ]);
+            });
           });
-
-          const commands = await serverProvider.provideCommands(
-            undefined,
-            cancellationToken,
-          );
-
-          assert.isDefined(commands);
-          expect(commands.map((c) => c.label)).to.deep.equal([
-            buildIconLabel(AUTO_CONNECT),
-            buildIconLabel(NEW_SERVER),
-            buildIconLabel(OPEN_COLAB_WEB),
-          ]);
-        });
-
-        it('excludes upgrade to pro command for users with pro-plus', async () => {
-          colabClientStub.getUserInfo.resolves({
-            subscriptionTier: SubscriptionTier.PRO_PLUS,
-            eligibleAccelerators: [],
-            ineligibleAccelerators: [],
-          });
-
-          const commands = await serverProvider.provideCommands(
-            undefined,
-            cancellationToken,
-          );
-
-          assert.isDefined(commands);
-          expect(commands.map((c) => c.label)).to.deep.equal([
-            buildIconLabel(AUTO_CONNECT),
-            buildIconLabel(NEW_SERVER),
-            buildIconLabel(OPEN_COLAB_WEB),
-          ]);
-        });
-
-        it('returns commands to auto-connect, create a server, open Colab web and upgrade to pro for free users', async () => {
-          colabClientStub.getUserInfo.resolves({
-            subscriptionTier: SubscriptionTier.NONE,
-            eligibleAccelerators: [],
-            ineligibleAccelerators: [],
-          });
-
-          const commands = await serverProvider.provideCommands(
-            undefined,
-            cancellationToken,
-          );
-
-          assert.isDefined(commands);
-          expect(commands.map((c) => c.label)).to.deep.equal([
-            buildIconLabel(AUTO_CONNECT),
-            buildIconLabel(NEW_SERVER),
-            buildIconLabel(OPEN_COLAB_WEB),
-            buildIconLabel(UPGRADE_TO_PRO),
-          ]);
         });
       });
 

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -17,7 +17,10 @@ import * as sinon from 'sinon';
 import { CancellationToken, CancellationTokenSource } from 'vscode';
 import { AuthChangeEvent } from '../auth/auth-provider';
 import { ColabClient, NotFoundError } from '../colab/client/v1';
-import { SubscriptionTier, Variant } from '../colab/client/v1/api';
+import { Variant } from '../colab/client/v1/api';
+import { ColabApiClient } from '../colab/client/v2';
+import { ColaboratoryApi } from '../colab/client/v2/generated/colab';
+import { ColaboratoryApi as OperationsApi } from '../colab/client/v2/generated/operations';
 import {
   AUTO_CONNECT,
   NEW_SERVER,
@@ -31,6 +34,7 @@ import {
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../colab/headers';
 import { ServerPicker } from '../colab/server-picker';
+import { SubscriptionTier } from '../colab/types';
 import { InputFlowAction } from '../common/multi-step-quickpick';
 import { TestEventEmitter } from '../test/helpers/events';
 import { TestUri } from '../test/helpers/uri';
@@ -72,6 +76,7 @@ describe('ColabJupyterServerProvider', () => {
   let authChangeEmitter: TestEventEmitter<AuthChangeEvent>;
   let assignmentStub: SinonStubbedInstance<AssignmentManager>;
   let colabClientStub: SinonStubbedInstance<ColabClient>;
+  let colabApiClientStub: SinonStubbedInstance<ColabApiClient>;
   let serverPickerStub: SinonStubbedInstance<ServerPicker>;
   let serverProvider: ColabJupyterServerProvider;
 
@@ -157,6 +162,10 @@ describe('ColabJupyterServerProvider', () => {
       value: sinon.stub(),
     });
     colabClientStub = sinon.createStubInstance(ColabClient);
+    colabApiClientStub = {
+      colab: sinon.createStubInstance(ColaboratoryApi),
+      operations: sinon.createStubInstance(OperationsApi),
+    };
     serverPickerStub = sinon.createStubInstance(ServerPicker);
 
     serverProvider = new ColabJupyterServerProvider(
@@ -164,6 +173,7 @@ describe('ColabJupyterServerProvider', () => {
       authChangeEmitter.event,
       assignmentStub,
       colabClientStub,
+      colabApiClientStub,
       serverPickerStub,
       jupyterStub as Partial<Jupyter> as Jupyter,
     );

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -6,10 +6,8 @@
 import assert from 'assert';
 import vscode from 'vscode';
 import { Disposable } from 'vscode';
-import {
-  AuthType,
-  SubscriptionTier as ColabSubscriptionTier,
-} from '../colab/client/v1/api';
+import { AuthType } from '../colab/client/v1/api';
+import { SubscriptionTier as ColabSubscriptionTier } from '../colab/types';
 import { COLAB_EXT_IDENTIFIER } from '../config/constants';
 import { getPackageInfo } from '../config/package-info';
 import { JUPYTER_EXT_IDENTIFIER } from '../jupyter/jupyter-extension';

--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -8,10 +8,8 @@ import { expect } from 'chai';
 import sinon, { SinonSpy, SinonFakeTimers } from 'sinon';
 import vscode from 'vscode';
 import { Disposable } from 'vscode';
-import {
-  AuthType,
-  SubscriptionTier as ColabSubscriptionTier,
-} from '../colab/client/v1/api';
+import { AuthType } from '../colab/client/v1/api';
+import { SubscriptionTier as ColabSubscriptionTier } from '../colab/types';
 import { COLAB_EXT_IDENTIFIER } from '../config/constants';
 import { JUPYTER_EXT_IDENTIFIER } from '../jupyter/jupyter-extension';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';


### PR DESCRIPTION
This is the first of the migration PRs, so I went with migrating a simpliest `GetSubscription` call in `ColabJupyterServerProvider` gated behind a new `EnablePublicApi` feature flag.

As part of this PR, the following one-time initial setup was required:
* Registering the new `EnablePublicApi` feature flag in `v1/api.ts`.
* Adding `ColabPublicApiDomain` in `generate-config.mts`.
* Lifting `ColabApiClient` to an interface, so it can be properly sinon stubbed.
* Lifting `SubsciptionTier` from `v1/api.ts` to a new common `types.ts`, so both v1 and v2 clients can be normalized to the same type.
   * *Note: This triggered reference changes in a bunch of files.*
* Updating `createColabClients` in `colab/module.ts` to return both `ColabClient` and `ColabApiClient`.

---

Local test shows a successful call to public API Prod:

<img width="676" height="693" alt="GetSubscriptionLocalTest_Prod" src="https://github.com/user-attachments/assets/94957961-69ae-4bf9-a1c5-a3196265c497" />