### PR TITLE
feat: migrate `getAvailableServerDescriptors` to invoke public API

### DIFF
--- a/src/colab/client/v1/api.ts
+++ b/src/colab/client/v1/api.ts
@@ -28,7 +28,7 @@ import {
   Session as GeneratedSession,
   Kernel as GeneratedKernel,
 } from '../../../jupyter/client/generated';
-import { SubscriptionTier } from '../../types';
+import { Shape, SubscriptionTier, Variant } from '../../types';
 
 export enum SubscriptionState {
   UNSUBSCRIBED = 1,
@@ -60,22 +60,10 @@ export enum Outcome {
   DENYLISTED = 5,
 }
 
-export enum Variant {
-  DEFAULT = 'DEFAULT',
-  GPU = 'GPU',
-  TPU = 'TPU',
-}
-
 enum ColabGapiVariant {
   UNSPECIFIED = 'VARIANT_UNSPECIFIED',
   GPU = 'VARIANT_GPU',
   TPU = 'VARIANT_TPU',
-}
-
-export enum Shape {
-  STANDARD = 0,
-  HIGHMEM = 1,
-  // VERYHIGHMEM (2) is deprecated.
 }
 
 enum ColabGapiShape {

--- a/src/colab/client/v1/index.ts
+++ b/src/colab/client/v1/index.ts
@@ -28,10 +28,10 @@ import {
   COLAB_VS_CODE_EXTENSION_VERSION,
   COLAB_XSRF_TOKEN_HEADER,
 } from '../../headers';
+import { Shape, Variant } from '../../types';
 import {
   Assignment,
   AuthType,
-  Variant,
   GetAssignmentResponse,
   AssignmentSchema,
   GetAssignmentResponseSchema,
@@ -46,7 +46,6 @@ import {
   ListedAssignment,
   RuntimeProxyToken,
   RuntimeProxyTokenSchema,
-  Shape,
   SessionSchema,
   CredentialsPropagationResult,
   CredentialsPropagationResultSchema,

--- a/src/colab/client/v1/index.unit.test.ts
+++ b/src/colab/client/v1/index.unit.test.ts
@@ -23,12 +23,10 @@ import {
   COLAB_VS_CODE_EXTENSION_VERSION,
   COLAB_XSRF_TOKEN_HEADER,
 } from '../../headers';
-import { SubscriptionTier } from '../../types';
+import { Shape, SubscriptionTier, Variant } from '../../types';
 import {
   Assignment,
-  Shape,
   SubscriptionState,
-  Variant,
   Outcome,
   RuntimeProxyToken,
   AuthType,

--- a/src/colab/client/v2/index.ts
+++ b/src/colab/client/v2/index.ts
@@ -7,7 +7,11 @@
 import { log } from '../../../common/logging';
 import { telemetry } from '../../../telemetry';
 import { AUTHORIZATION_HEADER, COLAB_CLIENT_AGENT_HEADER } from '../../headers';
-import { SubscriptionTier as CommonSubscriptionTier } from '../../types';
+import {
+  Shape as CommonShape,
+  SubscriptionTier as CommonSubscriptionTier,
+  Variant as CommonVariant,
+} from '../../types';
 import {
   ColaboratoryApi,
   Configuration as ColabConfig,
@@ -16,7 +20,9 @@ import {
   Middleware,
   RequestContext,
   ResponseContext,
+  Shape,
   SubscriptionTier,
+  Variant,
 } from './generated/colab';
 import {
   ColaboratoryApi as OperationsApi,
@@ -75,6 +81,42 @@ export function normalizeSubscriptionTier(
       return CommonSubscriptionTier.PRO_PLUS;
     default:
       throw new Error(`Unknown subscription tier: ${tier}`);
+  }
+}
+
+/**
+ * Normalizes the API {@link Variant} to the common {@link CommonVariant}.
+ *
+ * @param variant - Variant returned from public Colab API.
+ * @returns Normalized common variant value.
+ */
+export function normalizeVariant(variant: Variant): CommonVariant {
+  switch (variant) {
+    case Variant.VariantCpu:
+      return CommonVariant.DEFAULT;
+    case Variant.VariantGpu:
+      return CommonVariant.GPU;
+    case Variant.VariantTpu:
+      return CommonVariant.TPU;
+    default:
+      throw new Error(`Unknown variant: ${variant}`);
+  }
+}
+
+/**
+ * Normalizes the API {@link Shape} to the common {@link CommonShape}.
+ *
+ * @param shape - Shape returned from public Colab API.
+ * @returns Normalized common variant value.
+ */
+export function normalizeShape(shape: Shape): CommonShape {
+  switch (shape) {
+    case Shape.ShapeStandard:
+      return CommonShape.STANDARD;
+    case Shape.ShapeHighmem:
+      return CommonShape.HIGHMEM;
+    default:
+      throw new Error(`Unknown shape: ${shape}`);
   }
 }
 

--- a/src/colab/client/v2/index.unit.test.ts
+++ b/src/colab/client/v2/index.unit.test.ts
@@ -11,12 +11,24 @@ import * as sinon from 'sinon';
 import { SinonStubbedFunction } from 'sinon';
 import { telemetry } from '../../../telemetry';
 import { AUTHORIZATION_HEADER, COLAB_CLIENT_AGENT_HEADER } from '../../headers';
-import { SubscriptionTier as CommonSubscriptionTier } from '../../types';
-import { FetchAPI, Key, SubscriptionTier } from './generated/colab';
+import {
+  Shape as CommonShape,
+  SubscriptionTier as CommonSubscriptionTier,
+  Variant as CommonVariant,
+} from '../../types';
+import {
+  FetchAPI,
+  Key,
+  Shape,
+  SubscriptionTier,
+  Variant,
+} from './generated/colab';
 import {
   ColabApiClient,
   createColabApiClient,
+  normalizeShape,
   normalizeSubscriptionTier,
+  normalizeVariant,
 } from '.';
 
 const COLAB_API_HOST = 'colab.example.com';
@@ -1057,5 +1069,57 @@ describe('normalizeSubscriptionTier', () => {
     expect(() =>
       normalizeSubscriptionTier(SubscriptionTier.SubscriptionTierUnspecified),
     ).to.throw(/Unknown subscription tier:/);
+  });
+});
+
+describe('normalizeVariant', () => {
+  const tests = [
+    {
+      input: Variant.VariantCpu,
+      expected: CommonVariant.DEFAULT,
+    },
+    {
+      input: Variant.VariantGpu,
+      expected: CommonVariant.GPU,
+    },
+    {
+      input: Variant.VariantTpu,
+      expected: CommonVariant.TPU,
+    },
+  ];
+  tests.forEach(({ input, expected }) => {
+    it(`normalizes ${input}`, () => {
+      expect(normalizeVariant(input)).to.equal(expected);
+    });
+  });
+
+  it('throws an error if unspecified', () => {
+    expect(() => normalizeVariant(Variant.VariantUnspecified)).to.throw(
+      /Unknown variant:/,
+    );
+  });
+});
+
+describe('normalizeShape', () => {
+  const tests = [
+    {
+      input: Shape.ShapeStandard,
+      expected: CommonShape.STANDARD,
+    },
+    {
+      input: Shape.ShapeHighmem,
+      expected: CommonShape.HIGHMEM,
+    },
+  ];
+  tests.forEach(({ input, expected }) => {
+    it(`normalizes ${input}`, () => {
+      expect(normalizeShape(input)).to.equal(expected);
+    });
+  });
+
+  it('throws an error if unspecified', () => {
+    expect(() => normalizeShape(Shape.ShapeUnspecified)).to.throw(
+      /Unknown shape:/,
+    );
   });
 });

--- a/src/colab/commands/files.unit.test.ts
+++ b/src/colab/commands/files.unit.test.ts
@@ -13,7 +13,7 @@ import { CommandSource, Outcome } from '../../telemetry/api';
 import { TestCancellationTokenSource } from '../../test/helpers/cancellation';
 import { TestUri } from '../../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
-import { Variant } from '../client/v1/api';
+import { Variant } from '../types';
 import { upload } from './files';
 
 const DEFAULT_SERVER = {

--- a/src/colab/commands/server.unit.test.ts
+++ b/src/colab/commands/server.unit.test.ts
@@ -21,7 +21,7 @@ import {
   buildInputBoxStub,
 } from '../../test/helpers/quick-input';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
-import { Variant } from '../client/v1/api';
+import { Variant } from '../types';
 import { mountServer, removeServer, renameServerAlias } from './server';
 
 describe('Server Commands', () => {

--- a/src/colab/commands/terminal.unit.test.ts
+++ b/src/colab/commands/terminal.unit.test.ts
@@ -18,7 +18,7 @@ import {
 import { TestThemeIcon } from '../../test/helpers/theme';
 import { TestUri } from '../../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
-import { Variant } from '../client/v1/api';
+import { Variant } from '../types';
 import { openTerminal } from './terminal';
 
 describe('openTerminal command', () => {

--- a/src/colab/connection-refresher.unit.test.ts
+++ b/src/colab/connection-refresher.unit.test.ts
@@ -16,7 +16,6 @@ import { ControllableAsyncToggle } from '../test/helpers/async';
 import { TestEventEmitter } from '../test/helpers/events';
 import { TestUri } from '../test/helpers/uri';
 import { NotFoundError } from './client/v1';
-import { Variant } from './client/v1/api';
 import {
   ConnectionRefreshController,
   ConnectionRefresher,
@@ -25,6 +24,7 @@ import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from './headers';
+import { Variant } from './types';
 
 const REFRESH_MS = 1000 * 60 * 60;
 const DEFAULT_SERVER: ColabAssignedServer = {

--- a/src/colab/consumption/poller.unit.test.ts
+++ b/src/colab/consumption/poller.unit.test.ts
@@ -16,8 +16,8 @@ import { Deferred } from '../../test/helpers/async';
 import { TestEventEmitter } from '../../test/helpers/events';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
 import { ColabClient } from '../client/v1';
-import { ConsumptionUserInfo, Variant } from '../client/v1/api';
-import { SubscriptionTier } from '../types';
+import { ConsumptionUserInfo } from '../client/v1/api';
+import { SubscriptionTier, Variant } from '../types';
 import { ConsumptionPoller, TEST_ONLY } from './poller';
 
 const POLL_INTERVAL_MS = TEST_ONLY.POLL_INTERVAL_MS;

--- a/src/colab/content-browser/content-tree.vscode.test.ts
+++ b/src/colab/content-browser/content-tree.vscode.test.ts
@@ -21,11 +21,11 @@ import {
 import { ContentsFileSystemProvider } from '../../jupyter/contents/file-system';
 import { ColabAssignedServer } from '../../jupyter/servers';
 import { TestEventEmitter } from '../../test/helpers/events';
-import { Variant } from '../client/v1/api';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../headers';
+import { Variant } from '../types';
 import { ContentItem } from './content-item';
 import { ContentTreeProvider } from './content-tree';
 

--- a/src/colab/files.unit.test.ts
+++ b/src/colab/files.unit.test.ts
@@ -9,8 +9,8 @@ import { expect } from 'chai';
 import { describe } from 'mocha';
 import { TestUri } from '../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
-import { Variant } from './client/v1/api';
 import { buildColabFileUri } from './files';
+import { Variant } from './types';
 
 const DEFAULT_SERVER = {
   id: randomUUID(),

--- a/src/colab/keep-alive.unit.test.ts
+++ b/src/colab/keep-alive.unit.test.ts
@@ -19,12 +19,12 @@ import {
 import { TestUri } from '../test/helpers/uri';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
 import { ColabClient } from './client/v1';
-import { Variant } from './client/v1/api';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from './headers';
 import { ServerKeepAliveController } from './keep-alive';
+import { Variant } from './types';
 
 const NOW = new Date();
 const ONE_SECOND_MS = 1000;

--- a/src/colab/server-picker.ts
+++ b/src/colab/server-picker.ts
@@ -9,13 +9,12 @@ import { InputStep, MultiStepInput } from '../common/multi-step-quickpick';
 import { AssignmentManager } from '../jupyter/assignments';
 import { ColabServerDescriptor } from '../jupyter/servers';
 import {
-  Variant,
   variantToMachineType,
-  Shape,
   shapeToMachineShape,
   ExperimentFlag,
 } from './client/v1/api';
 import { getFlag } from './experiment-state';
+import { Shape, Variant } from './types';
 
 /** Provides an explanation to the user on updating the server alias. */
 export const PROMPT_SERVER_ALIAS =

--- a/src/colab/server-picker.unit.test.ts
+++ b/src/colab/server-picker.unit.test.ts
@@ -14,9 +14,10 @@ import {
   buildQuickPickStub,
 } from '../test/helpers/quick-input';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
-import { Variant, Shape, ExperimentFlag } from './client/v1/api';
+import { ExperimentFlag } from './client/v1/api';
 import { TEST_ONLY } from './experiment-state';
 import { ServerPicker } from './server-picker';
+import { Shape, Variant } from './types';
 
 const STANDARD_T4_SERVER = {
   label: 'Colab GPU T4',

--- a/src/colab/terminal/colab-terminal-websocket.unit.test.ts
+++ b/src/colab/terminal/colab-terminal-websocket.unit.test.ts
@@ -10,8 +10,8 @@ import sinon from 'sinon';
 import WebSocket from 'ws';
 import { ColabAssignedServer } from '../../jupyter/servers';
 import { newVsCodeStub, VsCodeStub } from '../../test/helpers/vscode';
-import { Variant } from '../client/v1/api';
 import { COLAB_RUNTIME_PROXY_TOKEN_HEADER } from '../headers';
+import { Variant } from '../types';
 import { ColabTerminalWebSocket } from './colab-terminal-websocket';
 
 describe('ColabTerminalWebSocket', () => {

--- a/src/colab/types.ts
+++ b/src/colab/types.ts
@@ -13,3 +13,15 @@ export enum SubscriptionTier {
   PRO = 1,
   PRO_PLUS = 2,
 }
+
+export enum Variant {
+  DEFAULT = 'DEFAULT',
+  GPU = 'GPU',
+  TPU = 'TPU',
+}
+
+export enum Shape {
+  STANDARD = 0,
+  HIGHMEM = 1,
+  // VERYHIGHMEM (2) is deprecated.
+}

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -147,8 +147,8 @@ export class AssignmentManager implements Disposable {
       // also returns additional high-memory shapes for the Pro users, so we
       // don't need to manually add them.
       const response = await this.colabApiClient.colab.listRuntimeSpecs(
-        {},
-        { signal },
+        /* requestParameters= */ {},
+        /* initOverrides= */ { signal },
       );
       return (
         response.runtimeSpecs

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -156,16 +156,12 @@ export class AssignmentManager implements Disposable {
           .map((spec) => {
             const variant = normalizeVariant(spec.key.variant);
             const shape = normalizeShape(spec.key.shape);
+            const accelerator = spec.key.accelerator;
             const label =
               variant === Variant.DEFAULT
                 ? 'Colab CPU'
-                : `Colab ${variant} ${spec.key.accelerator}`;
-            return {
-              label,
-              variant,
-              accelerator: spec.key.accelerator,
-              shape,
-            };
+                : `Colab ${variant} ${accelerator}`;
+            return { label, variant, accelerator, shape };
           }) ?? []
       );
     }

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -142,6 +142,10 @@ export class AssignmentManager implements Disposable {
     this.guardDisposed();
     const enablePublicApi = getFlag(ExperimentFlag.EnablePublicApi);
     if (enablePublicApi) {
+      // The new ListRuntimeSpecs API already takes user's subscription tier
+      // into account, returning with the correct eligibility info. The new API
+      // also returns additional high-memory shapes for the Pro users, so we
+      // don't need to manually add them.
       const response = await this.colabApiClient.colab.listRuntimeSpecs(
         {},
         { signal },
@@ -152,12 +156,14 @@ export class AssignmentManager implements Disposable {
           .map((spec) => {
             const variant = normalizeVariant(spec.key.variant);
             const shape = normalizeShape(spec.key.shape);
-            const accelerator =
-              spec.key.accelerator === 'NONE' ? '' : spec.key.accelerator;
+            const label =
+              variant === Variant.DEFAULT
+                ? 'Colab CPU'
+                : `Colab ${variant} ${spec.key.accelerator}`;
             return {
-              label: `Colab ${variant} ${accelerator}`,
+              label,
               variant,
-              accelerator,
+              accelerator: spec.key.accelerator,
               shape,
             };
           }) ?? []

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -25,18 +25,23 @@ import {
   Assignment,
   ListedAssignment,
   RuntimeProxyToken,
-  Variant,
   variantToMachineType,
-  Shape,
   isHighMemOnlyAccelerator,
+  ExperimentFlag,
 } from '../colab/client/v1/api';
+import {
+  ColabApiClient,
+  normalizeShape,
+  normalizeVariant,
+} from '../colab/client/v2';
 import { REMOVE_SERVER } from '../colab/commands/constants';
 import { ColabRequestError } from '../colab/errors';
+import { getFlag } from '../colab/experiment-state';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../colab/headers';
-import { SubscriptionTier } from '../colab/types';
+import { Shape, SubscriptionTier, Variant } from '../colab/types';
 import { waitForTimeout } from '../common/async';
 import { log } from '../common/logging';
 import { telemetry } from '../telemetry';
@@ -94,12 +99,14 @@ export class AssignmentManager implements Disposable {
    * Initializes a new instance.
    *
    * @param vs - The VS Code API instance.
-   * @param client - The API client instance.
+   * @param colabClient - The old Colab private API client instance.
+   * @param colabApiClient - The new Colab public API client instance.
    * @param storage - The storage instance for persistence.
    */
   constructor(
     private readonly vs: typeof vscode,
-    private readonly client: ColabClient,
+    private readonly colabClient: ColabClient,
+    private readonly colabApiClient: ColabApiClient,
     private readonly storage: ServerStorage,
   ) {
     this.assignmentChange = new vs.EventEmitter<AssignmentChangeEvent>();
@@ -133,7 +140,31 @@ export class AssignmentManager implements Disposable {
     signal?: AbortSignal,
   ): Promise<ColabServerDescriptor[]> {
     this.guardDisposed();
-    const userInfo = await this.client.getUserInfo(signal);
+    const enablePublicApi = getFlag(ExperimentFlag.EnablePublicApi);
+    if (enablePublicApi) {
+      const response = await this.colabApiClient.colab.listRuntimeSpecs(
+        {},
+        { signal },
+      );
+      return (
+        response.runtimeSpecs
+          ?.filter((spec) => spec.eligible)
+          .map((spec) => {
+            const variant = normalizeVariant(spec.key.variant);
+            const shape = normalizeShape(spec.key.shape);
+            const accelerator =
+              spec.key.accelerator === 'NONE' ? '' : spec.key.accelerator;
+            return {
+              label: `Colab ${variant} ${accelerator}`,
+              variant,
+              accelerator,
+              shape,
+            };
+          }) ?? []
+      );
+    }
+
+    const userInfo = await this.colabClient.getUserInfo(signal);
 
     const eligibleDescriptors: ColabServerDescriptor[] =
       userInfo.eligibleAccelerators.flatMap((acc) =>
@@ -176,7 +207,7 @@ export class AssignmentManager implements Disposable {
     if (stored.length === 0) {
       return;
     }
-    const live = await this.client.listAssignments(signal);
+    const live = await this.colabClient.listAssignments(signal);
     await this.reconcileStoredServers(stored, live);
   }
 
@@ -238,7 +269,7 @@ export class AssignmentManager implements Disposable {
       return storedServers;
     }
 
-    const allAssignments = await this.client.listAssignments(signal);
+    const allAssignments = await this.colabClient.listAssignments(signal);
 
     if (from === 'extension' || from === 'all') {
       storedServers = (
@@ -250,7 +281,7 @@ export class AssignmentManager implements Disposable {
           connectionInformation: {
             ...c,
             fetch: colabProxyFetch(c.token),
-            WebSocket: colabProxyWebSocket(this.vs, this.client, server),
+            WebSocket: colabProxyWebSocket(this.vs, this.colabClient, server),
           },
         };
       });
@@ -328,7 +359,7 @@ export class AssignmentManager implements Disposable {
           );
           hadFallback = assignment.accelerator !== descriptor.accelerator;
         } else {
-          ({ assignment } = await this.client.assign(
+          ({ assignment } = await this.colabClient.assign(
             id,
             { variant, accelerator, shape, version },
             signal,
@@ -454,7 +485,7 @@ export class AssignmentManager implements Disposable {
     if (!server) {
       throw new NotFoundError('Server is not assigned');
     }
-    const newConnectionInfo = await this.client.refreshConnection(
+    const newConnectionInfo = await this.colabClient.refreshConnection(
       server.endpoint,
       signal,
     );
@@ -492,7 +523,7 @@ export class AssignmentManager implements Disposable {
   ): Promise<void> {
     this.guardDisposed();
     if (!isColabAssignedServer(server)) {
-      await this.client.unassign(server.endpoint, signal);
+      await this.colabClient.unassign(server.endpoint, signal);
       return;
     }
 
@@ -501,7 +532,7 @@ export class AssignmentManager implements Disposable {
       return;
     }
     await this.deleteSessions(server, signal);
-    await this.client.unassign(server.endpoint, signal);
+    await this.colabClient.unassign(server.endpoint, signal);
     const removed = await this.storage.remove(server.id);
     if (!removed) {
       return;
@@ -607,7 +638,7 @@ export class AssignmentManager implements Disposable {
   ): Promise<Assignment> {
     const { variant, accelerator, shape, version } = descriptor;
     try {
-      const { assignment } = await this.client.assign(
+      const { assignment } = await this.colabClient.assign(
         id,
         { variant, accelerator, shape, version },
         signal,
@@ -703,7 +734,7 @@ export class AssignmentManager implements Disposable {
       ...colabServer,
       connectionInformation: {
         ...colabServer.connectionInformation,
-        WebSocket: colabProxyWebSocket(this.vs, this.client, colabServer),
+        WebSocket: colabProxyWebSocket(this.vs, this.colabClient, colabServer),
       },
     };
   }
@@ -729,7 +760,7 @@ export class AssignmentManager implements Disposable {
             );
             try {
               const sessions = await Promise.race([
-                this.client.listSessions(a.endpoint, signal),
+                this.colabClient.listSessions(a.endpoint, signal),
                 timeout.promise,
               ]);
               label =

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -24,18 +24,19 @@ import {
 import {
   Assignment,
   RuntimeProxyToken,
-  Shape,
   SubscriptionState,
   UserInfo,
-  Variant,
 } from '../colab/client/v1/api';
+import { ColabApiClient } from '../colab/client/v2';
+import { ColaboratoryApi } from '../colab/client/v2/generated/colab';
+import { ColaboratoryApi as OperationsApi } from '../colab/client/v2/generated/operations';
 import { REMOVE_SERVER } from '../colab/commands/constants';
 import { ColabRequestError } from '../colab/errors';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../colab/headers';
-import { SubscriptionTier } from '../colab/types';
+import { Shape, SubscriptionTier, Variant } from '../colab/types';
 import { telemetry } from '../telemetry';
 import { AssignmentOutcome, CommandSource } from '../telemetry/api';
 import { TestEventEmitter } from '../test/helpers/events';
@@ -103,6 +104,7 @@ describe('AssignmentManager', () => {
   let fakeClock: SinonFakeTimers;
   let vsCodeStub: VsCodeStub;
   let colabClientStub: SinonStubbedInstance<ColabClient>;
+  let colabApiClientStub: SinonStubbedInstance<ColabApiClient>;
   let serverStorage: ServerStorage;
   let assignmentChangeListener: sinon.SinonStub<[AssignmentChangeEvent], void>;
   let assignmentManager: AssignmentManager;
@@ -144,10 +146,15 @@ describe('AssignmentManager', () => {
     fakeClock = sinon.useFakeTimers({ now: NOW, toFake: [] });
     vsCodeStub = newVsCodeStub();
     colabClientStub = sinon.createStubInstance(ColabClient);
+    colabApiClientStub = {
+      colab: sinon.createStubInstance(ColaboratoryApi),
+      operations: sinon.createStubInstance(OperationsApi),
+    };
     serverStorage = new ServerStorageFake() as ServerStorage;
     assignmentManager = new AssignmentManager(
       vsCodeStub.asVsCode(),
       colabClientStub,
+      colabApiClientStub,
       serverStorage,
     );
     assignmentChangeListener = sinon.stub();

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -23,6 +23,7 @@ import {
 } from '../colab/client/v1';
 import {
   Assignment,
+  ExperimentFlag,
   RuntimeProxyToken,
   SubscriptionState,
   UserInfo,
@@ -32,6 +33,7 @@ import { ColaboratoryApi } from '../colab/client/v2/generated/colab';
 import { ColaboratoryApi as OperationsApi } from '../colab/client/v2/generated/operations';
 import { REMOVE_SERVER } from '../colab/commands/constants';
 import { ColabRequestError } from '../colab/errors';
+import { TEST_ONLY as EXPERIMENT_TEST } from '../colab/experiment-state';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
@@ -162,6 +164,7 @@ describe('AssignmentManager', () => {
   });
 
   afterEach(() => {
+    EXPERIMENT_TEST.resetFlagsForTest();
     fakeClock.restore();
     sinon.restore();
   });
@@ -174,22 +177,6 @@ describe('AssignmentManager', () => {
         assignmentManager.getAvailableServerDescriptors(),
       ).to.be.rejectedWith(/disposed/);
     });
-
-    const mockUserInfo: UserInfo = {
-      subscriptionTier: SubscriptionTier.NONE,
-      paidComputeUnitsBalance: 1,
-      eligibleAccelerators: [
-        {
-          variant: Variant.GPU,
-          models: ['T4', 'A100'],
-        },
-        {
-          variant: Variant.TPU,
-          models: ['V5E1', 'V6E1'],
-        },
-      ],
-      ineligibleAccelerators: [],
-    };
 
     const defaultGpuT4Descriptor = {
       label: 'Colab GPU T4',
@@ -215,38 +202,118 @@ describe('AssignmentManager', () => {
       accelerator: 'V6E1',
     };
 
-    it('returns the default CPU and the eligible servers', async () => {
-      colabClientStub.getUserInfo.resolves(mockUserInfo);
+    describe('with Public API disabled', () => {
+      const mockUserInfo: UserInfo = {
+        subscriptionTier: SubscriptionTier.NONE,
+        paidComputeUnitsBalance: 1,
+        eligibleAccelerators: [
+          {
+            variant: Variant.GPU,
+            models: ['T4', 'A100'],
+          },
+          {
+            variant: Variant.TPU,
+            models: ['V5E1', 'V6E1'],
+          },
+        ],
+        ineligibleAccelerators: [],
+      };
 
-      const servers = await assignmentManager.getAvailableServerDescriptors();
-
-      expect(servers).to.deep.equal([
-        DEFAULT_CPU_SERVER,
-        defaultGpuT4Descriptor,
-        defaultGpuA100Descriptor,
-        defaultTpuV5E1Descriptor,
-        defaultTpuV6E1Descriptor,
-      ]);
-    });
-
-    it('returns the default CPU and the eligible servers for pro users', async () => {
-      colabClientStub.getUserInfo.resolves({
-        ...mockUserInfo,
-        subscriptionTier: SubscriptionTier.PRO,
+      beforeEach(() => {
+        EXPERIMENT_TEST.setFlagForTest(ExperimentFlag.EnablePublicApi, false);
       });
 
-      const servers = await assignmentManager.getAvailableServerDescriptors();
+      it('returns the default CPU and the eligible servers', async () => {
+        colabClientStub.getUserInfo.resolves(mockUserInfo);
 
-      expect(servers).to.deep.equal([
-        { ...DEFAULT_CPU_SERVER, shape: Shape.STANDARD },
-        { ...DEFAULT_CPU_SERVER, shape: Shape.HIGHMEM },
-        { ...defaultGpuT4Descriptor, shape: Shape.STANDARD },
-        { ...defaultGpuT4Descriptor, shape: Shape.HIGHMEM },
-        { ...defaultGpuA100Descriptor, shape: Shape.STANDARD },
-        { ...defaultGpuA100Descriptor, shape: Shape.HIGHMEM },
-        { ...defaultTpuV5E1Descriptor, shape: Shape.HIGHMEM },
-        { ...defaultTpuV6E1Descriptor, shape: Shape.HIGHMEM },
-      ]);
+        const servers = await assignmentManager.getAvailableServerDescriptors();
+
+        expect(servers).to.deep.equal([
+          DEFAULT_CPU_SERVER,
+          defaultGpuT4Descriptor,
+          defaultGpuA100Descriptor,
+          defaultTpuV5E1Descriptor,
+          defaultTpuV6E1Descriptor,
+        ]);
+      });
+
+      it('returns the default CPU and the eligible servers for pro users', async () => {
+        colabClientStub.getUserInfo.resolves({
+          ...mockUserInfo,
+          subscriptionTier: SubscriptionTier.PRO,
+        });
+
+        const servers = await assignmentManager.getAvailableServerDescriptors();
+
+        expect(servers).to.deep.equal([
+          { ...DEFAULT_CPU_SERVER, shape: Shape.STANDARD },
+          { ...DEFAULT_CPU_SERVER, shape: Shape.HIGHMEM },
+          { ...defaultGpuT4Descriptor, shape: Shape.STANDARD },
+          { ...defaultGpuT4Descriptor, shape: Shape.HIGHMEM },
+          { ...defaultGpuA100Descriptor, shape: Shape.STANDARD },
+          { ...defaultGpuA100Descriptor, shape: Shape.HIGHMEM },
+          { ...defaultTpuV5E1Descriptor, shape: Shape.HIGHMEM },
+          { ...defaultTpuV6E1Descriptor, shape: Shape.HIGHMEM },
+        ]);
+      });
+    });
+
+    describe('with Public API enabled', () => {
+      const defaultCpuSpec = {
+        variant: 'VARIANT_CPU',
+        shape: 'SHAPE_STANDARD',
+        accelerator: 'NONE',
+      };
+      const defaultGpuSpec = {
+        variant: 'VARIANT_GPU',
+        shape: 'SHAPE_STANDARD',
+        accelerator: 'T4',
+      };
+      const defaultTpuSpec = {
+        variant: 'VARIANT_TPU',
+        shape: 'SHAPE_STANDARD',
+        accelerator: 'V5E1',
+      };
+
+      beforeEach(() => {
+        EXPERIMENT_TEST.setFlagForTest(ExperimentFlag.EnablePublicApi, true);
+        (colabApiClientStub.colab.listRuntimeSpecs as sinon.SinonStub).resolves(
+          {
+            runtimeSpecs: [
+              {
+                key: defaultCpuSpec,
+                eligible: true,
+              },
+              {
+                key: defaultGpuSpec,
+                eligible: true,
+              },
+              {
+                key: defaultTpuSpec,
+                eligible: true,
+              },
+              {
+                key: {
+                  variant: 'VARIANT_GPU',
+                  shape: 'SHAPE_HIGHMEM',
+                  accelerator: 'DOES_NOT_MATTER',
+                },
+                eligible: false,
+              },
+            ],
+          },
+        );
+      });
+
+      it('returns the eligible server specs', async () => {
+        await expect(
+          assignmentManager.getAvailableServerDescriptors(),
+        ).to.eventually.deep.equal([
+          { ...DEFAULT_CPU_SERVER, shape: Shape.STANDARD, accelerator: 'NONE' },
+          { ...defaultGpuT4Descriptor, shape: Shape.STANDARD },
+          { ...defaultTpuV5E1Descriptor, shape: Shape.STANDARD },
+        ]);
+      });
     });
   });
 

--- a/src/jupyter/client/index.unit.test.ts
+++ b/src/jupyter/client/index.unit.test.ts
@@ -8,11 +8,11 @@ import { randomUUID } from 'crypto';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Disposable } from 'vscode';
-import { Variant } from '../../colab/client/v1/api';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../../colab/headers';
+import { Variant } from '../../colab/types';
 import { TestEventEmitter } from '../../test/helpers/events';
 import { TestUri } from '../../test/helpers/uri';
 import { AssignmentChangeEvent } from '../assignments';

--- a/src/jupyter/contents/file-system.unit.test.ts
+++ b/src/jupyter/contents/file-system.unit.test.ts
@@ -8,7 +8,7 @@ import { randomUUID } from 'crypto';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { FileChangeEvent, Uri, WorkspaceFoldersChangeEvent } from 'vscode';
-import { Variant } from '../../colab/client/v1/api';
+import { Variant } from '../../colab/types';
 import { TestEventEmitter } from '../../test/helpers/events';
 import { TestUri } from '../../test/helpers/uri';
 import {

--- a/src/jupyter/contents/sessions.unit.test.ts
+++ b/src/jupyter/contents/sessions.unit.test.ts
@@ -14,8 +14,8 @@ import {
   WorkspaceConfiguration,
 } from 'vscode';
 import { AuthChangeEvent } from '../../auth/auth-provider';
-import { Variant } from '../../colab/client/v1/api';
 import { COLAB_RUNTIME_PROXY_TOKEN_HEADER } from '../../colab/headers';
+import { Variant } from '../../colab/types';
 import { Deferred } from '../../test/helpers/async';
 import { TestEventEmitter } from '../../test/helpers/events';
 import {

--- a/src/jupyter/module.ts
+++ b/src/jupyter/module.ts
@@ -74,6 +74,7 @@ export function createJupyterModule(
   const assignmentManager = new AssignmentManager(
     vs,
     colabClient,
+    colabApiClient,
     serverStorage,
   );
   const serverProvider = new ColabJupyterServerProvider(

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -17,7 +17,7 @@ import * as sinon from 'sinon';
 import { CancellationToken, CancellationTokenSource } from 'vscode';
 import { AuthChangeEvent } from '../auth/auth-provider';
 import { ColabClient, NotFoundError } from '../colab/client/v1';
-import { ExperimentFlag, Variant } from '../colab/client/v1/api';
+import { ExperimentFlag } from '../colab/client/v1/api';
 import { ColabApiClient } from '../colab/client/v2';
 import { ColaboratoryApi } from '../colab/client/v2/generated/colab';
 import { ColaboratoryApi as OperationsApi } from '../colab/client/v2/generated/operations';
@@ -35,7 +35,7 @@ import {
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../colab/headers';
 import { ServerPicker } from '../colab/server-picker';
-import { SubscriptionTier } from '../colab/types';
+import { SubscriptionTier, Variant } from '../colab/types';
 import { InputFlowAction } from '../common/multi-step-quickpick';
 import { TestEventEmitter } from '../test/helpers/events';
 import { TestUri } from '../test/helpers/uri';

--- a/src/jupyter/servers.ts
+++ b/src/jupyter/servers.ts
@@ -9,7 +9,7 @@ import {
   JupyterServer,
   JupyterServerConnectionInformation,
 } from '@vscode/jupyter-extension';
-import { Variant, Shape } from '../colab/client/v1/api';
+import { Variant, Shape } from '../colab/types';
 
 /**
  * Colab's Jupyter server descriptor which includes machine-specific

--- a/src/jupyter/storage.ts
+++ b/src/jupyter/storage.ts
@@ -7,7 +7,7 @@
 import { UUID } from 'crypto';
 import vscode from 'vscode';
 import { z } from 'zod';
-import { Variant } from '../colab/client/v1/api';
+import { Variant } from '../colab/types';
 import { PROVIDER_ID } from '../config/constants';
 import { isUUID } from '../utils/uuid';
 import { ColabAssignedServer } from './servers';

--- a/src/jupyter/storage.unit.test.ts
+++ b/src/jupyter/storage.unit.test.ts
@@ -8,7 +8,7 @@ import { randomUUID } from 'crypto';
 import { assert, expect } from 'chai';
 import sinon, { SinonStubbedInstance } from 'sinon';
 import { SecretStorage } from 'vscode';
-import { Variant } from '../colab/client/v1/api';
+import { Variant } from '../colab/types';
 import { PROVIDER_ID } from '../config/constants';
 import { SecretStorageFake } from '../test/helpers/secret-storage';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';


### PR DESCRIPTION
Migrated `AssignmentManager.getAvailableServerDescriptors` to invoke `ListRuntimeSpecs` API.

The main changes are in the following 3 files:
* `jupyter/assignments.ts` - This is where the new `ListRuntimeSpecs` API is invoked behind the `EnablePublicApi` feature flag.
* `colab/types.ts` - Lifted `Variant` and `Shape` from `colab/client/v1/api.ts`, so both v1 and v2 clients can be normalized to the same type.
   * *Note: This again triggered reference changes in a bunch of files.*
* `colab/client/v2/index.ts` - Added 2 new helper functions to normalize API returned `Variant` and `Shape` to the common types.

---

Local test shows a successful call to public API in Prod:

<img width="1344" height="1244" alt="60371BEB-E402-49AB-AF80-98CAFD8D4A2D" src="https://github.com/user-attachments/assets/2966857c-42fd-44ad-99d4-db0c8fd15dda" />