### PR TITLE
chore: regen Colab v2 client with `Runtime.version`

### DIFF
--- a/src/colab/client/v2/colab-api.json
+++ b/src/colab/client/v2/colab-api.json
@@ -165,7 +165,7 @@
             "type": "object"
           },
           "reason": {
-            "description": "The reason of the error. This is a constant value that identifies the\nproximate cause of the error. Error reasons are unique within a particular\ndomain of errors. This should be at most 63 characters and match a\nregular expression of `A-Z+[A-Z0-9]`, which represents\nUPPER_SNAKE_CASE.",
+            "description": "The reason for the error. This is a constant value that identifies the\nproximate cause of the error. Error reasons are unique within a particular\ndomain of errors. This should be at most 63 characters and match a\nregular expression of `A-Z+[A-Z0-9]`, which represents\nUPPER_SNAKE_CASE.",
             "type": "string"
           }
         },
@@ -323,6 +323,10 @@
               }
             ],
             "description": "Required. The specification of the runtime."
+          },
+          "version": {
+            "description": "Optional. The version of the runtime image.\n\nSee [Colab Runtime Version\nFAQ](https://research.google.com/colaboratory/runtime-version-faq.html) for\nsupported runtime versions. If omitted (empty), the latest runtime image is\nused.",
+            "type": "string"
           }
         },
         "required": ["runtimeSpec"],
@@ -446,7 +450,8 @@
             "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
             "refreshUrl": "https://oauth2.googleapis.com/token",
             "scopes": {
-              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources"
+              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources",
+              "https://www.googleapis.com/auth/colaboratory.readonly": "Read-only access to your Colab resources"
             },
             "tokenUrl": "https://oauth2.googleapis.com/token"
           }
@@ -459,7 +464,8 @@
           "implicit": {
             "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
             "scopes": {
-              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources"
+              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources",
+              "https://www.googleapis.com/auth/colaboratory.readonly": "Read-only access to your Colab resources"
             }
           }
         },
@@ -475,7 +481,7 @@
     "description": "colaboratory.googleapis.com API.",
     "title": "Colab API",
     "version": "v1beta",
