### PR TITLE
fix: `removeServer` to call Jupyter `sessions.list` instead of TFE

### DIFF
--- a/src/colab/client/v1/api.ts
+++ b/src/colab/client/v1/api.ts
@@ -24,10 +24,7 @@
  */
 
 import { z } from 'zod';
-import {
-  Session as GeneratedSession,
-  Kernel as GeneratedKernel,
-} from '../../../jupyter/client/generated';
+import { Kernel as GeneratedKernel } from '../../../jupyter/client/generated';
 import { Shape, SubscriptionTier, Variant } from '../../types';
 
 export enum SubscriptionState {
@@ -393,21 +390,6 @@ export const KernelSchema: z.ZodType<GeneratedKernel> = z
   }));
 /** A Colab Jupyter kernel. */
 export type Kernel = z.infer<typeof KernelSchema>;
-
-/** A session to a Colab Jupyter kernel returned from the Colab API. */
-export const SessionSchema: z.ZodType<GeneratedSession> = z.object({
-  /** The UUID of the session. */
-  id: z.string(),
-  /** The kernel associated with the session. */
-  kernel: KernelSchema,
-  /** The name of the session. */
-  name: z.string(),
-  /** The path to the session. */
-  path: z.string(),
-  /** The session type. */
-  type: z.string(),
-});
-export type Session = z.infer<typeof SessionSchema>;
 
 /** Information about memory usage on a Colab runtime. */
 export const MemorySchema = z

--- a/src/colab/client/v1/index.ts
+++ b/src/colab/client/v1/index.ts
@@ -16,7 +16,6 @@ import {
   createAuthMiddleware,
   createErrorMiddleware,
 } from '../../../common/middleware';
