### PR TITLE
chore: enable `jsonRecursiveSort` on OpenAPI JSON docs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -10,7 +10,8 @@
     {
       "files": ["src/colab/client/v2/*-api.json"],
       "options": {
-        "plugins": ["prettier-plugin-sort-json"]
+        "plugins": ["prettier-plugin-sort-json"],
+        "jsonRecursiveSort": true
       }
     }
   ]

--- a/src/colab/client/v2/colab-api.json
+++ b/src/colab/client/v2/colab-api.json
@@ -1,262 +1,126 @@
 {
   "components": {
-    "securitySchemes": {
-      "google_oauth_implicit": {
-        "description": "Google Oauth 2.0 implicit authentication flow.",
-        "type": "oauth2",
-        "flows": {
-          "implicit": {
-            "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
-            "scopes": {
-              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources"
-            }
-          }
-        }
-      },
-      "bearer_auth": {
-        "scheme": "bearer",
-        "description": "Http bearer authentication.",
-        "type": "http"
-      },
-      "google_oauth_code": {
-        "type": "oauth2",
-        "flows": {
-          "authorizationCode": {
-            "refreshUrl": "https://oauth2.googleapis.com/token",
-            "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
-            "tokenUrl": "https://oauth2.googleapis.com/token",
-            "scopes": {
-              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources"
-            }
-          }
-        },
-        "description": "Google Oauth 2.0 authorizationCode authentication flow."
-      }
-    },
     "parameters": {
       "_.xgafv": {
-        "name": "$.xgafv",
         "description": "V1 error format.",
+        "in": "query",
+        "name": "$.xgafv",
         "schema": {
           "enum": ["1", "2"],
-          "x-google-enum-descriptions": ["v1 error format", "v2 error format"],
-          "type": "string"
-        },
-        "in": "query"
+          "type": "string",
+          "x-google-enum-descriptions": ["v1 error format", "v2 error format"]
+        }
       },
       "alt": {
         "description": "Data format for response.",
-        "name": "$alt",
         "in": "query",
+        "name": "$alt",
         "schema": {
           "default": "json",
           "enum": ["json", "media", "proto"],
+          "type": "string",
           "x-google-enum-descriptions": [
             "Responses with Content-Type of application/json",
             "Media download with context-dependent Content-Type",
             "Responses with Content-Type of application/x-protobuf"
-          ],
-          "type": "string"
+          ]
         }
       },
       "callback": {
-        "name": "$callback",
         "description": "JSONP",
+        "in": "query",
+        "name": "$callback",
         "schema": {
           "type": "string"
-        },
-        "in": "query"
+        }
       },
       "prettyPrint": {
+        "description": "Returns response with indentations and line breaks.",
+        "in": "query",
+        "name": "$prettyPrint",
         "schema": {
           "default": "true",
           "type": "boolean"
-        },
-        "in": "query",
-        "name": "$prettyPrint",
-        "description": "Returns response with indentations and line breaks."
+        }
       }
     },
     "schemas": {
-      "ListRuntimesResponse": {
-        "type": "object",
-        "description": "Response message for `ListRuntimes`.",
-        "properties": {
-          "runtimes": {
-            "description": "The list of runtimes assigned to the requesting user.",
-            "items": {
-              "$ref": "#/components/schemas/Runtime"
-            },
-            "type": "array"
-          }
-        }
-      },
-      "Operation": {
-        "type": "object",
+      "BaseOperation": {
         "description": "This resource represents a long-running operation that is the result of a\nnetwork API call.",
+        "properties": {
+          "done": {
+            "description": "If the value is `false`, it means the operation is still in progress.\nIf `true`, the operation is completed, and either `error` or `response` is\navailable.",
+            "type": "boolean"
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Status"
+              }
+            ],
+            "description": "The error result of the operation in case of failure or cancellation."
+          },
+          "name": {
+            "description": "The server-assigned name, which is only unique within the same service that\noriginally returns it. If you use the default HTTP mapping, the\n`name` should be a resource name ending with `operations/{unique_id}`.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ConnectionInfo": {
+        "description": "Connection info used to authenticate to the runtime.",
+        "properties": {
+          "expireTime": {
+            "description": "Output only. The expiration time of the runtime proxy token.",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "token": {
+            "description": "Output only. The runtime proxy token. This is a short-lived credential used to\nauthenticate to the runtime.",
+            "readOnly": true,
+            "type": "string"
+          },
+          "url": {
+            "description": "Output only. The authenticated URL that can be used to connect to the runtime.",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CreateRuntimeMetadata": {
+        "description": "Metadata for `CreateRuntime` long-running operation.",
+        "properties": {
+          "runtime": {
+            "description": "The runtime resource being created, in the format of\n`runtimes/{runtime_id}`.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CreateRuntimeOperation": {
         "allOf": [
           {
             "$ref": "#/components/schemas/BaseOperation"
           },
           {
-            "type": "object",
             "properties": {
               "metadata": {
-                "description": "Service-specific metadata associated with the operation.  It typically\ncontains progress information and common metadata such as create time.\nSome services might not provide such metadata.  Any method that returns a\nlong-running operation should document the metadata type, if any.",
-                "additionalProperties": {
-                  "description": "Properties of the object. Contains field @type with type URL."
-                },
-                "type": "object"
+                "$ref": "#/components/schemas/CreateRuntimeMetadata"
               },
               "response": {
-                "description": "The normal, successful response of the operation.  If the original\nmethod returns no data on success, such as `Delete`, the response is\n`google.protobuf.Empty`.  If the original method is standard\n`Get`/`Create`/`Update`, the response should be the resource.  For other\nmethods, the response should have the type `XxxResponse`, where `Xxx`\nis the original method name.  For example, if the original method name\nis `TakeSnapshot()`, the inferred response type is\n`TakeSnapshotResponse`.",
-                "type": "object",
-                "additionalProperties": {
-                  "description": "Properties of the object. Contains field @type with type URL."
-                }
+                "$ref": "#/components/schemas/Runtime"
               }
-            }
+            },
+            "type": "object"
           }
-        ]
-      },
-      "RuntimeSpec": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "description": "Required. The key of the runtime spec.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Key"
-              }
-            ]
-          },
-          "eligible": {
-            "description": "Output only. Whether the requesting user is eligible for the runtime spec.",
-            "readOnly": true,
-            "type": "boolean"
-          }
-        },
-        "required": ["key"],
-        "description": "A specification of a runtime."
-      },
-      "CreateRuntimeMetadata": {
-        "type": "object",
-        "properties": {
-          "runtime": {
-            "type": "string",
-            "description": "The runtime resource being created, in the format of\n`runtimes/{runtime_id}`."
-          }
-        },
-        "description": "Metadata for `CreateRuntime` long-running operation."
-      },
-      "Key": {
-        "description": "Key fields that uniquely identify a runtime spec.",
-        "properties": {
-          "variant": {
-            "description": "Required. Runtime variant.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Variant"
-              }
-            ]
-          },
-          "accelerator": {
-            "type": "string",
-            "description": "Required. Runtime accelerator model name (e.g., \"T4\", \"L4\", \"A100\").\nFor CPU runtime specs, this field will be \"NONE\"."
-          },
-          "shape": {
-            "description": "Required. Runtime shape.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Shape"
-              }
-            ]
-          }
-        },
-        "required": ["variant", "accelerator", "shape"],
+        ],
+        "description": "This resource represents a long-running operation where metadata and response fields are strongly typed.",
         "type": "object"
       },
       "Empty": {
-        "type": "object",
-        "description": "A generic empty message that you can re-use to avoid defining duplicated\nempty messages in your APIs. A typical example is to use it as the request\nor the response type of an API method. For instance:\n\n    service Foo {\n      rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);\n    }"
-      },
-      "Subscription": {
-        "properties": {
-          "name": {
-            "description": "Identifier. Name of the subscription. This will always be \"subscription\".",
-            "x-google-identifier": true,
-            "type": "string"
-          },
-          "tier": {
-            "description": "User's Colab subscription tier.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/SubscriptionTier"
-              }
-            ]
-          }
-        },
-        "description": "Colab user subscription information.",
-        "type": "object"
-      },
-      "ListRuntimeSpecsResponse": {
-        "type": "object",
-        "properties": {
-          "runtimeSpecs": {
-            "description": "The list of runtime specs available to the requesting user.",
-            "items": {
-              "$ref": "#/components/schemas/RuntimeSpec"
-            },
-            "type": "array"
-          }
-        },
-        "description": "Response message for `ListRuntimeSpecs`."
-      },
-      "ExecuteCodeResult": {
-        "properties": {
-          "outputTruncated": {
-            "type": "boolean",
-            "description": "Whether the runtime truncated buffered output (size or line caps hit). When\ntrue, `stdout`/`stderr` are tail-truncated."
-          },
-          "stderr": {
-            "description": "Aggregated stderr across the execution.",
-            "type": "string"
-          },
-          "executionId": {
-            "description": "The execution identifier this result is for, echoed from the request. Empty\nwhen the request supplied no `execution_id` (such an execution is not\nresumable). Use it to resume.",
-            "type": "string"
-          },
-          "session": {
-            "description": "The session the execution ran in.\nFormat: `runtimes/{runtime}/sessions/{session}`.",
-            "type": "string"
-          },
-          "executionCount": {
-            "description": "The Jupyter `In[N]` execution count assigned by the kernel. Informational\nonly. Not for addressing executions, for that use `execution_id`.",
-            "type": "integer",
-            "format": "int32"
-          },
-          "stdout": {
-            "description": "Aggregated stdout across the execution.",
-            "type": "string"
-          },
-          "executionError": {
-            "description": "Populated when the execution raised. Mutually exclusive with a successful\ncompletion.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Error"
-              }
-            ]
-          },
-          "result": {
-            "type": "string",
-            "description": "The `text/plain` representation of the last expression's value, if the\nexecution ended on an expression. Empty otherwise."
-          },
-          "richOutputsDropped": {
-            "description": "Whether the execution produced rich (non-text) outputs that this tool does\nnot surface (e.g. images, Plotly/Vega figures, widgets). Always false for\nexecutions that produced only text.",
-            "type": "boolean"
-          }
-        },
-        "description": "The result of an `ExecuteCode` call, returned as the terminal\n`structured_content` of the response stream.",
+        "description": "A generic empty message that you can re-use to avoid defining duplicated\nempty messages in your APIs. A typical example is to use it as the request\nor the response type of an API method. For instance:\n\n    service Foo {\n      rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);\n    }",
         "type": "object"
       },
       "Error": {
@@ -266,66 +130,223 @@
             "description": "The exception class name, e.g. \"NameError\".",
             "type": "string"
           },
-          "value": {
-            "description": "The exception message, e.g. \"name 'foo' is not defined\".",
-            "type": "string"
-          },
           "traceback": {
             "description": "The formatted traceback, one frame per entry.",
             "items": {
               "type": "string"
             },
             "type": "array"
+          },
+          "value": {
+            "description": "The exception message, e.g. \"name 'foo' is not defined\".",
+            "type": "string"
           }
         },
         "type": "object"
       },
