### PR TITLE
chore: bump `google-auth-library` and `uuid` to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "dependencies": {
         "@jupyterlab/services": "^7.5.3",
         "glob": "^11.1.0",
-        "google-auth-library": "^9.15.0",
+        "google-auth-library": "^10.9.0",
         "node-fetch": "^2.6.7",
         "semver": "^7.7.3",
-        "uuid": "^14.0.0",
+        "uuid": "^14.0.1",
         "vscode-languageclient": "^10.0.0-next.17",
         "ws": "^6.2.4",
         "zod": "^4.0.17"
@@ -33,7 +33,7 @@
         "@types/react": "^19.2.10",
         "@types/semver": "^7.7.1",
         "@types/sinon": "^17.0.3",
-        "@types/uuid": "^10.0.0",
+        "@types/uuid": "^11.0.0",
         "@types/vscode": "^1.99.3",
         "@vscode/jupyter-extension": "1.0.93",
         "@vscode/test-cli": "^0.0.10",
@@ -3465,11 +3465,15 @@
       "license": "MIT"
     },
     "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
+      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
+      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "*"
+      }
     },
     "node_modules/@types/vscode": {
       "version": "1.102.0",
@@ -7384,6 +7388,29 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -7583,6 +7610,18 @@
         "node": ">= 18"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -7669,58 +7708,58 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
-      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9",
-        "uuid": "^9.0.1"
+        "node-fetch": "^3.3.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
-    "node_modules/gaxios/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+    "node_modules/gaxios/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">= 12"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/gaxios/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/gensequence": {
@@ -8009,26 +8048,26 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -8088,19 +8127,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
-      "license": "MIT",
-      "dependencies": {
-        "gaxios": "^6.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -10264,6 +10290,26 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -13724,9 +13770,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -14188,6 +14234,15 @@
       "optional": true,
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -400,7 +400,7 @@
     "@types/react": "^19.2.10",
     "@types/semver": "^7.7.1",
     "@types/sinon": "^17.0.3",
-    "@types/uuid": "^10.0.0",
+    "@types/uuid": "^11.0.0",
     "@types/vscode": "^1.99.3",
     "@vscode/jupyter-extension": "1.0.93",
     "@vscode/test-cli": "^0.0.10",
@@ -436,10 +436,10 @@
   "dependencies": {
     "@jupyterlab/services": "^7.5.3",
     "glob": "^11.1.0",
-    "google-auth-library": "^9.15.0",
+    "google-auth-library": "^10.9.0",
     "node-fetch": "^2.6.7",
     "semver": "^7.7.3",
-    "uuid": "^14.0.0",
+    "uuid": "^14.0.1",
     "vscode-languageclient": "^10.0.0-next.17",
     "ws": "^6.2.4",
     "zod": "^4.0.17"

--- a/src/auth/auth-provider.unit.test.ts
+++ b/src/auth/auth-provider.unit.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { expect } from 'chai';
-import { GaxiosError, GaxiosOptionsPrepared, GaxiosResponse } from 'gaxios';
+import { GaxiosError, GaxiosResponse } from 'gaxios';
 import { OAuth2Client } from 'google-auth-library';
 import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
 import { SinonStub, SinonStubbedInstance, SinonFakeTimers } from 'sinon';
@@ -293,17 +293,18 @@ describe('GoogleAuthProvider', () => {
 
         for (const { message, status } of GAXIOS_ERRORS) {
           it(`clears the session and re-initializes if refreshAccessToken throws a ${status.toString()} GaxiosError`, async () => {
+            const headers = new Headers();
+            const url = new URL('https://example.com');
             const gaxiosError: GaxiosError = new GaxiosError(
               message,
-              {} as GaxiosOptionsPrepared,
+              { headers, url },
               {
-                config: {},
+                config: { headers, url },
                 data: undefined,
                 status,
                 statusText: 'Unauthorized',
-                headers: {},
-                request: { responseURL: '' },
-              } as unknown as GaxiosResponse,
+                headers,
+              } as Partial<GaxiosResponse> as GaxiosResponse,
             );
             sinon.stub(oauth2Client, 'refreshAccessToken').throws(gaxiosError);
             storageStub.getSessions.onSecondCall().resolves([]);
@@ -598,17 +599,18 @@ describe('GoogleAuthProvider', () => {
 
       for (const { message, status } of GAXIOS_ERRORS) {
         it(`clears the session when refreshing the access token throws a ${status.toString()} GaxiosError`, async () => {
+          const headers = new Headers();
+          const url = new URL('https://example.com');
           const gaxiosError: GaxiosError = new GaxiosError(
             message,
-            {} as GaxiosOptionsPrepared,
+            { headers, url },
             {
-              config: {},
+              config: { headers, url },
               data: undefined,
               status,
               statusText: 'Unauthorized',
-              headers: {},
-              request: { responseURL: '' },
-            } as unknown as GaxiosResponse,
+              headers,
+            } as Partial<GaxiosResponse> as GaxiosResponse,
           );
           refreshAccessTokenStub.throws(gaxiosError);
           sinon.stub(oauth2Client, 'revokeToken').resolves();

--- a/src/auth/auth-provider.unit.test.ts
+++ b/src/auth/auth-provider.unit.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { expect } from 'chai';
-import { GaxiosError } from 'gaxios';
+import { GaxiosError, GaxiosOptionsPrepared, GaxiosResponse } from 'gaxios';
 import { OAuth2Client } from 'google-auth-library';
 import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
 import { SinonStub, SinonStubbedInstance, SinonFakeTimers } from 'sinon';
@@ -295,7 +295,7 @@ describe('GoogleAuthProvider', () => {
           it(`clears the session and re-initializes if refreshAccessToken throws a ${status.toString()} GaxiosError`, async () => {
             const gaxiosError: GaxiosError = new GaxiosError(
               message,
-              {},
+              {} as GaxiosOptionsPrepared,
               {
                 config: {},
                 data: undefined,
@@ -303,7 +303,7 @@ describe('GoogleAuthProvider', () => {
                 statusText: 'Unauthorized',
                 headers: {},
                 request: { responseURL: '' },
-              },
+              } as unknown as GaxiosResponse,
             );
             sinon.stub(oauth2Client, 'refreshAccessToken').throws(gaxiosError);
             storageStub.getSessions.onSecondCall().resolves([]);
@@ -600,7 +600,7 @@ describe('GoogleAuthProvider', () => {
         it(`clears the session when refreshing the access token throws a ${status.toString()} GaxiosError`, async () => {
           const gaxiosError: GaxiosError = new GaxiosError(
             message,
-            {},
+            {} as GaxiosOptionsPrepared,
             {
               config: {},
               data: undefined,
@@ -608,7 +608,7 @@ describe('GoogleAuthProvider', () => {
               statusText: 'Unauthorized',
               headers: {},
               request: { responseURL: '' },
-            },
+            } as unknown as GaxiosResponse,
           );
           refreshAccessTokenStub.throws(gaxiosError);
           sinon.stub(oauth2Client, 'revokeToken').resolves();


### PR DESCRIPTION
**Why**? This is to fix a vulnerability https://github.com/googlecolab/colab-vscode/security/dependabot/79.

The version bump of `google-auth-library` also bumped version of `gaxios` as a transitive dependency, which required me to add some casts in `auth-provider.unit.test.ts` to avoid typecheck errors.

I also explicitly verified locally that bumping `google-auth-library` wouldn't force users to re-auth.

---

The following are the results of `npm audit`.

After the fix:
```
# npm audit report

serialize-javascript  <=7.0.4
Severity: high
Serialize JavaScript is Vulnerable to RCE via RegExp.flags and Date.prototype.toISOString() - https://github.com/advisories/GHSA-5c6j-r48x-rmvq
Serialize JavaScript has CPU Exhaustion Denial of Service via crafted array-like objects - https://github.com/advisories/GHSA-qj8w-gfj5-8c6v
No fix available
node_modules/serialize-javascript
  mocha  8.2.0 - 12.0.0-beta-2
  Depends on vulnerable versions of serialize-javascript
  node_modules/mocha
    @vscode/test-cli  *
    Depends on vulnerable versions of mocha
    node_modules/@vscode/test-cli

3 vulnerabilities (2 moderate, 1 high)
```

Before the fix:
```
# npm audit report

serialize-javascript  <=7.0.4
Severity: high
Serialize JavaScript is Vulnerable to RCE via RegExp.flags and Date.prototype.toISOString() - https://github.com/advisories/GHSA-5c6j-r48x-rmvq
Serialize JavaScript has CPU Exhaustion Denial of Service via crafted array-like objects - https://github.com/advisories/GHSA-qj8w-gfj5-8c6v
No fix available
node_modules/serialize-javascript
  mocha  8.2.0 - 12.0.0-beta-2
  Depends on vulnerable versions of serialize-javascript
  node_modules/mocha
    @vscode/test-cli  *
    Depends on vulnerable versions of mocha
    node_modules/@vscode/test-cli

uuid  <11.1.1
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq
fix available via `npm audit fix`
node_modules/gaxios/node_modules/uuid
  gaxios  6.4.0 - 6.7.1
  Depends on vulnerable versions of uuid
  node_modules/gaxios

5 vulnerabilities (4 moderate, 1 high)
```