### PR TITLE
fix: make Prettier checks work on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary

- enforce LF checkouts for detected text files with a repository-level `.gitattributes` policy
- keep Prettier's default LF enforcement consistent on Windows and other platforms

## Why

With `core.autocrlf=true`, Windows checks out text files as CRLF when the repository has no line-ending policy. Prettier defaults to LF, so `npm run format:check` reports nearly every tracked text file even when the Git worktree is clean.

Adding `* text=auto eol=lf` makes the repository policy explicit: Git checks out detected text files as LF on every platform while leaving binary files untouched.

## Validation

- fresh Windows clone with global `core.autocrlf=true`: 295 text files checked out as LF; 4 binary files remained binary
- `npm run format:check`
- `npm run typecheck`
- `npm run lint` (0 errors; one warning in generated `src/colab-config.ts`)
- `npm run test:unit` (1,156 passing)
- CSpell check used by CI (199 files, 0 issues)