-      "CreateRuntimeOperation": {
-        "type": "object",
-        "description": "This resource represents a long-running operation where metadata and response fields are strongly typed.",
+      "ExecuteCodeResult": {
+        "description": "The result of an `ExecuteCode` call, returned as the terminal\n`structured_content` of the response stream.",
+        "properties": {
+          "executionCount": {
+            "description": "The Jupyter `In[N]` execution count assigned by the kernel. Informational\nonly. Not for addressing executions, for that use `execution_id`.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "executionError": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Error"
+              }
+            ],
+            "description": "Populated when the execution raised. Mutually exclusive with a successful\ncompletion."
+          },
+          "executionId": {
+            "description": "The execution identifier this result is for, echoed from the request. Empty\nwhen the request supplied no `execution_id` (such an execution is not\nresumable). Use it to resume.",
+            "type": "string"
+          },
+          "outputTruncated": {
+            "description": "Whether the runtime truncated buffered output (size or line caps hit). When\ntrue, `stdout`/`stderr` are tail-truncated.",
+            "type": "boolean"
+          },
+          "result": {
+            "description": "The `text/plain` representation of the last expression's value, if the\nexecution ended on an expression. Empty otherwise.",
+            "type": "string"
+          },
+          "richOutputsDropped": {
+            "description": "Whether the execution produced rich (non-text) outputs that this tool does\nnot surface (e.g. images, Plotly/Vega figures, widgets). Always false for\nexecutions that produced only text.",
+            "type": "boolean"
+          },
+          "session": {
+            "description": "The session the execution ran in.\nFormat: `runtimes/{runtime}/sessions/{session}`.",
+            "type": "string"
+          },
+          "stderr": {
+            "description": "Aggregated stderr across the execution.",
+            "type": "string"
+          },
+          "stdout": {
+            "description": "Aggregated stdout across the execution.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Key": {
+        "description": "Key fields that uniquely identify a runtime spec.",
+        "properties": {
+          "accelerator": {
+            "description": "Required. Runtime accelerator model name (e.g., \"T4\", \"L4\", \"A100\").\nFor CPU runtime specs, this field will be \"NONE\".",
+            "type": "string"
+          },
+          "shape": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Shape"
+              }
+            ],
+            "description": "Required. Runtime shape."
+          },
+          "variant": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Variant"
+              }
+            ],
+            "description": "Required. Runtime variant."
+          }
+        },
+        "required": ["variant", "accelerator", "shape"],
+        "type": "object"
+      },
+      "ListRuntimeSpecsResponse": {
+        "description": "Response message for `ListRuntimeSpecs`.",
+        "properties": {
+          "runtimeSpecs": {
+            "description": "The list of runtime specs available to the requesting user.",
+            "items": {
+              "$ref": "#/components/schemas/RuntimeSpec"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ListRuntimesResponse": {
+        "description": "Response message for `ListRuntimes`.",
+        "properties": {
+          "runtimes": {
+            "description": "The list of runtimes assigned to the requesting user.",
+            "items": {
+              "$ref": "#/components/schemas/Runtime"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Operation": {
         "allOf": [
           {
             "$ref": "#/components/schemas/BaseOperation"
           },
           {
-            "type": "object",
             "properties": {
               "metadata": {
-                "$ref": "#/components/schemas/CreateRuntimeMetadata"
+                "additionalProperties": {
+                  "description": "Properties of the object. Contains field @type with type URL."
+                },
+                "description": "Service-specific metadata associated with the operation.  It typically\ncontains progress information and common metadata such as create time.\nSome services might not provide such metadata.  Any method that returns a\nlong-running operation should document the metadata type, if any.",
+                "type": "object"
               },
               "response": {
-                "$ref": "#/components/schemas/Runtime"
+                "additionalProperties": {
+                  "description": "Properties of the object. Contains field @type with type URL."
+                },
+                "description": "The normal, successful response of the operation.  If the original\nmethod returns no data on success, such as `Delete`, the response is\n`google.protobuf.Empty`.  If the original method is standard\n`Get`/`Create`/`Update`, the response should be the resource.  For other\nmethods, the response should have the type `XxxResponse`, where `Xxx`\nis the original method name.  For example, if the original method name\nis `TakeSnapshot()`, the inferred response type is\n`TakeSnapshotResponse`.",
+                "type": "object"
               }
-            }
+            },
+            "type": "object"
           }
-        ]
+        ],
+        "description": "This resource represents a long-running operation that is the result of a\nnetwork API call.",
+        "type": "object"
+      },
+      "Runtime": {
+        "description": "A Colab managed runtime.",
+        "properties": {
+          "connectionInfo": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConnectionInfo"
+              }
+            ],
+            "description": "Output only. The connection info used to authenticate to the runtime.",
+            "readOnly": true
+          },
+          "name": {
+            "description": "Identifier. The name of the runtime in the format `runtimes/{runtime_id}`, where\n`runtime_id` is either the value supplied via\n`CreateRuntimeRequest.runtime_id` or, if none was supplied, a random UUID\ngenerated by the backend.",
+            "type": "string",
+            "x-google-identifier": true
+          },
+          "runtimeSpec": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Key"
+              }
+            ],
+            "description": "Required. The specification of the runtime."
+          }
+        },
+        "required": ["runtimeSpec"],
+        "type": "object"
+      },
+      "RuntimeSpec": {
+        "description": "A specification of a runtime.",
+        "properties": {
+          "eligible": {
+            "description": "Output only. Whether the requesting user is eligible for the runtime spec.",
+            "readOnly": true,
+            "type": "boolean"
+          },
+          "key": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Key"
+              }
+            ],
+            "description": "Required. The key of the runtime spec."
+          }
+        },
+        "required": ["key"],
+        "type": "object"
       },
       "Shape": {
+        "enum": ["SHAPE_UNSPECIFIED", "SHAPE_STANDARD", "SHAPE_HIGHMEM"],
         "type": "string",
         "x-google-enum-descriptions": [
           "Default value. This value is unused.",
           "Standard shape.",
           "High memory shape."
-        ],
-        "enum": ["SHAPE_UNSPECIFIED", "SHAPE_STANDARD", "SHAPE_HIGHMEM"]
+        ]
       },
       "Status": {
         "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). Each `Status` message contains\nthree pieces of data: error code, error message, and error details.\n\nYou can find out more about this error model and how to work with it in the\n[API Design Guide](https://cloud.google.com/apis/design/errors).",
         "properties": {
+          "code": {
+            "description": "The status code, which should be an enum value of google.rpc.Code.",
+            "format": "int32",
+            "type": "integer"
+          },
           "details": {
-            "type": "array",
             "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use.",
             "items": {
               "additionalProperties": {
                 "description": "Properties of the object. Contains field @type with type URL."
               },
               "type": "object"
-            }
-          },
-          "code": {
-            "type": "integer",
-            "format": "int32",
-            "description": "The status code, which should be an enum value of google.rpc.Code."
+            },
+            "type": "array"
           },
           "message": {
             "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\ngoogle.rpc.Status.details field, or localized by the client.",
@@ -334,249 +355,105 @@
         },
         "type": "object"
       },
-      "Runtime": {
-        "type": "object",
-        "description": "A Colab managed runtime.",
+      "Subscription": {
+        "description": "Colab user subscription information.",
         "properties": {
           "name": {
-            "description": "Identifier. The name of the runtime in the format `runtimes/{runtime_id}`, where\n`runtime_id` is either the value supplied via\n`CreateRuntimeRequest.runtime_id` or, if none was supplied, a random UUID\ngenerated by the backend.",
-            "x-google-identifier": true,
-            "type": "string"
+            "description": "Identifier. Name of the subscription. This will always be \"subscription\".",
+            "type": "string",
+            "x-google-identifier": true
           },
-          "runtimeSpec": {
-            "description": "Required. The specification of the runtime.",
+          "tier": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/Key"
-              }
-            ]
-          },
-          "connectionInfo": {
-            "description": "Output only. The connection info used to authenticate to the runtime.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ConnectionInfo"
+                "$ref": "#/components/schemas/SubscriptionTier"
               }
             ],
-            "readOnly": true
+            "description": "User's Colab subscription tier."
           }
         },
-        "required": ["runtimeSpec"]
-      },
-      "BaseOperation": {
-        "type": "object",
-        "description": "This resource represents a long-running operation that is the result of a\nnetwork API call.",
-        "properties": {
-          "error": {
-            "description": "The error result of the operation in case of failure or cancellation.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Status"
-              }
-            ]
-          },
-          "name": {
-            "description": "The server-assigned name, which is only unique within the same service that\noriginally returns it. If you use the default HTTP mapping, the\n`name` should be a resource name ending with `operations/{unique_id}`.",
-            "type": "string"
-          },
-          "done": {
-            "type": "boolean",
-            "description": "If the value is `false`, it means the operation is still in progress.\nIf `true`, the operation is completed, and either `error` or `response` is\navailable."
-          }
-        }
-      },
-      "Variant": {
-        "type": "string",
-        "x-google-enum-descriptions": [
-          "Default value. This value is unused.",
-          "CPU variant.",
-          "GPU variant.",
-          "TPU variant."
-        ],
-        "enum": [
-          "VARIANT_UNSPECIFIED",
-          "VARIANT_CPU",
-          "VARIANT_GPU",
-          "VARIANT_TPU"
-        ]
+        "type": "object"
       },
       "SubscriptionTier": {
+        "enum": [
+          "SUBSCRIPTION_TIER_UNSPECIFIED",
+          "SUBSCRIPTION_TIER_FREE",
+          "SUBSCRIPTION_TIER_PRO",
+          "SUBSCRIPTION_TIER_PRO_PLUS"
+        ],
         "type": "string",
         "x-google-enum-descriptions": [
           "Default value. This value is unused.",
           "User is not subscribed to any paid tier.",
           "User is subscribed to Colab Pro.",
           "User is subscribed to Colab Pro+."
-        ],
-        "enum": [
-          "SUBSCRIPTION_TIER_UNSPECIFIED",
-          "SUBSCRIPTION_TIER_FREE",
-          "SUBSCRIPTION_TIER_PRO",
-          "SUBSCRIPTION_TIER_PRO_PLUS"
         ]
       },