-import { Session } from '../../../jupyter/client/generated';
 import { ColabAssignedServer } from '../../../jupyter/servers';
 import { uuidToWebSafeBase64 } from '../../../utils/uuid';
 import {
@@ -52,7 +51,6 @@ import {
   ListedAssignment,
   RuntimeProxyToken,
   RuntimeProxyTokenSchema,
-  SessionSchema,
   CredentialsPropagationResult,
   CredentialsPropagationResultSchema,
   ExperimentStateSchema,
@@ -318,34 +316,6 @@ export class ColabClient {
       ListedAssignmentsSchema,
     );
     return response.assignments;
-  }
-
-  /**
-   * Lists all sessions for a given server by its endpoint.
-   *
-   * @param endpoint - The assignment endpoint to list sessions for.
-   * @param signal - Optional {@link AbortSignal} to cancel the request.
-   * @returns The list of sessions.
-   */
-  async listSessions(
-    endpoint: string,
-    signal?: AbortSignal,
-  ): Promise<Session[]> {
-    const url = new URL(
-      `${TUN_ENDPOINT}/${endpoint}/api/sessions`,
-      this.colabDomain,
-    );
-    const headers = { [COLAB_TUNNEL_HEADER.key]: COLAB_TUNNEL_HEADER.value };
-
-    return await this.issueRequest(
-      url,
-      {
-        method: 'GET',
-        headers,
-        signal,
-      },
-      z.array(SessionSchema),
-    );
   }
 
   /**

--- a/src/colab/client/v1/index.unit.test.ts
+++ b/src/colab/client/v1/index.unit.test.ts
@@ -9,7 +9,6 @@ import { expect } from 'chai';
 import fetch, { Response } from 'node-fetch';
 import { SinonStub, SinonMatcher } from 'sinon';
 import * as sinon from 'sinon';
-import { Session } from '../../../jupyter/client/generated';
 import { ColabAssignedServer } from '../../../jupyter/servers';
 import { TestUri } from '../../../test/helpers/uri';
 import { uuidToWebSafeBase64 } from '../../../utils/uuid';
@@ -750,59 +749,6 @@ describe('ColabClient', () => {
         };
         await expect(response).to.eventually.deep.equal(newConnectionInfo);
       });
-    });
-
-    it('successfully lists sessions by assignment endpoint', async () => {
-      const last_activity = new Date().toISOString();
-      const mockResponseSession = {
-        id: 'mock-session-id',
-        kernel: {
-          id: 'mock-kernel-id',
-          name: 'mock-kernel-name',
-          last_activity,
-          execution_state: 'idle',
-          connections: 1,
-        },
-        name: 'mock-session-name',
-        path: '/mock-path',
-        type: 'notebook',
-      };
-      const expectedSession: Session = {
-        id: 'mock-session-id',
-        kernel: {
-          id: 'mock-kernel-id',
-          name: 'mock-kernel-name',
-          lastActivity: last_activity,
-          executionState: 'idle',
-          connections: 1,
-        },
-        name: 'mock-session-name',
-        path: '/mock-path',
-        type: 'notebook',
-      };
-      fetchStub
-        .withArgs(
-          urlMatcher({
-            method: 'GET',
-            host: COLAB_HOST,
-            path: `/tun/m/${assignedServer.endpoint}/api/sessions`,
-            otherHeaders: {
-              [COLAB_TUNNEL_HEADER.key]: COLAB_TUNNEL_HEADER.value,
-            },
-            withAuthUser: false,
-          }),
-        )
-        .resolves(
-          new Response(withXSSI(JSON.stringify([mockResponseSession])), {
-            status: 200,
-          }),
-        );
-
-      await expect(
-        client.listSessions(assignedServer.endpoint),
-      ).to.eventually.deep.equal([expectedSession]);
-
-      sinon.assert.calledOnce(fetchStub);
     });
 
     it('successfully gets resources by server', async () => {

--- a/src/colab/commands/server.ts
+++ b/src/colab/commands/server.ts
@@ -5,6 +5,7 @@
  */
 
 import vscode, { QuickPickItem } from 'vscode';
+import { log } from '../../common/logging';
 import { MultiStepInput } from '../../common/multi-step-quickpick';
 import { AssignmentManager } from '../../jupyter/assignments';
 import { ContentsFileSystemProvider } from '../../jupyter/contents/file-system';
@@ -143,6 +144,7 @@ export async function removeServer(
     source ?? CommandSource.COMMAND_SOURCE_COMMAND_PALETTE,
   );
   const allServers = await assignmentManager.getServers('all');
+  log.trace(`removeServer: getServers('all') resolved:`, allServers);
   const vsCodeServers = allServers.assigned;
   const nonVsCodeServers = allServers.unowned;
   if (vsCodeServers.length === 0 && nonVsCodeServers.length === 0) {

--- a/src/colab/keep-alive.ts
+++ b/src/colab/keep-alive.ts
@@ -149,8 +149,12 @@ export class ServerKeepAliveController implements Toggleable, Disposable {
     assignment: ColabAssignedServer,
     signal: AbortSignal,
   ): Promise<void> {
-    const client = ProxiedJupyterClient.withStaticConnection(assignment);
-    const kernels = await client.kernels.list({ signal });
+    const c = assignment.connectionInformation;
+    const jupyterClient = ProxiedJupyterClient.withStaticConnection(
+      c.baseUrl,
+      c.token,
+    );
+    const kernels = await jupyterClient.kernels.list({ signal });
     if (await this.shouldKeepAlive(assignment, kernels)) {
       await this.colabClient.sendKeepAlive(assignment.endpoint, signal);
     }

--- a/src/colab/keep-alive.unit.test.ts
+++ b/src/colab/keep-alive.unit.test.ts
@@ -8,7 +8,7 @@ import { randomUUID } from 'crypto';
 import { expect } from 'chai';
 import sinon, { SinonFakeTimers, SinonStubbedInstance } from 'sinon';
 import { AssignmentManager } from '../jupyter/assignments';
-import { JupyterClient, ProxiedJupyterClient } from '../jupyter/client';
+import { ProxiedJupyterClient } from '../jupyter/client';
 import { Kernel } from '../jupyter/client/generated';
 import { ColabAssignedServer } from '../jupyter/servers';
 import { TestCancellationTokenSource } from '../test/helpers/cancellation';
@@ -76,9 +76,8 @@ describe('ServerKeepAliveController', () => {
   let clock: SinonFakeTimers;
   let vsCodeStub: VsCodeStub;
   let colabClientStub: SinonStubbedInstance<ColabClient>;
-  let jupyterClientFactoryStub: sinon.SinonStub<
-    [server: ColabAssignedServer],
-    JupyterClient
+  let jupyterClientFactoryStub: sinon.SinonStubbedFunction<
+    typeof ProxiedJupyterClient.withStaticConnection
   >;
   let defaultServerJupyterStub: JupyterClientStub;
   let assignmentStub: SinonStubbedInstance<AssignmentManager>;
@@ -101,7 +100,10 @@ describe('ServerKeepAliveController', () => {
     );
     defaultServerJupyterStub = createJupyterClientStub();
     jupyterClientFactoryStub
-      .withArgs(DEFAULT_SERVER)
+      .withArgs(
+        DEFAULT_SERVER.connectionInformation.baseUrl,
+        DEFAULT_SERVER.connectionInformation.token,
+      )
       .returns(defaultServerJupyterStub);
     assignmentStub = sinon.createStubInstance(AssignmentManager);
     keepAlive = new ServerKeepAliveController(
@@ -424,6 +426,11 @@ describe('ServerKeepAliveController', () => {
           ...DEFAULT_SERVER,
           id: randomUUID(),
           endpoint: `m-s-${n.toString()}`,
+          connectionInformation: {
+            ...DEFAULT_SERVER.connectionInformation,
+            baseUrl: TestUri.parse(`https://example${n.toString()}.com`),
+            token: `test-token-${n.toString()}`,
+          },
         };
         return { server, kernel: createKernel(server, activity) };
       }
@@ -456,7 +463,12 @@ describe('ServerKeepAliveController', () => {
         const servers = [active1, active2, idle1, idle2];
         for (const { server, kernel } of servers) {
           const jupyterStub = createJupyterClientStub();
-          jupyterClientFactoryStub.withArgs(server).returns(jupyterStub);
+          jupyterClientFactoryStub
+            .withArgs(
+              server.connectionInformation.baseUrl,
+              server.connectionInformation.token,
+            )
+            .returns(jupyterStub);
           jupyterStub.kernels.list.resolves([kernel]);
         }
         // Type assertion needed due to overloading on getServers

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -30,7 +30,6 @@ import {
 import { REMOVE_SERVER } from '../colab/commands/constants';
 import {
   AcceleratorUnavailableError,
-  ColabRequestError,
   DenylistedError,
   InsufficientQuotaError,
   NotFoundError,
@@ -44,6 +43,7 @@ import {
 import { Shape, SubscriptionTier, Variant } from '../colab/types';
 import { waitForTimeout } from '../common/async';
 import { log } from '../common/logging';
+import { FetchError as JupyterFetchError } from '../jupyter/client/generated';
 import { telemetry } from '../telemetry';
 import { AssignmentOutcome, CommandSource } from '../telemetry/api';
 import { ProxiedJupyterClient } from './client';
@@ -755,31 +755,34 @@ export class AssignmentManager implements Disposable {
           .map(async (a): Promise<UnownedServer | undefined> => {
             // For any remote servers created in Colab web UI, assuming there
             // is only one session per assignment.
-            let label: string;
+            let label = UNKNOWN_REMOTE_SERVER_NAME;
             const timeout = waitForTimeout(
               LIST_UNOWNED_SESSIONS_TIMEOUT_MS,
               `Listing sessions timeout exceeded for endpoint ${a.endpoint}`,
             );
             try {
-              const sessions = await Promise.race([
-                this.colabClient.listSessions(a.endpoint, signal),
-                timeout.promise,
-              ]);
-              label =
-                sessions.length === 1 && sessions[0].name?.length
-                  ? sessions[0].name
-                  : UNKNOWN_REMOTE_SERVER_NAME;
+              if (a.runtimeProxyInfo) {
+                const jupyterClient = ProxiedJupyterClient.withStaticConnection(
+                  a.runtimeProxyInfo.url,
+                  a.runtimeProxyInfo.token,
+                );
+                const sessions = await Promise.race([
+                  jupyterClient.sessions.list({ signal }),
+                  timeout.promise,
+                ]);
+                if (sessions.length === 1 && sessions[0].name?.length) {
+                  label = sessions[0].name;
+                }
+              }
             } catch (error: unknown) {
               // The assignment may have been removed (e.g. via Colab web UI
               // or another VS Code instance sharing the account) between
-              // listing assignments and listing its sessions. Drop it from
-              // the result rather than failing the entire call.
-              if (
-                error instanceof ColabRequestError &&
-                error.response.status === 404
-              ) {
+              // listing assignments and listing its sessions, resulting in a
+              // network error, i.e. FetchError. Drop it from the result rather
+              // than failing the entire call.
+              if (error instanceof JupyterFetchError) {
                 log.trace(
-                  `Dropping orphan assignment ${a.endpoint} - sessions endpoint returned 404`,
+                  `Dropping orphan assignment ${a.endpoint} - sessions.list resulted in a network error`,
                   error,
                 );
                 return undefined;
@@ -790,7 +793,6 @@ export class AssignmentManager implements Disposable {
                 `Failed to list sessions for assignment ${a.endpoint}, falling back to placeholder label`,
                 error,
               );
-              label = UNKNOWN_REMOTE_SERVER_NAME;
             } finally {
               timeout.dispose();
             }
@@ -885,9 +887,13 @@ export class AssignmentManager implements Disposable {
     // attached in VS Code. However, we don't want to fail the entire
     // unassignServer call because the unassign API call will eventually garbage
     // collect and clean up the sessions too.
-    const client = ProxiedJupyterClient.withStaticConnection(server);
+    const c = server.connectionInformation;
+    const jupyterClient = ProxiedJupyterClient.withStaticConnection(
+      c.baseUrl,
+      c.token,
+    );
     return Promise.allSettled(
-      await client.sessions
+      await jupyterClient.sessions
         .list({ signal })
         .catch((err: unknown) => {
           // Swallow the sessions.list error as this is best-effort.
@@ -897,7 +903,10 @@ export class AssignmentManager implements Disposable {
         .then((sessions) =>
           sessions.map((session) =>
             session.id
-              ? client.sessions.delete({ session: session.id }, { signal })
+              ? jupyterClient.sessions.delete(
+                  { session: session.id },
+                  { signal },
+                )
               : Promise.resolve(),
           ),
         ),

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -762,18 +762,25 @@ export class AssignmentManager implements Disposable {
             );
             try {
               const rp = a.runtimeProxyInfo;
-              if (rp) {
-                const jupyterClient = ProxiedJupyterClient.withStaticConnection(
-                  rp.url,
-                  rp.token,
-                );
-                const sessions = await Promise.race([
-                  jupyterClient.sessions.list({ signal }),
-                  timeout.promise,
-                ]);
-                if (sessions.length === 1 && sessions[0].name?.length) {
-                  label = sessions[0].name;
-                }
+              if (!rp) {
+                return {
+                  label,
+                  endpoint: a.endpoint,
+                  variant: a.variant,
+                  accelerator: a.accelerator,
+                };
+              }
+
+              const jupyterClient = ProxiedJupyterClient.withStaticConnection(
+                rp.url,
+                rp.token,
+              );
+              const sessions = await Promise.race([
+                jupyterClient.sessions.list({ signal }),
+                timeout.promise,
+              ]);
+              if (sessions.length === 1 && sessions[0].name?.length) {
+                label = sessions[0].name;
               }
             } catch (error: unknown) {
               // The assignment may have been removed (e.g. via Colab web UI

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -761,10 +761,11 @@ export class AssignmentManager implements Disposable {
               `Listing sessions timeout exceeded for endpoint ${a.endpoint}`,
             );
             try {
-              if (a.runtimeProxyInfo) {
+              const rp = a.runtimeProxyInfo;
+              if (rp) {
                 const jupyterClient = ProxiedJupyterClient.withStaticConnection(
-                  a.runtimeProxyInfo.url,
-                  a.runtimeProxyInfo.token,
+                  rp.url,
+                  rp.token,
                 );
                 const sessions = await Promise.race([
                   jupyterClient.sessions.list({ signal }),

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -6,7 +6,7 @@
 
 import { randomUUID } from 'crypto';
 import { assert, expect } from 'chai';
-import fetch, { Headers, Request, Response } from 'node-fetch';
+import fetch, { Headers, Request } from 'node-fetch';
 import sinon, {
   SinonFakeTimers,
   SinonStubbedFunction,
@@ -27,7 +27,6 @@ import { ColaboratoryApi as OperationsApi } from '../colab/client/v2/generated/o
 import { REMOVE_SERVER } from '../colab/commands/constants';
 import {
   AcceleratorUnavailableError,
-  ColabRequestError,
   DenylistedError,
   InsufficientQuotaError,
   NotFoundError,
@@ -39,6 +38,10 @@ import {
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../colab/headers';
 import { Shape, SubscriptionTier, Variant } from '../colab/types';
+import {
+  FetchError as JupyterFetchError,
+  ResponseError as JupyterResponseError,
+} from '../jupyter/client/generated';
 import { telemetry } from '../telemetry';
 import { AssignmentOutcome, CommandSource } from '../telemetry/api';
 import { TestEventEmitter } from '../test/helpers/events';
@@ -110,6 +113,9 @@ describe('AssignmentManager', () => {
   let serverStorage: ServerStorage;
   let assignmentChangeListener: sinon.SinonStub<[AssignmentChangeEvent], void>;
   let assignmentManager: AssignmentManager;
+  let jupyterStaticConnectionStub: sinon.SinonStubbedFunction<
+    typeof ProxiedJupyterClient.withStaticConnection
+  >;
 
   /**
    * Set up the stubs to return the given assignments from both the Colab client
@@ -161,6 +167,10 @@ describe('AssignmentManager', () => {
     );
     assignmentChangeListener = sinon.stub();
     assignmentManager.onDidAssignmentsChange(assignmentChangeListener);
+    jupyterStaticConnectionStub = sinon.stub(
+      ProxiedJupyterClient,
+      'withStaticConnection',
+    );
   });
 
   afterEach(() => {
@@ -545,6 +555,96 @@ describe('AssignmentManager', () => {
   });
 
   describe('getServers', () => {
+    const ENDPOINT_WITH_SESSION_NAME = 'test-endpoint-with-name';
+    const ENDPOINT_WITHOUT_SESSION_NAME = 'test-endpoint-without-name';
+    const ENDPOINT_WITHOUT_SESSION = 'test-endpoint-without-session';
+    const URL_WITH_SESSION_NAME = 'https://test.url.with.session.name';
+    const URL_WITHOUT_SESSION_NAME = 'https://test.url.without.session.name';
+    const URL_WITHOUT_SESSION = 'https://test.url.without.session';
+    const PROXY_TOKEN = 'test-proxy-token';
+    const TEST_SESSION_NAME = 'test-session-name';
+    const UNKNOWN_REMOTE_SERVER_NAME = 'Untitled';
+
+    const assignmentWithName = {
+      endpoint: ENDPOINT_WITH_SESSION_NAME,
+      variant: Variant.DEFAULT,
+      machineShape: Shape.STANDARD,
+      accelerator: '',
+      runtimeProxyInfo: {
+        url: URL_WITH_SESSION_NAME,
+        token: PROXY_TOKEN,
+        tokenExpiresInSeconds: 3600,
+      },
+    };
+    const assignmentWithoutName = {
+      endpoint: ENDPOINT_WITHOUT_SESSION_NAME,
+      variant: Variant.DEFAULT,
+      machineShape: Shape.STANDARD,
+      accelerator: '',
+      runtimeProxyInfo: {
+        url: URL_WITHOUT_SESSION_NAME,
+        token: PROXY_TOKEN,
+        tokenExpiresInSeconds: 3600,
+      },
+    };
+    const assignmentWithoutSession = {
+      endpoint: ENDPOINT_WITHOUT_SESSION,
+      variant: Variant.DEFAULT,
+      machineShape: Shape.STANDARD,
+      accelerator: '',
+      runtimeProxyInfo: {
+        url: URL_WITHOUT_SESSION,
+        token: PROXY_TOKEN,
+        tokenExpiresInSeconds: 3600,
+      },
+    };
+    const defaultSession = {
+      id: '',
+      path: '',
+      type: '',
+      kernel: {
+        lastActivity: '',
+        executionState: '',
+        id: '',
+        name: '',
+        connections: 1,
+      },
+    };
+
+    let jupyterStubWithSessionName: JupyterClientStub;
+    let jupyterStubWithoutSessionName: JupyterClientStub;
+    let jupyterStubWithoutSession: JupyterClientStub;
+
+    beforeEach(() => {
+      jupyterStubWithSessionName = createJupyterClientStub();
+      jupyterStaticConnectionStub
+        .withArgs(URL_WITH_SESSION_NAME, PROXY_TOKEN)
+        .returns(jupyterStubWithSessionName);
+      jupyterStubWithSessionName.sessions.list.resolves([
+        {
+          ...defaultSession,
+          name: TEST_SESSION_NAME,
+        },
+      ]);
+
+      jupyterStubWithoutSessionName = createJupyterClientStub();
+      jupyterStaticConnectionStub
+        .withArgs(URL_WITHOUT_SESSION_NAME, PROXY_TOKEN)
+        .returns(jupyterStubWithoutSessionName);
+      jupyterStubWithoutSessionName.sessions.list.resolves([
+        {
+          ...defaultSession,
+          name: UNKNOWN_REMOTE_SERVER_NAME,
+        },
+      ]);
+
+      jupyterStubWithoutSession = createJupyterClientStub();
+      jupyterStaticConnectionStub
+        .withArgs(URL_WITHOUT_SESSION, PROXY_TOKEN)
+        .returns(jupyterStubWithoutSession);
+      jupyterStubWithoutSession.sessions.list.resolves([]);
+    });
+
     it('throws after being disposed', async () => {
       assignmentManager.dispose();
 
@@ -725,40 +825,6 @@ describe('AssignmentManager', () => {
       });
     });
 
-    const endpointWithName = 'test-endpoint-with-name';
-    const endpointWithoutName = 'test-endpoint-without-name';
-    const endpointWithoutSession = 'test-endpoint-without-session';
-    const assignmentWithName = {
-      endpoint: endpointWithName,
-      variant: Variant.DEFAULT,
-      machineShape: Shape.STANDARD,
-      accelerator: '',
-    };
-    const assignmentWithoutName = {
-      endpoint: endpointWithoutName,
-      variant: Variant.DEFAULT,
-      machineShape: Shape.STANDARD,
-      accelerator: '',
-    };
-    const assignmentWithoutSession = {
-      endpoint: endpointWithoutSession,
-      variant: Variant.DEFAULT,
-      machineShape: Shape.STANDARD,
-      accelerator: '',
-    };
-    const defaultSession = {
-      id: '',
-      path: '',
-      type: '',
-      kernel: {
-        lastActivity: '',
-        executionState: '',
-        id: '',
-        name: '',
-        connections: 1,
-      },
-    };
-
     describe('from external', () => {
       it('returns unowned servers', async () => {
         // Given 3 total assignments
@@ -767,19 +833,10 @@ describe('AssignmentManager', () => {
           assignmentWithoutName,
           assignmentWithoutSession,
         ]);
-        colabClientStub.listSessions.withArgs(endpointWithName).resolves([
-          {
-            ...defaultSession,
-            name: 'test-session-name',
-          },
-        ]);
-        colabClientStub.listSessions
-          .withArgs(endpointWithoutSession)
-          .resolves([]);
         // One of the assignments was assigned within VS Code extension
         const assignedServer = {
           ...defaultServer,
-          endpoint: endpointWithoutName,
+          endpoint: ENDPOINT_WITHOUT_SESSION_NAME,
         };
         await serverStorage.store([assignedServer]);
 
@@ -789,21 +846,21 @@ describe('AssignmentManager', () => {
         // Then only 2 unowned external servers are returned
         expect(results).to.deep.equal([
           {
-            label: 'test-session-name',
-            endpoint: endpointWithName,
+            label: TEST_SESSION_NAME,
+            endpoint: ENDPOINT_WITH_SESSION_NAME,
             variant: Variant.DEFAULT,
             accelerator: '',
           },
           {
-            label: 'Untitled',
-            endpoint: endpointWithoutSession,
+            label: UNKNOWN_REMOTE_SERVER_NAME,
+            endpoint: ENDPOINT_WITHOUT_SESSION,
             variant: Variant.DEFAULT,
             accelerator: '',
           },
         ]);
       });
 
-      it('drops orphan unowned servers whose sessions endpoint returns 404', async () => {
+      it('drops orphan unowned servers whose Jupyter client throws a FetchError', async () => {
         // Simulates a race where the orphan assignment is deleted (e.g. via
         // Colab web or another VS Code instance sharing the account) between
         // listing assignments and listing its sessions.
@@ -811,98 +868,43 @@ describe('AssignmentManager', () => {
           assignmentWithName,
           assignmentWithoutSession,
         ]);
-        colabClientStub.listSessions.withArgs(endpointWithName).resolves([
-          {
-            ...defaultSession,
-            name: 'test-session-name',
-          },
-        ]);
-        colabClientStub.listSessions
-          .withArgs(endpointWithoutSession)
-          .rejects(
-            new ColabRequestError(
-              new Request('https://example.com'),
-              new Response(undefined, { status: 404 }),
-            ),
-          );
+        jupyterStubWithoutSession.sessions.list.rejects(
+          new JupyterFetchError(new Error('network error')),
+        );
 
         const results = await assignmentManager.getServers('external');
 
         expect(results).to.deep.equal([
           {
-            label: 'test-session-name',
-            endpoint: endpointWithName,
+            label: TEST_SESSION_NAME,
+            endpoint: ENDPOINT_WITH_SESSION_NAME,
             variant: Variant.DEFAULT,
             accelerator: '',
           },
         ]);
       });
 
-      it('falls back to placeholder label when listing sessions throws a non-404', async () => {
+      it('falls back to placeholder label when sessions.list throws a non-FetchError', async () => {
         colabClientStub.listAssignments.resolves([
           assignmentWithName,
           assignmentWithoutSession,
         ]);
-        colabClientStub.listSessions.withArgs(endpointWithName).resolves([
-          {
-            ...defaultSession,
-            name: 'test-session-name',
-          },
-        ]);
-        colabClientStub.listSessions
-          .withArgs(endpointWithoutSession)
-          .rejects(
-            new ColabRequestError(
-              new Request('https://example.com'),
-              new Response(undefined, { status: 500 }),
-            ),
-          );
+        jupyterStubWithoutSession.sessions.list.rejects(
+          new JupyterResponseError(new Response(undefined, { status: 500 })),
+        );
 
         const results = await assignmentManager.getServers('external');
 
         expect(results).to.deep.equal([
           {
-            label: 'test-session-name',
-            endpoint: endpointWithName,
+            label: TEST_SESSION_NAME,
+            endpoint: ENDPOINT_WITH_SESSION_NAME,
             variant: Variant.DEFAULT,
             accelerator: '',
           },
           {
-            label: 'Untitled',
-            endpoint: endpointWithoutSession,
-            variant: Variant.DEFAULT,
-            accelerator: '',
-          },
-        ]);
-      });
-
-      it('falls back to placeholder label when listing sessions throws a non-ColabRequestError', async () => {
-        colabClientStub.listAssignments.resolves([
-          assignmentWithName,
-          assignmentWithoutSession,
-        ]);
-        colabClientStub.listSessions.withArgs(endpointWithName).resolves([
-          {
-            ...defaultSession,
-            name: 'test-session-name',
-          },
-        ]);
-        colabClientStub.listSessions
-          .withArgs(endpointWithoutSession)
-          .rejects(new Error('network kaput'));
-
-        const results = await assignmentManager.getServers('external');
-
-        expect(results).to.deep.equal([
-          {
-            label: 'test-session-name',
-            endpoint: endpointWithName,
-            variant: Variant.DEFAULT,
-            accelerator: '',
-          },
-          {
-            label: 'Untitled',
-            endpoint: endpointWithoutSession,
+            label: UNKNOWN_REMOTE_SERVER_NAME,
+            endpoint: ENDPOINT_WITHOUT_SESSION,
             variant: Variant.DEFAULT,
             accelerator: '',
           },
@@ -910,9 +912,9 @@ describe('AssignmentManager', () => {
       });
     });
 
-    it('falls back to placeholder label when listing sessions times out', async () => {
+    it('falls back to placeholder label when sessions.list times out', async () => {
       colabClientStub.listAssignments.resolves([assignmentWithName]);
-      colabClientStub.listSessions.callsFake(async () => {
+      jupyterStubWithSessionName.sessions.list.callsFake(async () => {
         // Block listSessions to trigger the timeout.
         await new Promise((resolve) =>
           setTimeout(resolve, LIST_UNOWNED_SESSIONS_TIMEOUT_MS + 100),
@@ -930,8 +932,8 @@ describe('AssignmentManager', () => {
 
       await expect(resultsPromise).to.eventually.deep.equal([
         {
-          label: 'Untitled',
-          endpoint: endpointWithName,
+          label: UNKNOWN_REMOTE_SERVER_NAME,
+          endpoint: ENDPOINT_WITH_SESSION_NAME,
           variant: Variant.DEFAULT,
           accelerator: '',
         },
@@ -946,19 +948,10 @@ describe('AssignmentManager', () => {
           assignmentWithoutName,
           assignmentWithoutSession,
         ]);
-        colabClientStub.listSessions.withArgs(endpointWithName).resolves([
-          {
-            ...defaultSession,
-            name: 'test-session-name',
-          },
-        ]);
-        colabClientStub.listSessions
-          .withArgs(endpointWithoutSession)
-          .resolves([]);
         // One of the assignments was assigned within VS Code extension
         const assignedServer = {
           ...defaultServer,
-          endpoint: endpointWithoutName,
+          endpoint: ENDPOINT_WITHOUT_SESSION_NAME,
         };
         await serverStorage.store([assignedServer]);
 
@@ -971,14 +964,14 @@ describe('AssignmentManager', () => {
         ]);
         expect(results.unowned).to.deep.equal([
           {
-            label: 'test-session-name',
-            endpoint: endpointWithName,
+            label: TEST_SESSION_NAME,
+            endpoint: ENDPOINT_WITH_SESSION_NAME,
             variant: Variant.DEFAULT,
             accelerator: '',
           },
           {
-            label: 'Untitled',
-            endpoint: endpointWithoutSession,
+            label: UNKNOWN_REMOTE_SERVER_NAME,
+            endpoint: ENDPOINT_WITHOUT_SESSION,
             variant: Variant.DEFAULT,
             accelerator: '',
           },
@@ -991,21 +984,6 @@ describe('AssignmentManager', () => {
           assignmentWithoutName,
           assignmentWithoutSession,
         ]);
-        colabClientStub.listSessions.withArgs(endpointWithName).resolves([
-          {
-            ...defaultSession,
-            name: 'test-session-name',
-          },
-        ]);
-        colabClientStub.listSessions.withArgs(endpointWithoutName).resolves([
-          {
-            ...defaultSession,
-            name: '',
-          },
-        ]);
-        colabClientStub.listSessions
-          .withArgs(endpointWithoutSession)
-          .resolves([]);
         await serverStorage.store([]);
 
         const results = await assignmentManager.getServers('all');
@@ -1014,20 +992,20 @@ describe('AssignmentManager', () => {
           assigned: [],
           unowned: [
             {
-              label: 'test-session-name',
-              endpoint: endpointWithName,
+              label: TEST_SESSION_NAME,
+              endpoint: ENDPOINT_WITH_SESSION_NAME,
               variant: Variant.DEFAULT,
               accelerator: '',
             },
             {
-              label: 'Untitled',
-              endpoint: endpointWithoutName,
+              label: UNKNOWN_REMOTE_SERVER_NAME,
+              endpoint: ENDPOINT_WITHOUT_SESSION_NAME,
               variant: Variant.DEFAULT,
               accelerator: '',
             },
             {
-              label: 'Untitled',
-              endpoint: endpointWithoutSession,
+              label: UNKNOWN_REMOTE_SERVER_NAME,
+              endpoint: ENDPOINT_WITHOUT_SESSION,
               variant: Variant.DEFAULT,
               accelerator: '',
             },
@@ -1043,15 +1021,15 @@ describe('AssignmentManager', () => {
         ]);
         const assignedServer1 = {
           ...defaultServer,
-          endpoint: endpointWithName,
+          endpoint: ENDPOINT_WITH_SESSION_NAME,
         };
         const assignedServer2 = {
           ...defaultServer,
-          endpoint: endpointWithoutName,
+          endpoint: ENDPOINT_WITHOUT_SESSION_NAME,
         };
         const assignedServer3 = {
           ...defaultServer,
-          endpoint: endpointWithoutSession,
+          endpoint: ENDPOINT_WITHOUT_SESSION,
         };
         await serverStorage.store([
           assignedServer1,
@@ -1073,7 +1051,7 @@ describe('AssignmentManager', () => {
         colabClientStub.listAssignments.resolves([assignmentWithName]);
         const assignedServer = {
           ...defaultServer,
-          endpoint: endpointWithName,
+          endpoint: ENDPOINT_WITH_SESSION_NAME,
         };
         const noLongerAssignedServer = {
           ...defaultServer,
@@ -1641,9 +1619,11 @@ describe('AssignmentManager', () => {
       beforeEach(async () => {
         await serverStorage.store([defaultServer]);
         jupyterStub = createJupyterClientStub();
-        sinon
-          .stub(ProxiedJupyterClient, 'withStaticConnection')
-          .withArgs(defaultServer)
+        jupyterStaticConnectionStub
+          .withArgs(
+            defaultServer.connectionInformation.baseUrl,
+            defaultServer.connectionInformation.token,
+          )
           .returns(jupyterStub);
       });
 

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -555,47 +555,31 @@ describe('AssignmentManager', () => {
   });
 
   describe('getServers', () => {
-    const ENDPOINT_WITH_SESSION_NAME = 'test-endpoint-with-name';
-    const ENDPOINT_WITHOUT_SESSION_NAME = 'test-endpoint-without-name';
-    const ENDPOINT_WITHOUT_SESSION = 'test-endpoint-without-session';
-    const URL_WITH_SESSION_NAME = 'https://test.url.with.session.name';
-    const URL_WITHOUT_SESSION_NAME = 'https://test.url.without.session.name';
-    const URL_WITHOUT_SESSION = 'https://test.url.without.session';
-    const PROXY_TOKEN = 'test-proxy-token';
     const TEST_SESSION_NAME = 'test-session-name';
     const UNKNOWN_REMOTE_SERVER_NAME = 'Untitled';
 
     const assignmentWithName = {
-      endpoint: ENDPOINT_WITH_SESSION_NAME,
-      variant: Variant.DEFAULT,
-      machineShape: Shape.STANDARD,
-      accelerator: '',
+      ...defaultAssignment,
+      endpoint: 'test-endpoint-with-name',
       runtimeProxyInfo: {
-        url: URL_WITH_SESSION_NAME,
-        token: PROXY_TOKEN,
-        tokenExpiresInSeconds: 3600,
+        ...defaultAssignment.runtimeProxyInfo,
+        url: 'https://test.url.with.session.name',
       },
     };
     const assignmentWithoutName = {
-      endpoint: ENDPOINT_WITHOUT_SESSION_NAME,
-      variant: Variant.DEFAULT,
-      machineShape: Shape.STANDARD,
-      accelerator: '',
+      ...defaultAssignment,
+      endpoint: 'test-endpoint-without-name',
       runtimeProxyInfo: {
-        url: URL_WITHOUT_SESSION_NAME,
-        token: PROXY_TOKEN,
-        tokenExpiresInSeconds: 3600,
+        ...defaultAssignment.runtimeProxyInfo,
+        url: 'https://test.url.without.session.name',
       },
     };
     const assignmentWithoutSession = {
-      endpoint: ENDPOINT_WITHOUT_SESSION,
-      variant: Variant.DEFAULT,
-      machineShape: Shape.STANDARD,
-      accelerator: '',
+      ...defaultAssignment,
+      endpoint: 'test-endpoint-without-session',
       runtimeProxyInfo: {
-        url: URL_WITHOUT_SESSION,
-        token: PROXY_TOKEN,
-        tokenExpiresInSeconds: 3600,
+        ...defaultAssignment.runtimeProxyInfo,
+        url: 'https://test.url.without.session',
       },
     };
     const defaultSession = {
@@ -618,7 +602,10 @@ describe('AssignmentManager', () => {
     beforeEach(() => {
       jupyterStubWithSessionName = createJupyterClientStub();
       jupyterStaticConnectionStub
-        .withArgs(URL_WITH_SESSION_NAME, PROXY_TOKEN)
+        .withArgs(
+          assignmentWithName.runtimeProxyInfo.url,
+          assignmentWithName.runtimeProxyInfo.token,
+        )
         .returns(jupyterStubWithSessionName);
       jupyterStubWithSessionName.sessions.list.resolves([
         {
@@ -629,7 +616,10 @@ describe('AssignmentManager', () => {
 
       jupyterStubWithoutSessionName = createJupyterClientStub();
       jupyterStaticConnectionStub
-        .withArgs(URL_WITHOUT_SESSION_NAME, PROXY_TOKEN)
+        .withArgs(
+          assignmentWithoutName.runtimeProxyInfo.url,
+          assignmentWithoutName.runtimeProxyInfo.token,
+        )
         .returns(jupyterStubWithoutSessionName);
       jupyterStubWithoutSessionName.sessions.list.resolves([
         {
@@ -640,7 +630,10 @@ describe('AssignmentManager', () => {
 
       jupyterStubWithoutSession = createJupyterClientStub();
       jupyterStaticConnectionStub
-        .withArgs(URL_WITHOUT_SESSION, PROXY_TOKEN)
+        .withArgs(
+          assignmentWithoutSession.runtimeProxyInfo.url,
+          assignmentWithoutSession.runtimeProxyInfo.token,
+        )
         .returns(jupyterStubWithoutSession);
       jupyterStubWithoutSession.sessions.list.resolves([]);
     });
@@ -836,7 +829,7 @@ describe('AssignmentManager', () => {
         // One of the assignments was assigned within VS Code extension
         const assignedServer = {
           ...defaultServer,
-          endpoint: ENDPOINT_WITHOUT_SESSION_NAME,
+          endpoint: assignmentWithoutName.endpoint,
         };
         await serverStorage.store([assignedServer]);
 
@@ -847,15 +840,15 @@ describe('AssignmentManager', () => {
         expect(results).to.deep.equal([
           {
             label: TEST_SESSION_NAME,
-            endpoint: ENDPOINT_WITH_SESSION_NAME,
-            variant: Variant.DEFAULT,
-            accelerator: '',
+            endpoint: assignmentWithName.endpoint,
+            variant: assignmentWithName.variant,
+            accelerator: assignmentWithName.accelerator,
           },
           {
             label: UNKNOWN_REMOTE_SERVER_NAME,
-            endpoint: ENDPOINT_WITHOUT_SESSION,
-            variant: Variant.DEFAULT,
-            accelerator: '',
+            endpoint: assignmentWithoutSession.endpoint,
+            variant: assignmentWithoutSession.variant,
+            accelerator: assignmentWithoutSession.accelerator,
           },
         ]);
       });
@@ -877,9 +870,9 @@ describe('AssignmentManager', () => {
         expect(results).to.deep.equal([
           {
             label: TEST_SESSION_NAME,
-            endpoint: ENDPOINT_WITH_SESSION_NAME,
-            variant: Variant.DEFAULT,
-            accelerator: '',
+            endpoint: assignmentWithName.endpoint,
+            variant: assignmentWithName.variant,
+            accelerator: assignmentWithName.accelerator,
           },
         ]);
       });
@@ -898,15 +891,15 @@ describe('AssignmentManager', () => {
         expect(results).to.deep.equal([
           {
             label: TEST_SESSION_NAME,
-            endpoint: ENDPOINT_WITH_SESSION_NAME,
-            variant: Variant.DEFAULT,
-            accelerator: '',
+            endpoint: assignmentWithName.endpoint,
+            variant: assignmentWithName.variant,
+            accelerator: assignmentWithName.accelerator,
           },
           {
             label: UNKNOWN_REMOTE_SERVER_NAME,
-            endpoint: ENDPOINT_WITHOUT_SESSION,
-            variant: Variant.DEFAULT,
-            accelerator: '',
+            endpoint: assignmentWithoutSession.endpoint,
+            variant: assignmentWithoutSession.variant,
+            accelerator: assignmentWithoutSession.accelerator,
           },
         ]);
       });
@@ -933,9 +926,9 @@ describe('AssignmentManager', () => {
       await expect(resultsPromise).to.eventually.deep.equal([
         {
           label: UNKNOWN_REMOTE_SERVER_NAME,
-          endpoint: ENDPOINT_WITH_SESSION_NAME,
-          variant: Variant.DEFAULT,
-          accelerator: '',
+          endpoint: assignmentWithName.endpoint,
+          variant: assignmentWithName.variant,
+          accelerator: assignmentWithName.accelerator,
         },
       ]);
     });
@@ -951,7 +944,7 @@ describe('AssignmentManager', () => {
         // One of the assignments was assigned within VS Code extension
         const assignedServer = {
           ...defaultServer,
-          endpoint: ENDPOINT_WITHOUT_SESSION_NAME,
+          endpoint: assignmentWithoutName.endpoint,
         };
         await serverStorage.store([assignedServer]);
 
@@ -965,15 +958,15 @@ describe('AssignmentManager', () => {
         expect(results.unowned).to.deep.equal([
           {
             label: TEST_SESSION_NAME,
-            endpoint: ENDPOINT_WITH_SESSION_NAME,
-            variant: Variant.DEFAULT,
-            accelerator: '',
+            endpoint: assignmentWithName.endpoint,
+            variant: assignmentWithName.variant,
+            accelerator: assignmentWithName.accelerator,
           },
           {
             label: UNKNOWN_REMOTE_SERVER_NAME,
-            endpoint: ENDPOINT_WITHOUT_SESSION,
-            variant: Variant.DEFAULT,
-            accelerator: '',
+            endpoint: assignmentWithoutSession.endpoint,
+            variant: assignmentWithoutSession.variant,
+            accelerator: assignmentWithoutSession.accelerator,
           },
         ]);
       });
@@ -993,21 +986,21 @@ describe('AssignmentManager', () => {
           unowned: [
             {
               label: TEST_SESSION_NAME,
-              endpoint: ENDPOINT_WITH_SESSION_NAME,
-              variant: Variant.DEFAULT,
-              accelerator: '',
+              endpoint: assignmentWithName.endpoint,
+              variant: assignmentWithName.variant,
+              accelerator: assignmentWithName.accelerator,
             },
             {
               label: UNKNOWN_REMOTE_SERVER_NAME,
-              endpoint: ENDPOINT_WITHOUT_SESSION_NAME,
-              variant: Variant.DEFAULT,
-              accelerator: '',
+              endpoint: assignmentWithoutName.endpoint,
+              variant: assignmentWithoutName.variant,
+              accelerator: assignmentWithoutName.accelerator,
             },
             {
               label: UNKNOWN_REMOTE_SERVER_NAME,
-              endpoint: ENDPOINT_WITHOUT_SESSION,
-              variant: Variant.DEFAULT,
-              accelerator: '',
+              endpoint: assignmentWithoutSession.endpoint,
+              variant: assignmentWithoutSession.variant,
+              accelerator: assignmentWithoutSession.accelerator,
             },
           ],
         });
@@ -1021,15 +1014,15 @@ describe('AssignmentManager', () => {
         ]);
         const assignedServer1 = {
           ...defaultServer,
-          endpoint: ENDPOINT_WITH_SESSION_NAME,
+          endpoint: assignmentWithName.endpoint,
         };
         const assignedServer2 = {
           ...defaultServer,
-          endpoint: ENDPOINT_WITHOUT_SESSION_NAME,
+          endpoint: assignmentWithoutName.endpoint,
         };
         const assignedServer3 = {
           ...defaultServer,
-          endpoint: ENDPOINT_WITHOUT_SESSION,
+          endpoint: assignmentWithoutSession.endpoint,
         };
         await serverStorage.store([
           assignedServer1,
@@ -1051,7 +1044,7 @@ describe('AssignmentManager', () => {
         colabClientStub.listAssignments.resolves([assignmentWithName]);
         const assignedServer = {
           ...defaultServer,
-          endpoint: ENDPOINT_WITH_SESSION_NAME,
+          endpoint: assignmentWithName.endpoint,
         };
         const noLongerAssignedServer = {
           ...defaultServer,

--- a/src/jupyter/client/index.ts
+++ b/src/jupyter/client/index.ts
@@ -110,16 +110,18 @@ export class ProxiedJupyterClient implements JupyterClient {
 
   /**
    * Initializes a {@link ProxiedJupyterClient} with static connection
-   * information corresponding to the provided server. In other words, the proxy
+   * URL and proxy token of the provided server. In other words, the same proxy
    * token is used on all requests and is not refreshed.
    *
-   * @param server - The Colab server to connect to.
+   * @param url - The Colab server URL to connect to.
+   * @param proxyToken - The Colab runtime proxy token.
    * @returns a {@link ProxiedJupyterClient} to the specified server.
    */
-  static withStaticConnection(server: ColabAssignedServer): JupyterClient {
-    return new ProxiedJupyterClient(server.connectionInformation.baseUrl, () =>
-      Promise.resolve(server.connectionInformation.token),
-    );
+  static withStaticConnection(
+    url: string | Uri,
+    proxyToken: string,
+  ): JupyterClient {
+    return new ProxiedJupyterClient(url, () => Promise.resolve(proxyToken));
   }
 
   /**

--- a/src/jupyter/client/index.unit.test.ts
+++ b/src/jupyter/client/index.unit.test.ts
@@ -68,10 +68,21 @@ describe('ProxiedJupyterClient', () => {
   });
 
   const clients = [
-    ['static', () => ProxiedJupyterClient.withStaticConnection(DEFAULT_SERVER)],
+    [
+      'static',
+      () =>
+        ProxiedJupyterClient.withStaticConnection(
+          DEFAULT_SERVER.connectionInformation.baseUrl,
+          DEFAULT_SERVER.connectionInformation.token,
+        ),
+    ],
     [
       'refreshing',
-      () => ProxiedJupyterClient.withStaticConnection(DEFAULT_SERVER),
+      () =>
+        ProxiedJupyterClient.withRefreshingConnection(
+          DEFAULT_SERVER,
+          new TestEventEmitter<AssignmentChangeEvent>().event,
+        ),
     ],
   ] as const;
   for (const factoryFn of clients) {


### PR DESCRIPTION
**Why**? During public API migration, I found that the current `listSessions` call via TFE endpoint was consistently hanging / failing (likely started since cl/922783892). Since TFE is on the deprecation path and this API is also available as part of the standard [Jupyter REST API](https://jupyter-server.readthedocs.io/en/latest/developers/rest-api.html#get--api-sessions), I figure it is best to migrate.

This change is safe because the existing call is already consistently hanging/failing and this call in `removeServer` to get unowned servers is considered best-effort, hence doing it without a feature flag.

Screencasts:
* [Before](https://screencast.googleplex.com/cast/NjU0ODQyNTQ5NDQ5NTIzMnwzYzFjZGY3MC03OA)
* [After](https://screencast.googleplex.com/cast/NjcyNDEwNDY1NTczMjczNnxjMDFhYjAxNS1hNg)

---

As part of this PR, I also:
* Cleaned up the old `listSessions` implementation since `removeServer` was the only call site.
* Changed `ProxiedJupyterClient.withStaticConnection` signature to be more generic to accept connection info from different source shapes.
* Added a trace log in `removeServer` to log all resolved servers for future tracing and debugging purposes.