-    "x-google-revision": "20260709"
+    "x-google-revision": "20260714"
   },
   "openapi": "3.0.3",
   "paths": {
@@ -499,12 +505,14 @@
         "security": [
           {
             "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
             "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
@@ -573,12 +581,14 @@
         "security": [
           {
             "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
             "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
@@ -619,12 +629,14 @@
         "security": [
           {
             "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
             "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
@@ -662,12 +674,14 @@
         "security": [
           {
             "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
             "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
@@ -711,12 +725,14 @@
         "security": [
           {
             "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
             "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
@@ -760,12 +776,14 @@
         "security": [
           {
             "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
             "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {

--- a/src/colab/client/v2/generated/colab/apis/ColaboratoryApi.ts
+++ b/src/colab/client/v2/generated/colab/apis/ColaboratoryApi.ts
@@ -323,12 +323,12 @@ export class ColaboratoryApi extends runtime.BaseAPI implements ColaboratoryApiI
         }
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
 
@@ -402,12 +402,12 @@ export class ColaboratoryApi extends runtime.BaseAPI implements ColaboratoryApiI
         }
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
 
@@ -480,12 +480,12 @@ export class ColaboratoryApi extends runtime.BaseAPI implements ColaboratoryApiI
         }
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
 
@@ -552,12 +552,12 @@ export class ColaboratoryApi extends runtime.BaseAPI implements ColaboratoryApiI
         }
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
 
@@ -623,12 +623,12 @@ export class ColaboratoryApi extends runtime.BaseAPI implements ColaboratoryApiI
         }
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
 
@@ -694,12 +694,12 @@ export class ColaboratoryApi extends runtime.BaseAPI implements ColaboratoryApiI
         }
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
 

--- a/src/colab/client/v2/generated/colab/models/ErrorInfo.ts
+++ b/src/colab/client/v2/generated/colab/models/ErrorInfo.ts
@@ -69,7 +69,7 @@ export interface ErrorInfo {
      */
     metadata?: { [key: string]: string; };
     /**
-     * The reason of the error. This is a constant value that identifies the
+     * The reason for the error. This is a constant value that identifies the
      * proximate cause of the error. Error reasons are unique within a particular
      * domain of errors. This should be at most 63 characters and match a
      * regular expression of `A-Z+[A-Z0-9]`, which represents

--- a/src/colab/client/v2/generated/colab/models/Runtime.ts
+++ b/src/colab/client/v2/generated/colab/models/Runtime.ts
@@ -56,6 +56,17 @@ export interface Runtime {
      * @memberof Runtime
      */
     runtimeSpec: Key;
+    /**
+     * Optional. The version of the runtime image.
+     * 
+     * See [Colab Runtime Version
+     * FAQ](https://research.google.com/colaboratory/runtime-version-faq.html) for
+     * supported runtime versions. If omitted (empty), the latest runtime image is
+     * used.
+     * @type {string}
+     * @memberof Runtime
+     */
+    version?: string;
 }
 
 /**
@@ -79,6 +90,7 @@ export function RuntimeFromJSONTyped(json: any, ignoreDiscriminator: boolean): R
         'connectionInfo': json['connectionInfo'] == null ? undefined : ConnectionInfoFromJSON(json['connectionInfo']),
         'name': json['name'] == null ? undefined : json['name'],
         'runtimeSpec': KeyFromJSON(json['runtimeSpec']),
+        'version': json['version'] == null ? undefined : json['version'],
     };
 }
 
@@ -95,6 +107,7 @@ export function RuntimeToJSONTyped(value?: Omit<Runtime, 'connectionInfo'> | nul
         
         'name': value['name'],
         'runtimeSpec': KeyToJSON(value['runtimeSpec']),
+        'version': value['version'],
     };
 }
 

--- a/src/colab/client/v2/generated/operations/apis/ColaboratoryApi.ts
+++ b/src/colab/client/v2/generated/operations/apis/ColaboratoryApi.ts
@@ -206,12 +206,12 @@ export class ColaboratoryApi extends runtime.BaseAPI implements ColaboratoryApiI
         }
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
 
@@ -294,12 +294,12 @@ export class ColaboratoryApi extends runtime.BaseAPI implements ColaboratoryApiI
         }
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
 
@@ -376,12 +376,12 @@ export class ColaboratoryApi extends runtime.BaseAPI implements ColaboratoryApiI
         }
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_code", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
         if (this.configuration && this.configuration.accessToken) {
             // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory"]);
+            headerParameters["Authorization"] = await this.configuration.accessToken("google_oauth_implicit", ["https://www.googleapis.com/auth/colaboratory", "https://www.googleapis.com/auth/colaboratory.readonly"]);
         }
 
 

--- a/src/colab/client/v2/generated/operations/models/ErrorInfo.ts
+++ b/src/colab/client/v2/generated/operations/models/ErrorInfo.ts
@@ -69,7 +69,7 @@ export interface ErrorInfo {
      */
     metadata?: { [key: string]: string; };
     /**
-     * The reason of the error. This is a constant value that identifies the
+     * The reason for the error. This is a constant value that identifies the
      * proximate cause of the error. Error reasons are unique within a particular
      * domain of errors. This should be at most 63 characters and match a
      * regular expression of `A-Z+[A-Z0-9]`, which represents

--- a/src/colab/client/v2/index.unit.test.ts
+++ b/src/colab/client/v2/index.unit.test.ts
@@ -346,6 +346,7 @@ describe('ColabApiClient', () => {
           token: 'test-token',
           expireTime: new Date(2026, 0, 1),
         },
+        version: 'test.version',
       },
       {
         name: 'runtimes/r-2',
@@ -355,6 +356,7 @@ describe('ColabApiClient', () => {
           shape: 'SHAPE_STANDARD',
         },
         connectionInfo: undefined,
+        version: undefined,
       },
       {
         name: 'runtimes/r-3',
@@ -364,6 +366,7 @@ describe('ColabApiClient', () => {
           shape: 'SHAPE_HIGHMEM',
         },
         connectionInfo: undefined,
+        version: undefined,
       },
     ];
 

--- a/src/colab/client/v2/operations-api.json
+++ b/src/colab/client/v2/operations-api.json
@@ -103,7 +103,7 @@
             "type": "object"
           },
           "reason": {
-            "description": "The reason of the error. This is a constant value that identifies the\nproximate cause of the error. Error reasons are unique within a particular\ndomain of errors. This should be at most 63 characters and match a\nregular expression of `A-Z+[A-Z0-9]`, which represents\nUPPER_SNAKE_CASE.",
+            "description": "The reason for the error. This is a constant value that identifies the\nproximate cause of the error. Error reasons are unique within a particular\ndomain of errors. This should be at most 63 characters and match a\nregular expression of `A-Z+[A-Z0-9]`, which represents\nUPPER_SNAKE_CASE.",
             "type": "string"
           }
         },
@@ -248,7 +248,8 @@
             "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
             "refreshUrl": "https://oauth2.googleapis.com/token",
             "scopes": {
-              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources"
+              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources",
+              "https://www.googleapis.com/auth/colaboratory.readonly": "Read-only access to your Colab resources"
             },
             "tokenUrl": "https://oauth2.googleapis.com/token"
           }
@@ -261,7 +262,8 @@
           "implicit": {
             "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
             "scopes": {
-              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources"
+              "https://www.googleapis.com/auth/colaboratory": "Read, write, and delete your Colab resources",
+              "https://www.googleapis.com/auth/colaboratory.readonly": "Read-only access to your Colab resources"
             }
           }
         },
@@ -277,7 +279,7 @@
     "description": "colaboratory.googleapis.com API.",
     "title": "Colab API",
     "version": "v1",
-    "x-google-revision": "20260710"
+    "x-google-revision": "20260714"
   },
   "openapi": "3.0.3",
   "paths": {
@@ -335,12 +337,14 @@
         "security": [
           {
             "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
             "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
@@ -394,12 +398,14 @@
         "security": [
           {
             "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
             "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
@@ -462,12 +468,14 @@
         "security": [
           {
             "google_oauth_implicit": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {
             "google_oauth_code": [
-              "https://www.googleapis.com/auth/colaboratory"
+              "https://www.googleapis.com/auth/colaboratory",
+              "https://www.googleapis.com/auth/colaboratory.readonly"
             ]
           },
           {


### PR DESCRIPTION
Regenerated Colab v2 client to include the following changes:
* Add `Runtime.version` to support past runtime version picker (cl/947286207)
* Add `https://www.googleapis.com/auth/colaboratory.readonly` scope for read-only methods (cl/947718236)

Also updated unit tests to cover the new `Runtime.version` property in `src/colab/client/v2/index.unit.test.ts`.