-      "ConnectionInfo": {
-        "properties": {
-          "url": {
-            "readOnly": true,
-            "description": "Output only. The authenticated URL that can be used to connect to the runtime.",
-            "type": "string"
-          },
-          "token": {
-            "type": "string",
-            "readOnly": true,
-            "description": "Output only. The runtime proxy token. This is a short-lived credential used to\nauthenticate to the runtime."
-          },
-          "expireTime": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Output only. The expiration time of the runtime proxy token.",
-            "readOnly": true
+      "Variant": {
+        "enum": [
+          "VARIANT_UNSPECIFIED",
+          "VARIANT_CPU",
+          "VARIANT_GPU",
+          "VARIANT_TPU"
+        ],
+        "type": "string",
+        "x-google-enum-descriptions": [
+          "Default value. This value is unused.",
+          "CPU variant.",
+          "GPU variant.",
+          "TPU variant."
+        ]
+      }
+    },
+    "securitySchemes": {
+      "bearer_auth": {
+        "description": "Http bearer authentication.",
+        "scheme": "bearer",
+        "type": "http"
+      },
+      "google_oauth_code": {
+        "description": "Google Oauth 2.0 authorizationCode authentication flow.",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+            "refreshUrl": "https://oauth2.googleapis.com/token",
+            "scopes": {
+              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources"
+            },
+            "tokenUrl": "https://oauth2.googleapis.com/token"
           }
         },
-        "description": "Connection info used to authenticate to the runtime.",
-        "type": "object"
+        "type": "oauth2"
+      },
+      "google_oauth_implicit": {
+        "description": "Google Oauth 2.0 implicit authentication flow.",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+            "scopes": {
+              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources"
+            }
+          }
+        },
+        "type": "oauth2"
       }
     }
   },
   "externalDocs": {
-    "url": "https://developers.google.com/colab",
-    "description": "Find more info here."
+    "description": "Find more info here.",
+    "url": "https://developers.google.com/colab"
   },
   "info": {
+    "description": "colaboratory.googleapis.com API.",
     "title": "Colab API",
     "version": "v1beta",
-    "x-google-revision": "20260622",
-    "description": "colaboratory.googleapis.com API."
+    "x-google-revision": "20260622"
   },
   "openapi": "3.0.3",
   "paths": {
-    "/v1beta/subscription": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/alt"
-        },
-        {
-          "$ref": "#/components/parameters/callback"
-        },
-        {
-          "$ref": "#/components/parameters/prettyPrint"
-        },
-        {
-          "$ref": "#/components/parameters/_.xgafv"
-        }
-      ],
-      "get": {
-        "parameters": [],
-        "responses": {
-          "default": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Subscription"
-                }
-              }
-            }
-          }
-        },
-        "operationId": "GetSubscription",
-        "security": [
-          {
-            "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
-            ]
-          },
-          {
-            "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
-            ]
-          },
-          {
-            "bearer_auth": []
-          }
-        ],
-        "tags": ["colaboratory"],
-        "description": "Gets the subscription of the requesting user."
-      }
-    },
     "/v1beta/runtimes": {
-      "post": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "query",
-            "name": "requestId",
-            "description": "Optional. A unique identifier for this request.\n\nThis request is only idempotent if a `request_id` is provided.\nSee https://google.aip.dev/155 for more details.\n\nIf provided, the request ID must be in UUID4 format per\nhttps://linter.aip.dev/155/request-id-format."
-          },
-          {
-            "name": "runtimeId",
-            "description": "Optional. A unique identifier for the runtime. If not supplied, a random UUID will be\ngenerated. If a runtime with the given ID owned by the requesting user\nalready exists, a completed Operation with an ALREADY_EXISTS error will be\nreturned.\nSee https://google.aip.dev/133#user-specified-ids for more details.\n\nThe ID must conform to https://datatracker.ietf.org/doc/html/rfc1034,\nspecifically:\n- 1 to 63 characters\n- Lower-case letters, digits, and hyphens\n- Start with a letter\n- End with a letter or digit",
-            "schema": {
-              "type": "string"
-            },
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateRuntimeOperation"
-                }
-              }
-            },
-            "description": "Successful operation"
-          }
-        },
-        "operationId": "CreateRuntime",
-        "security": [
-          {
-            "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
-            ]
-          },
-          {
-            "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
-            ]
-          },
-          {
-            "bearer_auth": []
-          }
-        ],
-        "tags": ["colaboratory"],
-        "x-google-lro": "true",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Runtime"
-              }
-            }
-          },
-          "description": "Required. Specifications for the runtime to assign."
-        },
-        "description": "Creates a Colab runtime assignment."
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/alt"
-        },
-        {
-          "$ref": "#/components/parameters/callback"
-        },
-        {
-          "$ref": "#/components/parameters/prettyPrint"
-        },
-        {
-          "$ref": "#/components/parameters/_.xgafv"
-        }
-      ],
       "get": {
+        "description": "Lists Colab runtimes assigned to the requesting user.",
         "operationId": "ListRuntimes",
         "parameters": [],
         "responses": {
@@ -591,7 +468,6 @@
             "description": "Successful operation"
           }
         },
-        "tags": ["colaboratory"],
         "security": [
           {
             "google_oauth_implicit": [
@@ -607,10 +483,8 @@
             "bearer_auth": []
           }
         ],
-        "description": "Lists Colab runtimes assigned to the requesting user."
-      }
-    },
-    "/v1beta/runtimespecs": {
+        "tags": ["colaboratory"]
+      },
       "parameters": [
         {
           "$ref": "#/components/parameters/alt"
@@ -625,9 +499,49 @@
           "$ref": "#/components/parameters/_.xgafv"
         }
       ],
-      "get": {
-        "description": "Lists Colab runtime specs available to the requesting user.",
-        "tags": ["colaboratory"],
+      "post": {
+        "description": "Creates a Colab runtime assignment.",
+        "operationId": "CreateRuntime",
+        "parameters": [
+          {
+            "description": "Optional. A unique identifier for this request.\n\nThis request is only idempotent if a `request_id` is provided.\nSee https://google.aip.dev/155 for more details.\n\nIf provided, the request ID must be in UUID4 format per\nhttps://linter.aip.dev/155/request-id-format.",
+            "in": "query",
+            "name": "requestId",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional. A unique identifier for the runtime. If not supplied, a random UUID will be\ngenerated. If a runtime with the given ID owned by the requesting user\nalready exists, a completed Operation with an ALREADY_EXISTS error will be\nreturned.\nSee https://google.aip.dev/133#user-specified-ids for more details.\n\nThe ID must conform to https://datatracker.ietf.org/doc/html/rfc1034,\nspecifically:\n- 1 to 63 characters\n- Lower-case letters, digits, and hyphens\n- Start with a letter\n- End with a letter or digit",
+            "in": "query",
+            "name": "runtimeId",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Runtime"
+              }
+            }
+          },
+          "description": "Required. Specifications for the runtime to assign."
+        },
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateRuntimeOperation"
+                }
+              }
+            },
+            "description": "Successful operation"
+          }
+        },
         "security": [
           {
             "google_oauth_implicit": [
@@ -643,108 +557,23 @@
             "bearer_auth": []
           }
         ],
-        "operationId": "ListRuntimeSpecs",
-        "parameters": [],
-        "responses": {
-          "default": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListRuntimeSpecsResponse"
-                }
-              }
-            }
-          }
-        }
+        "tags": ["colaboratory"],
+        "x-google-lro": "true"
       }
     },
     "/v1beta/runtimes/{runtime}": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/alt"
-        },
-        {
-          "$ref": "#/components/parameters/callback"
-        },
-        {
-          "$ref": "#/components/parameters/prettyPrint"
-        },
-        {
-          "$ref": "#/components/parameters/_.xgafv"
-        }
-      ],
-      "get": {
-        "description": "Gets a Colab runtime assigned to the requesting user.",
-        "operationId": "GetRuntime",
-        "parameters": [
-          {
-            "description": "Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.",
-            "name": "runtime",
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "default": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Runtime"
-                }
-              }
-            }
-          }
-        },
-        "tags": ["colaboratory"],
-        "security": [
-          {
-            "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
-            ]
-          },
-          {
-            "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
-            ]
-          },
-          {
-            "bearer_auth": []
-          }
-        ]
-      },
       "delete": {
         "description": "Deletes a Colab runtime assignment.",
-        "tags": ["colaboratory"],
-        "security": [
-          {
-            "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
-            ]
-          },
-          {
-            "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
-            ]
-          },
-          {
-            "bearer_auth": []
-          }
-        ],
         "operationId": "DeleteRuntime",
         "parameters": [
           {
+            "description": "Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.",
+            "in": "path",
+            "name": "runtime",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "description": "Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.",
-            "name": "runtime",
-            "in": "path",
-            "required": true
+            }
           }
         ],
         "responses": {
@@ -758,14 +587,185 @@
             },
             "description": "Successful operation"
           }
+        },
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/colaboratory"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/colaboratory"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": ["colaboratory"]
+      },
+      "get": {
+        "description": "Gets a Colab runtime assigned to the requesting user.",
+        "operationId": "GetRuntime",
+        "parameters": [
+          {
+            "description": "Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.",
+            "in": "path",
+            "name": "runtime",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Runtime"
+                }
+              }
+            },
+            "description": "Successful operation"
+          }
+        },
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/colaboratory"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/colaboratory"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": ["colaboratory"]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/_.xgafv"
         }
-      }
+      ]
+    },
+    "/v1beta/runtimespecs": {
+      "get": {
+        "description": "Lists Colab runtime specs available to the requesting user.",
+        "operationId": "ListRuntimeSpecs",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListRuntimeSpecsResponse"
+                }
+              }
+            },
+            "description": "Successful operation"
+          }
+        },
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/colaboratory"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/colaboratory"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": ["colaboratory"]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        }
+      ]
+    },
+    "/v1beta/subscription": {
+      "get": {
+        "description": "Gets the subscription of the requesting user.",
+        "operationId": "GetSubscription",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Subscription"
+                }
+              }
+            },
+            "description": "Successful operation"
+          }
+        },
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/colaboratory"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/colaboratory"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": ["colaboratory"]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        }
+      ]
     }
   },
   "servers": [
     {
-      "url": "https://colaboratory.googleapis.com",
-      "description": "Global Endpoint"
+      "description": "Global Endpoint",
+      "url": "https://colaboratory.googleapis.com"
     }
   ]
 }

