### PR TITLE
build: bump version to 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.4",
         "@jupyterlab/services": "^7.5.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
Changes since last bump:

- feat: migrate `unassignServer` to `DeleteRuntime` (#660)
- chore: regenerate Colab OpenAPI clients (#659)
- feat: migrate `refreshConnection` to `GetRuntime` (#653)
- feat: migrate `AssignmentManager` to `ListRuntimes` (#652)
- build(deps-dev): bump linkify-it from 5.0.1 to 5.0.2 (#651)
- build(deps): bump fast-uri from 3.1.2 to 3.1.4 (#650)
- feat: migrate `assignServer` to `CreateRuntime` (#639)
- fix: `removeServer` to call Jupyter `sessions.list` instead of TFE (#646)
- chore: regen Colab v2 client with `Runtime.version` (#644)
- chore: bump `google-auth-library` and `uuid` to latest (#643)
- fix: make Prettier checks work on Windows (#641)
- feat: regen Colab v2 client with `WaitOperation` (#640)
- chore: regen Colab v2 client with `endpoint` and `ErrorInfo` (#638)
- refactor: lift error definitions to `colab/errors.ts` (#636)
- chore: regenerate `Subscription.tier` as required field (#632)
- chore: enable `jsonRecursiveSort` on OpenAPI JSON docs (#634)
- refactor: sort Colab OpenAPI JSON spec documents (#633)
- feat: migrate `getAvailableServerDescriptors` to invoke public API (#630)
- chore: clean up generated Jupyter client (#629)
- feat: migrate `ColabJupyterServerProvider` to invoke public API (#628)
- feat: new ColabApiClient with openapi-generator (#626)
- chore: move `colab/client.ts` to `colab/client/v1` (#627)
- feat: generate Colab OpenAPI schema (#623)
- build(deps): bump js-yaml and @textlint/linter-formatter (#618)
- build(deps-dev): bump markdown-it from 14.1.1 to 14.2.0 (#617)
- build(deps): bump ws (#619)
- fix: failing `upload file` E2E test (#622)
- build(deps-dev): bump undici from 7.24.1 to 7.28.0 (#621)
- build(deps): bump form-data from 4.0.5 to 4.0.6 (#616)
- build(deps-dev): bump esbuild, esbuild-node-externals and tsx (#614)
- test: update e2e test email selector (#613)
- build(deps-dev): bump qs from 6.14.2 to 6.15.2 (#602)
- build(deps): bump tmp from 0.2.5 to 0.2.7 (#605)
- test: guard QuickPick interactions against orphaned pickers (#599)
- build(deps): bump fast-uri from 3.0.6 to 3.1.2 (#596)
- build(deps-dev): bump axios from 1.15.0 to 1.16.0 (#595)
- build(deps-dev): bump ip-address from 10.1.0 to 10.2.0 (#594)