--- a/src/colab/client/v2/generated/colab/models/BaseOperation.ts
+++ b/src/colab/client/v2/generated/colab/models/BaseOperation.ts
@@ -30,6 +30,14 @@ import {
  */
 export interface BaseOperation {
     /**
+     * If the value is `false`, it means the operation is still in progress.
+     * If `true`, the operation is completed, and either `error` or `response` is
+     * available.
+     * @type {boolean}
+     * @memberof BaseOperation
+     */
+    done?: boolean;
+    /**
      * The error result of the operation in case of failure or cancellation.
      * @type {Status}
      * @memberof BaseOperation
@@ -43,14 +51,6 @@ export interface BaseOperation {
      * @memberof BaseOperation
      */
     name?: string;
-    /**
-     * If the value is `false`, it means the operation is still in progress.
-     * If `true`, the operation is completed, and either `error` or `response` is
-     * available.
-     * @type {boolean}
-     * @memberof BaseOperation
-     */
-    done?: boolean;
 }
 
 /**
@@ -70,9 +70,9 @@ export function BaseOperationFromJSONTyped(json: any, ignoreDiscriminator: boole
     }
     return {
         
+        'done': json['done'] == null ? undefined : json['done'],
         'error': json['error'] == null ? undefined : StatusFromJSON(json['error']),
         'name': json['name'] == null ? undefined : json['name'],
-        'done': json['done'] == null ? undefined : json['done'],
     };
 }
 
@@ -87,9 +87,9 @@ export function BaseOperationToJSONTyped(value?: BaseOperation | null, ignoreDis
 
     return {
         
+        'done': value['done'],
         'error': StatusToJSON(value['error']),
         'name': value['name'],
-        'done': value['done'],
     };
 }
 

--- a/src/colab/client/v2/generated/colab/models/ConnectionInfo.ts
+++ b/src/colab/client/v2/generated/colab/models/ConnectionInfo.ts
@@ -21,11 +21,11 @@ import { mapValues } from '../runtime';
  */
 export interface ConnectionInfo {
     /**
-     * Output only. The authenticated URL that can be used to connect to the runtime.
-     * @type {string}
+     * Output only. The expiration time of the runtime proxy token.
+     * @type {Date}
      * @memberof ConnectionInfo
      */
-    readonly url?: string;
+    readonly expireTime?: Date;
     /**
      * Output only. The runtime proxy token. This is a short-lived credential used to
      * authenticate to the runtime.
@@ -34,11 +34,11 @@ export interface ConnectionInfo {
      */
     readonly token?: string;
     /**
-     * Output only. The expiration time of the runtime proxy token.
-     * @type {Date}
+     * Output only. The authenticated URL that can be used to connect to the runtime.
+     * @type {string}
      * @memberof ConnectionInfo
      */
-    readonly expireTime?: Date;
+    readonly url?: string;
 }
 
 /**
@@ -58,9 +58,9 @@ export function ConnectionInfoFromJSONTyped(json: any, ignoreDiscriminator: bool
     }
     return {
         
-        'url': json['url'] == null ? undefined : json['url'],
-        'token': json['token'] == null ? undefined : json['token'],
         'expireTime': json['expireTime'] == null ? undefined : (new Date(json['expireTime'])),
+        'token': json['token'] == null ? undefined : json['token'],
+        'url': json['url'] == null ? undefined : json['url'],
     };
 }
 
@@ -68,7 +68,7 @@ export function ConnectionInfoToJSON(json: any): ConnectionInfo {
     return ConnectionInfoToJSONTyped(json, false);
 }
 
-export function ConnectionInfoToJSONTyped(value?: Omit<ConnectionInfo, 'url'|'token'|'expireTime'> | null, ignoreDiscriminator: boolean = false): any {
+export function ConnectionInfoToJSONTyped(value?: Omit<ConnectionInfo, 'expireTime'|'token'|'url'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/src/colab/client/v2/generated/colab/models/CreateRuntimeOperation.ts
+++ b/src/colab/client/v2/generated/colab/models/CreateRuntimeOperation.ts
@@ -43,6 +43,14 @@ import {
  */
 export interface CreateRuntimeOperation {
     /**
+     * If the value is `false`, it means the operation is still in progress.
+     * If `true`, the operation is completed, and either `error` or `response` is
+     * available.
+     * @type {boolean}
+     * @memberof CreateRuntimeOperation
+     */
+    done?: boolean;
+    /**
      * The error result of the operation in case of failure or cancellation.
      * @type {Status}
      * @memberof CreateRuntimeOperation
@@ -56,14 +64,6 @@ export interface CreateRuntimeOperation {
      * @memberof CreateRuntimeOperation
      */
     name?: string;
-    /**
-     * If the value is `false`, it means the operation is still in progress.
-     * If `true`, the operation is completed, and either `error` or `response` is
-     * available.
-     * @type {boolean}
-     * @memberof CreateRuntimeOperation
-     */
-    done?: boolean;
     /**
      * 
      * @type {CreateRuntimeMetadata}
@@ -95,9 +95,9 @@ export function CreateRuntimeOperationFromJSONTyped(json: any, ignoreDiscriminat
     }
     return {
         
+        'done': json['done'] == null ? undefined : json['done'],
         'error': json['error'] == null ? undefined : StatusFromJSON(json['error']),
         'name': json['name'] == null ? undefined : json['name'],
-        'done': json['done'] == null ? undefined : json['done'],
         'metadata': json['metadata'] == null ? undefined : CreateRuntimeMetadataFromJSON(json['metadata']),
         'response': json['response'] == null ? undefined : RuntimeFromJSON(json['response']),
     };
@@ -114,9 +114,9 @@ export function CreateRuntimeOperationToJSONTyped(value?: CreateRuntimeOperation
 
     return {
         
+        'done': value['done'],
         'error': StatusToJSON(value['error']),
         'name': value['name'],
-        'done': value['done'],
         'metadata': CreateRuntimeMetadataToJSON(value['metadata']),
         'response': RuntimeToJSON(value['response']),
     };

--- a/src/colab/client/v2/generated/colab/models/ExecuteCodeResult.ts
+++ b/src/colab/client/v2/generated/colab/models/ExecuteCodeResult.ts
@@ -22,18 +22,19 @@ import { mapValues } from '../runtime';
  */
 export interface ExecuteCodeResult {
     /**
-     * Whether the runtime truncated buffered output (size or line caps hit). When
-     * true, `stdout`/`stderr` are tail-truncated.
-     * @type {boolean}
+     * The Jupyter `In[N]` execution count assigned by the kernel. Informational
+     * only. Not for addressing executions, for that use `execution_id`.
+     * @type {number}
      * @memberof ExecuteCodeResult
      */
-    outputTruncated?: boolean;
+    executionCount?: number;
     /**
-     * Aggregated stderr across the execution.
-     * @type {string}
+     * Populated when the execution raised. Mutually exclusive with a successful
+     * completion.
+     * @type {Error}
      * @memberof ExecuteCodeResult
      */
-    stderr?: string;
+    executionError?: Error;
     /**
      * The execution identifier this result is for, echoed from the request. Empty
      * when the request supplied no `execution_id` (such an execution is not
@@ -43,32 +44,12 @@ export interface ExecuteCodeResult {
      */
     executionId?: string;
     /**
-     * The session the execution ran in.
-     * Format: `runtimes/{runtime}/sessions/{session}`.
-     * @type {string}
+     * Whether the runtime truncated buffered output (size or line caps hit). When
+     * true, `stdout`/`stderr` are tail-truncated.
+     * @type {boolean}
      * @memberof ExecuteCodeResult
      */
-    session?: string;
-    /**
-     * The Jupyter `In[N]` execution count assigned by the kernel. Informational
-     * only. Not for addressing executions, for that use `execution_id`.
-     * @type {number}
-     * @memberof ExecuteCodeResult
-     */
-    executionCount?: number;
-    /**
-     * Aggregated stdout across the execution.
-     * @type {string}
-     * @memberof ExecuteCodeResult
-     */
-    stdout?: string;
-    /**
-     * Populated when the execution raised. Mutually exclusive with a successful
-     * completion.
-     * @type {Error}
-     * @memberof ExecuteCodeResult
-     */
-    executionError?: Error;
+    outputTruncated?: boolean;
     /**
      * The `text/plain` representation of the last expression's value, if the
      * execution ended on an expression. Empty otherwise.
@@ -84,6 +65,25 @@ export interface ExecuteCodeResult {
      * @memberof ExecuteCodeResult
      */
     richOutputsDropped?: boolean;
+    /**
+     * The session the execution ran in.
+     * Format: `runtimes/{runtime}/sessions/{session}`.
+     * @type {string}
+     * @memberof ExecuteCodeResult
+     */
+    session?: string;
+    /**
+     * Aggregated stderr across the execution.
+     * @type {string}
+     * @memberof ExecuteCodeResult
+     */
+    stderr?: string;
+    /**
+     * Aggregated stdout across the execution.
+     * @type {string}
+     * @memberof ExecuteCodeResult
+     */
+    stdout?: string;
 }
 
 /**
@@ -103,15 +103,15 @@ export function ExecuteCodeResultFromJSONTyped(json: any, ignoreDiscriminator: b
     }
     return {
         
-        'outputTruncated': json['outputTruncated'] == null ? undefined : json['outputTruncated'],
-        'stderr': json['stderr'] == null ? undefined : json['stderr'],
-        'executionId': json['executionId'] == null ? undefined : json['executionId'],
-        'session': json['session'] == null ? undefined : json['session'],
         'executionCount': json['executionCount'] == null ? undefined : json['executionCount'],
-        'stdout': json['stdout'] == null ? undefined : json['stdout'],
         'executionError': json['executionError'] == null ? undefined : json['executionError'],
+        'executionId': json['executionId'] == null ? undefined : json['executionId'],
+        'outputTruncated': json['outputTruncated'] == null ? undefined : json['outputTruncated'],
         'result': json['result'] == null ? undefined : json['result'],
         'richOutputsDropped': json['richOutputsDropped'] == null ? undefined : json['richOutputsDropped'],
+        'session': json['session'] == null ? undefined : json['session'],
+        'stderr': json['stderr'] == null ? undefined : json['stderr'],
+        'stdout': json['stdout'] == null ? undefined : json['stdout'],
     };
 }
 
@@ -126,15 +126,15 @@ export function ExecuteCodeResultToJSONTyped(value?: ExecuteCodeResult | null, i
 
     return {
         
-        'outputTruncated': value['outputTruncated'],
-        'stderr': value['stderr'],
-        'executionId': value['executionId'],
-        'session': value['session'],
         'executionCount': value['executionCount'],
-        'stdout': value['stdout'],
         'executionError': value['executionError'],
+        'executionId': value['executionId'],
+        'outputTruncated': value['outputTruncated'],
         'result': value['result'],
         'richOutputsDropped': value['richOutputsDropped'],
+        'session': value['session'],
+        'stderr': value['stderr'],
+        'stdout': value['stdout'],
     };
 }
 

--- a/src/colab/client/v2/generated/colab/models/Key.ts
+++ b/src/colab/client/v2/generated/colab/models/Key.ts
@@ -36,12 +36,6 @@ import {
  */
 export interface Key {
     /**
-     * Required. Runtime variant.
-     * @type {Variant}
-     * @memberof Key
-     */
-    variant: Variant;
-    /**
      * Required. Runtime accelerator model name (e.g., "T4", "L4", "A100").
      * For CPU runtime specs, this field will be "NONE".
      * @type {string}
@@ -54,6 +48,12 @@ export interface Key {
      * @memberof Key
      */
     shape: Shape;
+    /**
+     * Required. Runtime variant.
+     * @type {Variant}
+     * @memberof Key
+     */
+    variant: Variant;
 }
 
 
@@ -62,9 +62,9 @@ export interface Key {
  * Check if a given object implements the Key interface.
  */
 export function instanceOfKey(value: object): value is Key {
-    if (!('variant' in value) || value['variant'] === undefined) return false;
     if (!('accelerator' in value) || value['accelerator'] === undefined) return false;
     if (!('shape' in value) || value['shape'] === undefined) return false;
+    if (!('variant' in value) || value['variant'] === undefined) return false;
     return true;
 }
 
@@ -78,9 +78,9 @@ export function KeyFromJSONTyped(json: any, ignoreDiscriminator: boolean): Key {
     }
     return {
         
-        'variant': VariantFromJSON(json['variant']),
         'accelerator': json['accelerator'],
         'shape': ShapeFromJSON(json['shape']),
+        'variant': VariantFromJSON(json['variant']),
     };
 }
 
@@ -95,9 +95,9 @@ export function KeyToJSONTyped(value?: Key | null, ignoreDiscriminator: boolean 
 
     return {
         
-        'variant': VariantToJSON(value['variant']),
         'accelerator': value['accelerator'],
         'shape': ShapeToJSON(value['shape']),
+        'variant': VariantToJSON(value['variant']),
     };
 }
 

--- a/src/colab/client/v2/generated/colab/models/ModelError.ts
+++ b/src/colab/client/v2/generated/colab/models/ModelError.ts
@@ -27,17 +27,17 @@ export interface ModelError {
      */
     name?: string;
     /**
-     * The exception message, e.g. "name 'foo' is not defined".
-     * @type {string}
-     * @memberof ModelError
-     */
-    value?: string;
-    /**
      * The formatted traceback, one frame per entry.
      * @type {Array<string>}
      * @memberof ModelError
      */
     traceback?: Array<string>;
+    /**
+     * The exception message, e.g. "name 'foo' is not defined".
+     * @type {string}
+     * @memberof ModelError
+     */
+    value?: string;
 }
 
 /**
@@ -58,8 +58,8 @@ export function ModelErrorFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     return {
         
         'name': json['name'] == null ? undefined : json['name'],
-        'value': json['value'] == null ? undefined : json['value'],
         'traceback': json['traceback'] == null ? undefined : json['traceback'],
+        'value': json['value'] == null ? undefined : json['value'],
     };
 }
 
@@ -75,8 +75,8 @@ export function ModelErrorToJSONTyped(value?: ModelError | null, ignoreDiscrimin
     return {
         
         'name': value['name'],
-        'value': value['value'],
         'traceback': value['traceback'],
+        'value': value['value'],
     };
 }
 

--- a/src/colab/client/v2/generated/colab/models/Operation.ts
+++ b/src/colab/client/v2/generated/colab/models/Operation.ts
@@ -30,6 +30,14 @@ import {
  */
 export interface Operation {
     /**
+     * If the value is `false`, it means the operation is still in progress.
+     * If `true`, the operation is completed, and either `error` or `response` is
+     * available.
+     * @type {boolean}
+     * @memberof Operation
+     */
+    done?: boolean;
+    /**
      * The error result of the operation in case of failure or cancellation.
      * @type {Status}
      * @memberof Operation
@@ -43,14 +51,6 @@ export interface Operation {
      * @memberof Operation
      */
     name?: string;
-    /**
-     * If the value is `false`, it means the operation is still in progress.
-     * If `true`, the operation is completed, and either `error` or `response` is
-     * available.
-     * @type {boolean}
-     * @memberof Operation
-     */
-    done?: boolean;
     /**
      * Service-specific metadata associated with the operation.  It typically
      * contains progress information and common metadata such as create time.
@@ -92,9 +92,9 @@ export function OperationFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     }
     return {
         
+        'done': json['done'] == null ? undefined : json['done'],
         'error': json['error'] == null ? undefined : StatusFromJSON(json['error']),
         'name': json['name'] == null ? undefined : json['name'],
-        'done': json['done'] == null ? undefined : json['done'],
         'metadata': json['metadata'] == null ? undefined : json['metadata'],
         'response': json['response'] == null ? undefined : json['response'],
     };
@@ -111,9 +111,9 @@ export function OperationToJSONTyped(value?: Operation | null, ignoreDiscriminat
 
     return {
         
+        'done': value['done'],
         'error': StatusToJSON(value['error']),
         'name': value['name'],
-        'done': value['done'],
         'metadata': value['metadata'],
         'response': value['response'],
     };

--- a/src/colab/client/v2/generated/colab/models/Runtime.ts
+++ b/src/colab/client/v2/generated/colab/models/Runtime.ts
@@ -36,6 +36,12 @@ import {
  */
 export interface Runtime {
     /**
+     * Output only. The connection info used to authenticate to the runtime.
+     * @type {ConnectionInfo}
+     * @memberof Runtime
+     */
+    readonly connectionInfo?: ConnectionInfo;
+    /**
      * Identifier. The name of the runtime in the format `runtimes/{runtime_id}`, where
      * `runtime_id` is either the value supplied via
      * `CreateRuntimeRequest.runtime_id` or, if none was supplied, a random UUID
@@ -50,12 +56,6 @@ export interface Runtime {
      * @memberof Runtime
      */
     runtimeSpec: Key;
-    /**
-     * Output only. The connection info used to authenticate to the runtime.
-     * @type {ConnectionInfo}
-     * @memberof Runtime
-     */
-    readonly connectionInfo?: ConnectionInfo;
 }
 
 /**
@@ -76,9 +76,9 @@ export function RuntimeFromJSONTyped(json: any, ignoreDiscriminator: boolean): R
     }
     return {
         
+        'connectionInfo': json['connectionInfo'] == null ? undefined : ConnectionInfoFromJSON(json['connectionInfo']),
         'name': json['name'] == null ? undefined : json['name'],
         'runtimeSpec': KeyFromJSON(json['runtimeSpec']),
-        'connectionInfo': json['connectionInfo'] == null ? undefined : ConnectionInfoFromJSON(json['connectionInfo']),
     };
 }
 

--- a/src/colab/client/v2/generated/colab/models/RuntimeSpec.ts
+++ b/src/colab/client/v2/generated/colab/models/RuntimeSpec.ts
@@ -29,17 +29,17 @@ import {
  */
 export interface RuntimeSpec {
     /**
-     * Required. The key of the runtime spec.
-     * @type {Key}
-     * @memberof RuntimeSpec
-     */
-    key: Key;
-    /**
      * Output only. Whether the requesting user is eligible for the runtime spec.
      * @type {boolean}
      * @memberof RuntimeSpec
      */
     readonly eligible?: boolean;
+    /**
+     * Required. The key of the runtime spec.
+     * @type {Key}
+     * @memberof RuntimeSpec
+     */
+    key: Key;
 }
 
 /**
@@ -60,8 +60,8 @@ export function RuntimeSpecFromJSONTyped(json: any, ignoreDiscriminator: boolean
     }
     return {
         
-        'key': KeyFromJSON(json['key']),
         'eligible': json['eligible'] == null ? undefined : json['eligible'],
+        'key': KeyFromJSON(json['key']),
     };
 }
 

--- a/src/colab/client/v2/generated/colab/models/Status.ts
+++ b/src/colab/client/v2/generated/colab/models/Status.ts
@@ -27,18 +27,18 @@ import { mapValues } from '../runtime';
  */
 export interface Status {
     /**
+     * The status code, which should be an enum value of google.rpc.Code.
+     * @type {number}
+     * @memberof Status
+     */
+    code?: number;
+    /**
      * A list of messages that carry the error details.  There is a common set of
      * message types for APIs to use.
      * @type {Array<{ [key: string]: any; }>}
      * @memberof Status
      */
     details?: Array<{ [key: string]: any; }>;
-    /**
-     * The status code, which should be an enum value of google.rpc.Code.
-     * @type {number}
-     * @memberof Status
-     */
-    code?: number;
     /**
      * A developer-facing error message, which should be in English. Any
      * user-facing error message should be localized and sent in the
@@ -66,8 +66,8 @@ export function StatusFromJSONTyped(json: any, ignoreDiscriminator: boolean): St
     }
     return {
         
-        'details': json['details'] == null ? undefined : json['details'],
         'code': json['code'] == null ? undefined : json['code'],
+        'details': json['details'] == null ? undefined : json['details'],
         'message': json['message'] == null ? undefined : json['message'],
     };
 }
@@ -83,8 +83,8 @@ export function StatusToJSONTyped(value?: Status | null, ignoreDiscriminator: bo
 
     return {
         
-        'details': value['details'],
         'code': value['code'],
+        'details': value['details'],
         'message': value['message'],
     };
 }

--- a/src/colab/client/v2/generated/operations/models/BaseOperation.ts
+++ b/src/colab/client/v2/generated/operations/models/BaseOperation.ts
@@ -30,14 +30,6 @@ import {
  */
 export interface BaseOperation {
     /**
-     * The server-assigned name, which is only unique within the same service that
-     * originally returns it. If you use the default HTTP mapping, the
-     * `name` should be a resource name ending with `operations/{unique_id}`.
-     * @type {string}
-     * @memberof BaseOperation
-     */
-    name?: string;
-    /**
      * If the value is `false`, it means the operation is still in progress.
      * If `true`, the operation is completed, and either `error` or `response` is
      * available.
@@ -51,6 +43,14 @@ export interface BaseOperation {
      * @memberof BaseOperation
      */
     error?: Status;
+    /**
+     * The server-assigned name, which is only unique within the same service that
+     * originally returns it. If you use the default HTTP mapping, the
+     * `name` should be a resource name ending with `operations/{unique_id}`.
+     * @type {string}
+     * @memberof BaseOperation
+     */
+    name?: string;
 }
 
 /**
@@ -70,9 +70,9 @@ export function BaseOperationFromJSONTyped(json: any, ignoreDiscriminator: boole
     }
     return {
         
-        'name': json['name'] == null ? undefined : json['name'],
         'done': json['done'] == null ? undefined : json['done'],
         'error': json['error'] == null ? undefined : StatusFromJSON(json['error']),
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
@@ -87,9 +87,9 @@ export function BaseOperationToJSONTyped(value?: BaseOperation | null, ignoreDis
 
     return {
         
-        'name': value['name'],
         'done': value['done'],
         'error': StatusToJSON(value['error']),
+        'name': value['name'],
     };
 }
 

--- a/src/colab/client/v2/generated/operations/models/ExecuteCodeResult.ts
+++ b/src/colab/client/v2/generated/operations/models/ExecuteCodeResult.ts
@@ -22,27 +22,19 @@ import { mapValues } from '../runtime';
  */
 export interface ExecuteCodeResult {
     /**
-     * The `text/plain` representation of the last expression's value, if the
-     * execution ended on an expression. Empty otherwise.
-     * @type {string}
+     * The Jupyter `In[N]` execution count assigned by the kernel. Informational
+     * only. Not for addressing executions, for that use `execution_id`.
+     * @type {number}
      * @memberof ExecuteCodeResult
      */
-    result?: string;
+    executionCount?: number;
     /**
-     * Whether the runtime truncated buffered output (size or line caps hit). When
-     * true, `stdout`/`stderr` are tail-truncated.
-     * @type {boolean}
+     * Populated when the execution raised. Mutually exclusive with a successful
+     * completion.
+     * @type {Error}
      * @memberof ExecuteCodeResult
      */
-    outputTruncated?: boolean;
-    /**
-     * Whether the execution produced rich (non-text) outputs that this tool does
-     * not surface (e.g. images, Plotly/Vega figures, widgets). Always false for
-     * executions that produced only text.
-     * @type {boolean}
-     * @memberof ExecuteCodeResult
-     */
-    richOutputsDropped?: boolean;
+    executionError?: Error;
     /**
      * The execution identifier this result is for, echoed from the request. Empty
      * when the request supplied no `execution_id` (such an execution is not
@@ -52,6 +44,28 @@ export interface ExecuteCodeResult {
      */
     executionId?: string;
     /**
+     * Whether the runtime truncated buffered output (size or line caps hit). When
+     * true, `stdout`/`stderr` are tail-truncated.
+     * @type {boolean}
+     * @memberof ExecuteCodeResult
+     */
+    outputTruncated?: boolean;
+    /**
+     * The `text/plain` representation of the last expression's value, if the
+     * execution ended on an expression. Empty otherwise.
+     * @type {string}
+     * @memberof ExecuteCodeResult
+     */
+    result?: string;
+    /**
+     * Whether the execution produced rich (non-text) outputs that this tool does
+     * not surface (e.g. images, Plotly/Vega figures, widgets). Always false for
+     * executions that produced only text.
+     * @type {boolean}
+     * @memberof ExecuteCodeResult
+     */
+    richOutputsDropped?: boolean;
+    /**
      * The session the execution ran in.
      * Format: `runtimes/{runtime}/sessions/{session}`.
      * @type {string}
@@ -59,25 +73,11 @@ export interface ExecuteCodeResult {
      */
     session?: string;
     /**
-     * The Jupyter `In[N]` execution count assigned by the kernel. Informational
-     * only. Not for addressing executions, for that use `execution_id`.
-     * @type {number}
-     * @memberof ExecuteCodeResult
-     */
-    executionCount?: number;
-    /**
      * Aggregated stderr across the execution.
      * @type {string}
      * @memberof ExecuteCodeResult
      */
     stderr?: string;
-    /**
-     * Populated when the execution raised. Mutually exclusive with a successful
-     * completion.
-     * @type {Error}
-     * @memberof ExecuteCodeResult
-     */
-    executionError?: Error;
     /**
      * Aggregated stdout across the execution.
      * @type {string}
@@ -103,14 +103,14 @@ export function ExecuteCodeResultFromJSONTyped(json: any, ignoreDiscriminator: b
     }
     return {
         
-        'result': json['result'] == null ? undefined : json['result'],
-        'outputTruncated': json['outputTruncated'] == null ? undefined : json['outputTruncated'],
-        'richOutputsDropped': json['richOutputsDropped'] == null ? undefined : json['richOutputsDropped'],
-        'executionId': json['executionId'] == null ? undefined : json['executionId'],
-        'session': json['session'] == null ? undefined : json['session'],
         'executionCount': json['executionCount'] == null ? undefined : json['executionCount'],
-        'stderr': json['stderr'] == null ? undefined : json['stderr'],
         'executionError': json['executionError'] == null ? undefined : json['executionError'],
+        'executionId': json['executionId'] == null ? undefined : json['executionId'],
+        'outputTruncated': json['outputTruncated'] == null ? undefined : json['outputTruncated'],
+        'result': json['result'] == null ? undefined : json['result'],
+        'richOutputsDropped': json['richOutputsDropped'] == null ? undefined : json['richOutputsDropped'],
+        'session': json['session'] == null ? undefined : json['session'],
+        'stderr': json['stderr'] == null ? undefined : json['stderr'],
         'stdout': json['stdout'] == null ? undefined : json['stdout'],
     };
 }
@@ -126,14 +126,14 @@ export function ExecuteCodeResultToJSONTyped(value?: ExecuteCodeResult | null, i
 
     return {
         
-        'result': value['result'],
-        'outputTruncated': value['outputTruncated'],
-        'richOutputsDropped': value['richOutputsDropped'],
-        'executionId': value['executionId'],
-        'session': value['session'],
         'executionCount': value['executionCount'],
-        'stderr': value['stderr'],
         'executionError': value['executionError'],
+        'executionId': value['executionId'],
+        'outputTruncated': value['outputTruncated'],
+        'result': value['result'],
+        'richOutputsDropped': value['richOutputsDropped'],
+        'session': value['session'],
+        'stderr': value['stderr'],
         'stdout': value['stdout'],
     };
 }

--- a/src/colab/client/v2/generated/operations/models/ListOperationsResponse.ts
+++ b/src/colab/client/v2/generated/operations/models/ListOperationsResponse.ts
@@ -35,6 +35,12 @@ export interface ListOperationsResponse {
      */
     nextPageToken?: string;
     /**
+     * A list of operations that matches the specified filter in the request.
+     * @type {Array<Operation>}
+     * @memberof ListOperationsResponse
+     */
+    operations?: Array<Operation>;
+    /**
      * Unordered list. Unreachable resources. Populated when the request sets
      * `ListOperationsRequest.return_partial_success` and reads across
      * collections. For example, when attempting to list all resources across all
@@ -43,12 +49,6 @@ export interface ListOperationsResponse {
      * @memberof ListOperationsResponse
      */
     unreachable?: Array<string>;
-    /**
-     * A list of operations that matches the specified filter in the request.
-     * @type {Array<Operation>}
-     * @memberof ListOperationsResponse
-     */
-    operations?: Array<Operation>;
 }
 
 /**
@@ -69,8 +69,8 @@ export function ListOperationsResponseFromJSONTyped(json: any, ignoreDiscriminat
     return {
         
         'nextPageToken': json['nextPageToken'] == null ? undefined : json['nextPageToken'],
-        'unreachable': json['unreachable'] == null ? undefined : json['unreachable'],
         'operations': json['operations'] == null ? undefined : ((json['operations'] as Array<any>).map(OperationFromJSON)),
+        'unreachable': json['unreachable'] == null ? undefined : json['unreachable'],
     };
 }
 
@@ -86,8 +86,8 @@ export function ListOperationsResponseToJSONTyped(value?: ListOperationsResponse
     return {
         
         'nextPageToken': value['nextPageToken'],
-        'unreachable': value['unreachable'],
         'operations': value['operations'] == null ? undefined : ((value['operations'] as Array<any>).map(OperationToJSON)),
+        'unreachable': value['unreachable'],
     };
 }
 

--- a/src/colab/client/v2/generated/operations/models/Operation.ts
+++ b/src/colab/client/v2/generated/operations/models/Operation.ts
@@ -30,14 +30,6 @@ import {
  */
 export interface Operation {
     /**
-     * The server-assigned name, which is only unique within the same service that
-     * originally returns it. If you use the default HTTP mapping, the
-     * `name` should be a resource name ending with `operations/{unique_id}`.
-     * @type {string}
-     * @memberof Operation
-     */
-    name?: string;
-    /**
      * If the value is `false`, it means the operation is still in progress.
      * If `true`, the operation is completed, and either `error` or `response` is
      * available.
@@ -51,6 +43,14 @@ export interface Operation {
      * @memberof Operation
      */
     error?: Status;
+    /**
+     * The server-assigned name, which is only unique within the same service that
+     * originally returns it. If you use the default HTTP mapping, the
+     * `name` should be a resource name ending with `operations/{unique_id}`.
+     * @type {string}
+     * @memberof Operation
+     */
+    name?: string;
     /**
      * Service-specific metadata associated with the operation.  It typically
      * contains progress information and common metadata such as create time.
@@ -92,9 +92,9 @@ export function OperationFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     }
     return {
         
-        'name': json['name'] == null ? undefined : json['name'],
         'done': json['done'] == null ? undefined : json['done'],
         'error': json['error'] == null ? undefined : StatusFromJSON(json['error']),
+        'name': json['name'] == null ? undefined : json['name'],
         'metadata': json['metadata'] == null ? undefined : json['metadata'],
         'response': json['response'] == null ? undefined : json['response'],
     };
@@ -111,9 +111,9 @@ export function OperationToJSONTyped(value?: Operation | null, ignoreDiscriminat
 
     return {
         
-        'name': value['name'],
         'done': value['done'],
         'error': StatusToJSON(value['error']),
+        'name': value['name'],
         'metadata': value['metadata'],
         'response': value['response'],
     };

--- a/src/colab/client/v2/generated/operations/models/Status.ts
+++ b/src/colab/client/v2/generated/operations/models/Status.ts
@@ -33,6 +33,13 @@ export interface Status {
      */
     code?: number;
     /**
+     * A list of messages that carry the error details.  There is a common set of
+     * message types for APIs to use.
+     * @type {Array<{ [key: string]: any; }>}
+     * @memberof Status
+     */
+    details?: Array<{ [key: string]: any; }>;
+    /**
      * A developer-facing error message, which should be in English. Any
      * user-facing error message should be localized and sent in the
      * google.rpc.Status.details field, or localized by the client.
@@ -40,13 +47,6 @@ export interface Status {
      * @memberof Status
      */
     message?: string;
-    /**
-     * A list of messages that carry the error details.  There is a common set of
-     * message types for APIs to use.
-     * @type {Array<{ [key: string]: any; }>}
-     * @memberof Status
-     */
-    details?: Array<{ [key: string]: any; }>;
 }
 
 /**
@@ -67,8 +67,8 @@ export function StatusFromJSONTyped(json: any, ignoreDiscriminator: boolean): St
     return {
         
         'code': json['code'] == null ? undefined : json['code'],
-        'message': json['message'] == null ? undefined : json['message'],
         'details': json['details'] == null ? undefined : json['details'],
+        'message': json['message'] == null ? undefined : json['message'],
     };
 }
 
@@ -84,8 +84,8 @@ export function StatusToJSONTyped(value?: Status | null, ignoreDiscriminator: bo
     return {
         
         'code': value['code'],
-        'message': value['message'],
         'details': value['details'],
+        'message': value['message'],
     };
 }
 

--- a/src/colab/client/v2/operations-api.json
+++ b/src/colab/client/v2/operations-api.json
@@ -1,42 +1,108 @@
 {
   "components": {
+    "parameters": {
+      "_.xgafv": {
+        "description": "V1 error format.",
+        "in": "query",
+        "name": "$.xgafv",
+        "schema": {
+          "enum": ["1", "2"],
+          "type": "string",
+          "x-google-enum-descriptions": ["v1 error format", "v2 error format"]
+        }
+      },
+      "alt": {
+        "description": "Data format for response.",
+        "in": "query",
+        "name": "$alt",
+        "schema": {
+          "default": "json",
+          "enum": ["json", "media", "proto"],
+          "type": "string",
+          "x-google-enum-descriptions": [
+            "Responses with Content-Type of application/json",
+            "Media download with context-dependent Content-Type",
+            "Responses with Content-Type of application/x-protobuf"
+          ]
+        }
+      },
+      "callback": {
+        "description": "JSONP",
+        "in": "query",
+        "name": "$callback",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "prettyPrint": {
+        "description": "Returns response with indentations and line breaks.",
+        "in": "query",
+        "name": "$prettyPrint",
+        "schema": {
+          "default": "true",
+          "type": "boolean"
+        }
+      }
+    },
     "schemas": {
+      "BaseOperation": {
+        "description": "This resource represents a long-running operation that is the result of a\nnetwork API call.",
+        "properties": {
+          "done": {
+            "description": "If the value is `false`, it means the operation is still in progress.\nIf `true`, the operation is completed, and either `error` or `response` is\navailable.",
+            "type": "boolean"
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Status"
+              }
+            ],
+            "description": "The error result of the operation in case of failure or cancellation."
+          },
+          "name": {
+            "description": "The server-assigned name, which is only unique within the same service that\noriginally returns it. If you use the default HTTP mapping, the\n`name` should be a resource name ending with `operations/{unique_id}`.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "CancelOperationRequest": {
         "description": "The request message for Operations.CancelOperation.",
         "type": "object"
       },
+      "Empty": {
+        "description": "A generic empty message that you can re-use to avoid defining duplicated\nempty messages in your APIs. A typical example is to use it as the request\nor the response type of an API method. For instance:\n\n    service Foo {\n      rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);\n    }",
+        "type": "object"
+      },
+      "Error": {
+        "description": "A Python exception raised during execution.",
+        "properties": {
+          "name": {
+            "description": "The exception class name, e.g. \"NameError\".",
+            "type": "string"
+          },
+          "traceback": {
+            "description": "The formatted traceback, one frame per entry.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "value": {
+            "description": "The exception message, e.g. \"name 'foo' is not defined\".",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "ExecuteCodeResult": {
         "description": "The result of an `ExecuteCode` call, returned as the terminal\n`structured_content` of the response stream.",
-        "type": "object",
         "properties": {
-          "result": {
-            "description": "The `text/plain` representation of the last expression's value, if the\nexecution ended on an expression. Empty otherwise.",
-            "type": "string"
-          },
-          "outputTruncated": {
-            "description": "Whether the runtime truncated buffered output (size or line caps hit). When\ntrue, `stdout`/`stderr` are tail-truncated.",
-            "type": "boolean"
-          },
-          "richOutputsDropped": {
-            "description": "Whether the execution produced rich (non-text) outputs that this tool does\nnot surface (e.g. images, Plotly/Vega figures, widgets). Always false for\nexecutions that produced only text.",
-            "type": "boolean"
-          },
-          "executionId": {
-            "description": "The execution identifier this result is for, echoed from the request. Empty\nwhen the request supplied no `execution_id` (such an execution is not\nresumable). Use it to resume.",
-            "type": "string"
-          },
-          "session": {
-            "description": "The session the execution ran in.\nFormat: `runtimes/{runtime}/sessions/{session}`.",
-            "type": "string"
-          },
           "executionCount": {
             "description": "The Jupyter `In[N]` execution count assigned by the kernel. Informational\nonly. Not for addressing executions, for that use `execution_id`.",
-            "type": "integer",
-            "format": "int32"
-          },
-          "stderr": {
-            "description": "Aggregated stderr across the execution.",
-            "type": "string"
+            "format": "int32",
+            "type": "integer"
           },
           "executionError": {
             "allOf": [
@@ -46,65 +112,63 @@
             ],
             "description": "Populated when the execution raised. Mutually exclusive with a successful\ncompletion."
           },
+          "executionId": {
+            "description": "The execution identifier this result is for, echoed from the request. Empty\nwhen the request supplied no `execution_id` (such an execution is not\nresumable). Use it to resume.",
+            "type": "string"
+          },
+          "outputTruncated": {
+            "description": "Whether the runtime truncated buffered output (size or line caps hit). When\ntrue, `stdout`/`stderr` are tail-truncated.",
+            "type": "boolean"
+          },
+          "result": {
+            "description": "The `text/plain` representation of the last expression's value, if the\nexecution ended on an expression. Empty otherwise.",
+            "type": "string"
+          },
+          "richOutputsDropped": {
+            "description": "Whether the execution produced rich (non-text) outputs that this tool does\nnot surface (e.g. images, Plotly/Vega figures, widgets). Always false for\nexecutions that produced only text.",
+            "type": "boolean"
+          },
+          "session": {
+            "description": "The session the execution ran in.\nFormat: `runtimes/{runtime}/sessions/{session}`.",
+            "type": "string"
+          },
+          "stderr": {
+            "description": "Aggregated stderr across the execution.",
+            "type": "string"
+          },
           "stdout": {
             "description": "Aggregated stdout across the execution.",
             "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "ListOperationsResponse": {
         "description": "The response message for Operations.ListOperations.",
-        "type": "object",
         "properties": {
           "nextPageToken": {
             "description": "The standard List next-page token.",
             "type": "string"
           },
+          "operations": {
+            "description": "A list of operations that matches the specified filter in the request.",
+            "items": {
+              "$ref": "#/components/schemas/Operation"
+            },
+            "type": "array"
+          },
           "unreachable": {
             "description": "Unordered list. Unreachable resources. Populated when the request sets\n`ListOperationsRequest.return_partial_success` and reads across\ncollections. For example, when attempting to list all resources across all\nsupported locations.",
-            "type": "array",
             "items": {
               "type": "string"
             },
-            "x-google-unordered-list": true
-          },
-          "operations": {
-            "description": "A list of operations that matches the specified filter in the request.",
             "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Operation"
-            }
+            "x-google-unordered-list": true
           }
-        }
-      },
-      "Empty": {
-        "description": "A generic empty message that you can re-use to avoid defining duplicated\nempty messages in your APIs. A typical example is to use it as the request\nor the response type of an API method. For instance:\n\n    service Foo {\n      rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);\n    }",
+        },
         "type": "object"
       },
-      "Error": {
-        "description": "A Python exception raised during execution.",
-        "type": "object",
-        "properties": {
-          "name": {
-            "description": "The exception class name, e.g. \"NameError\".",
-            "type": "string"
-          },
-          "traceback": {
-            "description": "The formatted traceback, one frame per entry.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "value": {
-            "description": "The exception message, e.g. \"name 'foo' is not defined\".",
-            "type": "string"
-          }
-        }
-      },
       "Operation": {
-        "description": "This resource represents a long-running operation that is the result of a\nnetwork API call.",
-        "type": "object",
         "allOf": [
           {
             "$ref": "#/components/schemas/BaseOperation"
@@ -112,136 +176,59 @@
           {
             "properties": {
               "metadata": {
-                "description": "Service-specific metadata associated with the operation.  It typically\ncontains progress information and common metadata such as create time.\nSome services might not provide such metadata.  Any method that returns a\nlong-running operation should document the metadata type, if any.",
-                "type": "object",
                 "additionalProperties": {
                   "description": "Properties of the object. Contains field @type with type URL."
-                }
+                },
+                "description": "Service-specific metadata associated with the operation.  It typically\ncontains progress information and common metadata such as create time.\nSome services might not provide such metadata.  Any method that returns a\nlong-running operation should document the metadata type, if any.",
+                "type": "object"
               },
               "response": {
-                "description": "The normal, successful response of the operation.  If the original\nmethod returns no data on success, such as `Delete`, the response is\n`google.protobuf.Empty`.  If the original method is standard\n`Get`/`Create`/`Update`, the response should be the resource.  For other\nmethods, the response should have the type `XxxResponse`, where `Xxx`\nis the original method name.  For example, if the original method name\nis `TakeSnapshot()`, the inferred response type is\n`TakeSnapshotResponse`.",
-                "type": "object",
                 "additionalProperties": {
                   "description": "Properties of the object. Contains field @type with type URL."
-                }
+                },
+                "description": "The normal, successful response of the operation.  If the original\nmethod returns no data on success, such as `Delete`, the response is\n`google.protobuf.Empty`.  If the original method is standard\n`Get`/`Create`/`Update`, the response should be the resource.  For other\nmethods, the response should have the type `XxxResponse`, where `Xxx`\nis the original method name.  For example, if the original method name\nis `TakeSnapshot()`, the inferred response type is\n`TakeSnapshotResponse`.",
+                "type": "object"
               }
             },
             "type": "object"
           }
-        ]
+        ],
+        "description": "This resource represents a long-running operation that is the result of a\nnetwork API call.",
+        "type": "object"
       },
       "Status": {
         "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). Each `Status` message contains\nthree pieces of data: error code, error message, and error details.\n\nYou can find out more about this error model and how to work with it in the\n[API Design Guide](https://cloud.google.com/apis/design/errors).",
-        "type": "object",
         "properties": {
           "code": {
             "description": "The status code, which should be an enum value of google.rpc.Code.",
-            "type": "integer",
-            "format": "int32"
-          },
-          "message": {
-            "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\ngoogle.rpc.Status.details field, or localized by the client.",
-            "type": "string"
+            "format": "int32",
+            "type": "integer"
           },
           "details": {
             "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use.",
-            "type": "array",
             "items": {
               "additionalProperties": {
                 "description": "Properties of the object. Contains field @type with type URL."
               },
               "type": "object"
-            }
-          }
-        }
-      },
-      "BaseOperation": {
-        "properties": {
-          "name": {
-            "description": "The server-assigned name, which is only unique within the same service that\noriginally returns it. If you use the default HTTP mapping, the\n`name` should be a resource name ending with `operations/{unique_id}`.",
+            },
+            "type": "array"
+          },
+          "message": {
+            "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\ngoogle.rpc.Status.details field, or localized by the client.",
             "type": "string"
-          },
-          "done": {
-            "description": "If the value is `false`, it means the operation is still in progress.\nIf `true`, the operation is completed, and either `error` or `response` is\navailable.",
-            "type": "boolean"
-          },
-          "error": {
-            "description": "The error result of the operation in case of failure or cancellation.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Status"
-              }
-            ]
           }
         },
-        "description": "This resource represents a long-running operation that is the result of a\nnetwork API call.",
         "type": "object"
-      }
-    },
-    "parameters": {
-      "callback": {
-        "name": "$callback",
-        "description": "JSONP",
-        "schema": {
-          "type": "string"
-        },
-        "in": "query"
-      },
-      "prettyPrint": {
-        "name": "$prettyPrint",
-        "description": "Returns response with indentations and line breaks.",
-        "schema": {
-          "default": "true",
-          "type": "boolean"
-        },
-        "in": "query"
-      },
-      "_.xgafv": {
-        "name": "$.xgafv",
-        "description": "V1 error format.",
-        "schema": {
-          "enum": ["1", "2"],
-          "x-google-enum-descriptions": ["v1 error format", "v2 error format"],
-          "type": "string"
-        },
-        "in": "query"
-      },
-      "alt": {
-        "name": "$alt",
-        "description": "Data format for response.",
-        "schema": {
-          "enum": ["json", "media", "proto"],
-          "default": "json",
-          "type": "string",
-          "x-google-enum-descriptions": [
-            "Responses with Content-Type of application/json",
-            "Media download with context-dependent Content-Type",
-            "Responses with Content-Type of application/x-protobuf"
-          ]
-        },
-        "in": "query"
       }
     },
     "securitySchemes": {
       "bearer_auth": {
+        "description": "Http bearer authentication.",
         "scheme": "bearer",
-        "type": "http",
-        "description": "Http bearer authentication."
-      },
-      "google_oauth_implicit": {
-        "type": "oauth2",
-        "description": "Google Oauth 2.0 implicit authentication flow.",
-        "flows": {
-          "implicit": {
-            "scopes": {
-              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources"
-            },
-            "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth"
-          }
-        }
+        "type": "http"
       },
       "google_oauth_code": {
-        "type": "oauth2",
         "description": "Google Oauth 2.0 authorizationCode authentication flow.",
         "flows": {
           "authorizationCode": {
@@ -252,7 +239,20 @@
             },
             "tokenUrl": "https://oauth2.googleapis.com/token"
           }
-        }
+        },
+        "type": "oauth2"
+      },
+      "google_oauth_implicit": {
+        "description": "Google Oauth 2.0 implicit authentication flow.",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+            "scopes": {
+              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources"
+            }
+          }
+        },
+        "type": "oauth2"
       }
     }
   },
@@ -262,30 +262,63 @@
   },
   "info": {
     "description": "colaboratory.googleapis.com API.",
-    "x-google-revision": "20260622",
+    "title": "Colab API",
     "version": "v1",
-    "title": "Colab API"
+    "x-google-revision": "20260622"
   },
   "openapi": "3.0.3",
   "paths": {
     "/v1/operations": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/alt"
-        },
-        {
-          "$ref": "#/components/parameters/callback"
-        },
-        {
-          "$ref": "#/components/parameters/prettyPrint"
-        },
-        {
-          "$ref": "#/components/parameters/_.xgafv"
-        }
-      ],
       "get": {
         "description": "Lists operations that match the specified filter in the request. If the\nserver doesn't support this method, it returns `UNIMPLEMENTED`.",
         "operationId": "ListOperations",
+        "parameters": [
+          {
+            "description": "The standard list filter.",
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The standard list page size.",
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The standard list page token.",
+            "in": "query",
+            "name": "pageToken",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "When set to `true`, operations that are reachable are returned as normal,\nand those that are unreachable are returned in the\nListOperationsResponse.unreachable\nfield.\n\nThis can only be `true` when reading across collections. For example, when\n`parent` is set to `\"projects/example/locations/-\"`.\n\nThis field is not supported by default and will result in an\n`UNIMPLEMENTED` error if set unless explicitly documented otherwise in\nservice or product specific documentation.",
+            "in": "query",
+            "name": "returnPartialSuccess",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListOperationsResponse"
+                }
+              }
+            },
+            "description": "Successful operation"
+          }
+        },
         "security": [
           {
             "google_oauth_implicit": [
@@ -301,55 +334,124 @@
             "bearer_auth": []
           }
         ],
+        "tags": ["colaboratory"]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        }
+      ]
+    },
+    "/v1/operations/{operationsId}": {
+      "delete": {
+        "description": "Deletes a long-running operation. This method indicates that the client is\nno longer interested in the operation result. It does not cancel the\noperation. If the server doesn't support this method, it returns\n`google.rpc.Code.UNIMPLEMENTED`.",
+        "operationId": "DeleteOperation",
         "parameters": [
           {
-            "name": "filter",
-            "description": "The standard list filter.",
-            "in": "query",
+            "description": "Part of `name`. The name of the operation resource to be deleted.",
+            "in": "path",
+            "name": "operationsId",
+            "required": true,
             "schema": {
               "type": "string"
-            }
-          },
-          {
-            "name": "pageSize",
-            "description": "The standard list page size.",
-            "in": "query",
-            "schema": {
-              "format": "int32",
-              "type": "integer"
-            }
-          },
-          {
-            "name": "pageToken",
-            "description": "The standard list page token.",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "returnPartialSuccess",
-            "description": "When set to `true`, operations that are reachable are returned as normal,\nand those that are unreachable are returned in the\nListOperationsResponse.unreachable\nfield.\n\nThis can only be `true` when reading across collections. For example, when\n`parent` is set to `\"projects/example/locations/-\"`.\n\nThis field is not supported by default and will result in an\n`UNIMPLEMENTED` error if set unless explicitly documented otherwise in\nservice or product specific documentation.",
-            "in": "query",
-            "schema": {
-              "type": "boolean"
             }
           }
         ],
-        "tags": ["colaboratory"],
         "responses": {
           "default": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListOperationsResponse"
+                  "$ref": "#/components/schemas/Empty"
                 }
               }
             },
             "description": "Successful operation"
           }
+        },
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/colaboratory"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/colaboratory"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": ["colaboratory"]
+      },
+      "get": {
+        "description": "Gets the latest state of a long-running operation.  Clients can use this\nmethod to poll the operation result at intervals as recommended by the API\nservice.",
+        "operationId": "GetOperation",
+        "parameters": [
+          {
+            "description": "Part of `name`. The name of the operation resource.",
+            "in": "path",
+            "name": "operationsId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Operation"
+                }
+              }
+            },
+            "description": "Successful operation"
+          }
+        },
+        "security": [
+          {
+            "google_oauth_implicit": [
+              "https://www.googleapis.com/auth/colaboratory"
+            ]
+          },
+          {
+            "google_oauth_code": [
+              "https://www.googleapis.com/auth/colaboratory"
+            ]
+          },
+          {
+            "bearer_auth": []
+          }
+        ],
+        "tags": ["colaboratory"]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/_.xgafv"
         }
-      }
+      ]
     },
     "/v1/operations/{operationsId}:cancel": {
       "parameters": [
@@ -367,119 +469,41 @@
         }
       ],
       "post": {
+        "description": "Starts asynchronous cancellation on a long-running operation.  The server\nmakes a best effort to cancel the operation, but success is not\nguaranteed.  If the server doesn't support this method, it returns\n`google.rpc.Code.UNIMPLEMENTED`.  Clients can use\nOperations.GetOperation or\nother methods to check whether the cancellation succeeded or whether the\noperation completed despite cancellation. On successful cancellation,\nthe operation is not deleted; instead, it becomes an operation with\nan Operation.error value with a google.rpc.Status.code of `1`,\ncorresponding to `Code.CANCELLED`.",
         "operationId": "CancelOperation",
-        "security": [
-          {
-            "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
-            ]
-          },
-          {
-            "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
-            ]
-          },
-          {
-            "bearer_auth": []
-          }
-        ],
         "parameters": [
           {
             "description": "Part of `name`. The name of the operation resource to be cancelled.",
             "in": "path",
             "name": "operationsId",
+            "required": true,
             "schema": {
               "type": "string"
-            },
-            "required": true
-          }
-        ],
-        "description": "Starts asynchronous cancellation on a long-running operation.  The server\nmakes a best effort to cancel the operation, but success is not\nguaranteed.  If the server doesn't support this method, it returns\n`google.rpc.Code.UNIMPLEMENTED`.  Clients can use\nOperations.GetOperation or\nother methods to check whether the cancellation succeeded or whether the\noperation completed despite cancellation. On successful cancellation,\nthe operation is not deleted; instead, it becomes an operation with\nan Operation.error value with a google.rpc.Status.code of `1`,\ncorresponding to `Code.CANCELLED`.",
-        "tags": ["colaboratory"],
-        "responses": {
-          "default": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Empty"
-                }
-              }
             }
           }
-        },
+        ],
         "requestBody": {
-          "description": "The request body.",
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CancelOperationRequest"
               }
             }
-          }
-        }
-      }
-    },
-    "/v1/operations/{operationsId}": {
-      "get": {
-        "description": "Gets the latest state of a long-running operation.  Clients can use this\nmethod to poll the operation result at intervals as recommended by the API\nservice.",
-        "operationId": "GetOperation",
-        "security": [
-          {
-            "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
-            ]
           },
-          {
-            "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
-            ]
-          },
-          {
-            "bearer_auth": []
-          }
-        ],
-        "parameters": [
-          {
-            "description": "Part of `name`. The name of the operation resource.",
-            "in": "path",
-            "name": "operationsId",
-            "schema": {
-              "type": "string"
-            },
-            "required": true
-          }
-        ],
-        "tags": ["colaboratory"],
+          "description": "The request body."
+        },
         "responses": {
           "default": {
-            "description": "Successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Operation"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": ["colaboratory"],
-        "responses": {
-          "default": {
-            "description": "Successful operation",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Empty"
                 }
               }
-            }
+            },
+            "description": "Successful operation"
           }
         },
-        "description": "Deletes a long-running operation. This method indicates that the client is\nno longer interested in the operation result. It does not cancel the\noperation. If the server doesn't support this method, it returns\n`google.rpc.Code.UNIMPLEMENTED`.",
-        "operationId": "DeleteOperation",
         "security": [
           {
             "google_oauth_implicit": [
@@ -495,38 +519,14 @@
             "bearer_auth": []
           }
         ],
-        "parameters": [
-          {
-            "name": "operationsId",
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "description": "Part of `name`. The name of the operation resource to be deleted.",
-            "in": "path"
-          }
-        ]
-      },
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/alt"
-        },
-        {
-          "$ref": "#/components/parameters/callback"
-        },
-        {
-          "$ref": "#/components/parameters/prettyPrint"
-        },
-        {
-          "$ref": "#/components/parameters/_.xgafv"
-        }
-      ]
+        "tags": ["colaboratory"]
+      }
     }
   },
   "servers": [
     {
-      "url": "https://colaboratory.googleapis.com",
-      "description": "Global Endpoint"
+      "description": "Global Endpoint",
+      "url": "https://colaboratory.googleapis.com"
     }
   ]
 }


### PR DESCRIPTION
**Why**? In the previous https://github.com/googlecolab/colab-vscode/pull/633, I forgot to set this `jsonRecursiveSort` option, so only the top-level elements were sorted. The resulted JSON structure was still not stable.

In this PR, I enabled `jsonRecursiveSort` on `colab-api.json` and `operations-api.json`, so all child elements are sorted recursively. I also re-generated the TS client code.

(With this change, hopefully all future client regen PRs will show deterministic and meaningful diffs only.)