### PR TITLE
feat: log `experiment_ids` in all telemetry events

### DIFF
--- a/src/colab/client/v1/api.ts
+++ b/src/colab/client/v1/api.ts
@@ -599,6 +599,7 @@ export const ExperimentStateSchema = z.object({
       return new Map(entries) as Map<ExperimentFlag, ExperimentFlagValue>;
     })
     .optional(),
+  selectedIds: z.array(z.int32()).optional(),
 });
 /** The experiment state response. */
 export type ExperimentState = z.infer<typeof ExperimentStateSchema>;

--- a/src/colab/client/v1/api.ts
+++ b/src/colab/client/v1/api.ts
@@ -599,7 +599,8 @@ export const ExperimentStateSchema = z.object({
       return new Map(entries) as Map<ExperimentFlag, ExperimentFlagValue>;
     })
     .optional(),
-  selectedIds: z.array(z.int32()).optional(),
+  /** The selected experiment IDs. */
+  selectedIds: z.array(z.number()).optional(),
 });
 /** The experiment state response. */
 export type ExperimentState = z.infer<typeof ExperimentStateSchema>;

--- a/src/colab/experiment-state.ts
+++ b/src/colab/experiment-state.ts
@@ -156,9 +156,7 @@ function setFlagForTest(
  *
  * @param ids - The experiment IDs to override.
  */
-function setExperimentIdsForTest(
-  ids: readonly number[],
-): void {
+function setExperimentIdsForTest(ids: readonly number[]): void {
   experimentIds = ids;
 }
 

--- a/src/colab/experiment-state.ts
+++ b/src/colab/experiment-state.ts
@@ -25,6 +25,15 @@ export function getFlag(flag: ExperimentFlag): ExperimentFlagValue {
   return flags.get(flag) ?? EXPERIMENT_FLAG_DEFAULT_VALUES[flag];
 }
 
+/**
+ * Gets the list of selected experiment IDs.
+ *
+ * @returns A list of experiment IDs.
+ */
+export function getExperimentIds(): readonly number[] {
+  return experimentIds;
+}
+
 const REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes.
 const REFRESH_TIMEOUT_MS = 30 * 1000; // 30 seconds.
 
@@ -44,6 +53,7 @@ export class ExperimentStateProvider implements Toggleable, Disposable {
   constructor(private readonly client: ColabClient) {
     // Reset experiment flags.
     flags = new Map<ExperimentFlag, ExperimentFlagValue>();
+    experimentIds = [];
     this.refreshPoller = new SequentialTaskRunner(
       {
         intervalTimeoutMs: REFRESH_INTERVAL_MS,
@@ -114,6 +124,7 @@ export class ExperimentStateProvider implements Toggleable, Disposable {
       );
       if (result.experiments) {
         flags = result.experiments;
+        experimentIds = result.selectedIds ?? [];
         log.trace(
           `Experiment state updated while ${requireAccessToken ? 'authorized' : 'not authorized'}:`,
           Object.fromEntries(flags),
@@ -140,9 +151,21 @@ function setFlagForTest(
   flags = newFlags;
 }
 
-/** Resets the experiment flags for testing. */
-function resetFlagsForTest(): void {
+/**
+ * Sets the selected experiment IDs for testing.
+ *
+ * @param ids - The experiment IDs to override.
+ */
+function setExperimentIdsForTest(
+  ids: readonly number[],
+): void {
+  experimentIds = ids;
+}
+
+/** Resets the experiment flags and selected experiment IDs for testing. */
+function resetExperimentsForTest(): void {
   flags = new Map();
+  experimentIds = [];
 }
 
 let flags: ReadonlyMap<ExperimentFlag, ExperimentFlagValue> = new Map<
@@ -150,8 +173,11 @@ let flags: ReadonlyMap<ExperimentFlag, ExperimentFlagValue> = new Map<
   ExperimentFlagValue
 >();
 
+let experimentIds: readonly number[] = [];
+
 export const TEST_ONLY = {
   setFlagForTest,
-  resetFlagsForTest,
+  setExperimentIdsForTest,
+  resetExperimentsForTest,
   REFRESH_INTERVAL_MS,
 };

--- a/src/colab/experiment-state.ts
+++ b/src/colab/experiment-state.ts
@@ -122,11 +122,16 @@ export class ExperimentStateProvider implements Toggleable, Disposable {
         requireAccessToken,
         signal,
       );
+      experimentIds = result.selectedIds ?? [];
+      log.trace(
+        `Selected experiment IDs updated while ${requireAccessToken ? 'authorized' : 'not authorized'}:`,
+        experimentIds,
+      );
+
       if (result.experiments) {
         flags = result.experiments;
-        experimentIds = result.selectedIds ?? [];
         log.trace(
-          `Experiment state updated while ${requireAccessToken ? 'authorized' : 'not authorized'}:`,
+          `Experiment flags updated while ${requireAccessToken ? 'authorized' : 'not authorized'}:`,
           Object.fromEntries(flags),
         );
       }

--- a/src/colab/experiment-state.unit.test.ts
+++ b/src/colab/experiment-state.unit.test.ts
@@ -53,6 +53,20 @@ describe('ExperimentStateProvider', () => {
   });
 
   const TEST_FLAG_NAME = ExperimentFlag.RuntimeVersionNames;
+  const authStates = [
+    {
+      withAuth: true,
+      trigger: (provider: ExperimentStateProvider) => {
+        provider.on();
+      },
+    },
+    {
+      withAuth: false,
+      trigger: (provider: ExperimentStateProvider) => {
+        provider.off();
+      },
+    },
+  ];
   const tests = [
     {
       name: 'fetches flags with undefined selected IDs',
@@ -86,46 +100,26 @@ describe('ExperimentStateProvider', () => {
     },
   ];
 
-  describe('when auth turned on', () => {
-    tests.forEach((t) => {
-      it(t.name, async () => {
-        const getExperimentStateRanPromise = stubGetExperimentStateResponse(
-          t.experiments,
-          t.selectedIds,
-        );
+  authStates.forEach(({ withAuth, trigger }) => {
+    describe(`when auth turned ${withAuth ? 'on' : 'off'}`, () => {
+      tests.forEach((t) => {
+        it(t.name, async () => {
+          const getExperimentStateRanPromise = stubGetExperimentStateResponse(
+            t.experiments,
+            t.selectedIds,
+          );
 
-        provider.on();
+          trigger(provider);
 
-        await expect(getExperimentStateRanPromise).to.eventually.be.fulfilled;
-        sinon.assert.calledOnceWithExactly(
-          colabClientStub.getExperimentState,
-          true,
-          sinon.match.any,
-        );
-        expect(getFlag(TEST_FLAG_NAME)).to.deep.equal(t.expectedFlagValue);
-        expect(getExperimentIds()).to.deep.equal(t.expectedExperimentIds);
-      });
-    });
-  });
-
-  describe('when auth turned off', () => {
-    tests.forEach((t) => {
-      it(t.name, async () => {
-        const getExperimentStateRanPromise = stubGetExperimentStateResponse(
-          t.experiments,
-          t.selectedIds,
-        );
-
-        provider.off();
-
-        await expect(getExperimentStateRanPromise).to.eventually.be.fulfilled;
-        sinon.assert.calledOnceWithExactly(
-          colabClientStub.getExperimentState,
-          false,
-          sinon.match.any,
-        );
-        expect(getFlag(TEST_FLAG_NAME)).to.deep.equal(t.expectedFlagValue);
-        expect(getExperimentIds()).to.deep.equal(t.expectedExperimentIds);
+          await expect(getExperimentStateRanPromise).to.eventually.be.fulfilled;
+          sinon.assert.calledOnceWithExactly(
+            colabClientStub.getExperimentState,
+            withAuth,
+            sinon.match.any,
+          );
+          expect(getFlag(TEST_FLAG_NAME)).to.deep.equal(t.expectedFlagValue);
+          expect(getExperimentIds()).to.deep.equal(t.expectedExperimentIds);
+        });
       });
     });
   });

--- a/src/colab/experiment-state.unit.test.ts
+++ b/src/colab/experiment-state.unit.test.ts
@@ -118,7 +118,6 @@ describe('ExperimentStateProvider', () => {
 
   it('returns empty experiment IDs when no IDs are returned', async () => {
     const getExperimentStateRanPromise = stubGetExperimentStateResponse(
-      // Ensure flags are empty
       new Map(),
     );
 

--- a/src/colab/experiment-state.unit.test.ts
+++ b/src/colab/experiment-state.unit.test.ts
@@ -52,42 +52,82 @@ describe('ExperimentStateProvider', () => {
     expect(getExperimentIds()).to.be.empty;
   });
 
-  it('fetches experiment state with auth when turned on', async () => {
-    const expectedExperimentIds = [1, 2, 3];
-    const getExperimentStateRanPromise = stubGetExperimentStateResponse(
-      new Map([[ExperimentFlag.RuntimeVersionNames, true]]),
-      expectedExperimentIds,
-    );
+  const TEST_FLAG_NAME = ExperimentFlag.RuntimeVersionNames;
+  const tests = [
+    {
+      name: 'fetches flags with undefined selected IDs',
+      experiments: new Map([[TEST_FLAG_NAME, true]]),
+      expectedFlagValue: true,
+      expectedExperimentIds: [],
+    },
+    {
+      name: 'fetches experiment IDs and defaults flags with undefined experiments',
+      selectedIds: [1, 2, 3],
+      expectedFlagValue: [],
+      expectedExperimentIds: [1, 2, 3],
+    },
+    {
+      name: 'fetches flags and experiment IDs with both defined',
+      experiments: new Map([[TEST_FLAG_NAME, true]]),
+      selectedIds: [1, 2, 3],
+      expectedFlagValue: true,
+      expectedExperimentIds: [1, 2, 3],
+    },
+    {
+      name: 'defaults flags and experiment IDs with both undefined',
+      expectedFlagValue: [],
+      expectedExperimentIds: [],
+    },
+    {
+      name: 'defaults flags with flag missing in experiments map',
+      experiments: new Map(),
+      expectedFlagValue: [],
+      expectedExperimentIds: [],
+    },
+  ];
 
-    provider.on();
+  describe('when auth turned on', () => {
+    tests.forEach((t) => {
+      it(t.name, async () => {
+        const getExperimentStateRanPromise = stubGetExperimentStateResponse(
+          t.experiments,
+          t.selectedIds,
+        );
 
-    await expect(getExperimentStateRanPromise).to.eventually.be.fulfilled;
-    sinon.assert.calledOnceWithExactly(
-      colabClientStub.getExperimentState,
-      true,
-      sinon.match.any,
-    );
-    expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.be.true;
-    expect(getExperimentIds()).to.deep.equal(expectedExperimentIds);
+        provider.on();
+
+        await expect(getExperimentStateRanPromise).to.eventually.be.fulfilled;
+        sinon.assert.calledOnceWithExactly(
+          colabClientStub.getExperimentState,
+          true,
+          sinon.match.any,
+        );
+        expect(getFlag(TEST_FLAG_NAME)).to.deep.equal(t.expectedFlagValue);
+        expect(getExperimentIds()).to.deep.equal(t.expectedExperimentIds);
+      });
+    });
   });
 
-  it('fetches experiment state without auth when turned off', async () => {
-    const expectedExperimentIds = [1, 2];
-    const getExperimentStateRanPromise = stubGetExperimentStateResponse(
-      new Map([[ExperimentFlag.RuntimeVersionNames, false]]),
-      expectedExperimentIds,
-    );
+  describe('when auth turned off', () => {
+    tests.forEach((t) => {
+      it(t.name, async () => {
+        const getExperimentStateRanPromise = stubGetExperimentStateResponse(
+          t.experiments,
+          t.selectedIds,
+        );
 
-    provider.off();
+        provider.off();
 
-    await expect(getExperimentStateRanPromise).to.eventually.be.fulfilled;
-    sinon.assert.calledOnceWithExactly(
-      colabClientStub.getExperimentState,
-      false,
-      sinon.match.any,
-    );
-    expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.be.false;
-    expect(getExperimentIds()).to.deep.equal(expectedExperimentIds);
+        await expect(getExperimentStateRanPromise).to.eventually.be.fulfilled;
+        sinon.assert.calledOnceWithExactly(
+          colabClientStub.getExperimentState,
+          false,
+          sinon.match.any,
+        );
+        expect(getFlag(TEST_FLAG_NAME)).to.deep.equal(t.expectedFlagValue);
+        expect(getExperimentIds()).to.deep.equal(t.expectedExperimentIds);
+      });
+    });
   });
 
   it('handles errors when fetching experiment state', async () => {
@@ -102,29 +142,6 @@ describe('ExperimentStateProvider', () => {
 
     await expect(getExperimentStateRun.promise).to.eventually.be.fulfilled;
     sinon.assert.calledOnce(colabClientStub.getExperimentState);
-  });
-
-  it('returns default value when flag is missing', async () => {
-    const getExperimentStateRanPromise = stubGetExperimentStateResponse(
-      // Ensure flags are empty
-      new Map(),
-    );
-
-    provider.on();
-
-    await expect(getExperimentStateRanPromise).to.eventually.be.fulfilled;
-    expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.deep.equal([]);
-  });
-
-  it('returns empty experiment IDs when no IDs are returned', async () => {
-    const getExperimentStateRanPromise = stubGetExperimentStateResponse(
-      new Map(),
-    );
-
-    provider.on();
-
-    await expect(getExperimentStateRanPromise).to.eventually.be.fulfilled;
-    expect(getExperimentIds()).to.be.empty;
   });
 
   it('updates flags when state changes', async () => {
@@ -230,7 +247,7 @@ describe('ExperimentStateProvider', () => {
   });
 
   function stubGetExperimentStateResponse(
-    experiments: Map<ExperimentFlag, ExperimentFlagValue>,
+    experiments?: Map<ExperimentFlag, ExperimentFlagValue>,
     selectedIds?: number[],
   ): Promise<void> {
     const runGetExperimentState = new Deferred<void>();

--- a/src/colab/experiment-state.unit.test.ts
+++ b/src/colab/experiment-state.unit.test.ts
@@ -11,6 +11,7 @@ import { ColabClient } from './client/v1';
 import { ExperimentFlag, ExperimentFlagValue } from './client/v1/api';
 import {
   ExperimentStateProvider,
+  getExperimentIds,
   getFlag,
   TEST_ONLY,
 } from './experiment-state';
@@ -47,9 +48,15 @@ describe('ExperimentStateProvider', () => {
     expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.deep.equal([]);
   });
 
+  it('initializes with no experiment IDs', () => {
+    expect(getExperimentIds()).to.be.empty;
+  });
+
   it('fetches experiment state with auth when turned on', async () => {
+    const expectedExperimentIds = [1, 2, 3];
     const getExperimentStateRanPromise = stubGetExperimentStateResponse(
       new Map([[ExperimentFlag.RuntimeVersionNames, true]]),
+      expectedExperimentIds,
     );
 
     provider.on();
@@ -61,11 +68,14 @@ describe('ExperimentStateProvider', () => {
       sinon.match.any,
     );
     expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.be.true;
+    expect(getExperimentIds()).to.deep.equal(expectedExperimentIds);
   });
 
   it('fetches experiment state without auth when turned off', async () => {
+    const expectedExperimentIds = [1, 2];
     const getExperimentStateRanPromise = stubGetExperimentStateResponse(
       new Map([[ExperimentFlag.RuntimeVersionNames, false]]),
+      expectedExperimentIds,
     );
 
     provider.off();
@@ -77,6 +87,7 @@ describe('ExperimentStateProvider', () => {
       sinon.match.any,
     );
     expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.be.false;
+    expect(getExperimentIds()).to.deep.equal(expectedExperimentIds);
   });
 
   it('handles errors when fetching experiment state', async () => {
@@ -103,6 +114,18 @@ describe('ExperimentStateProvider', () => {
 
     await expect(getExperimentStateRanPromise).to.eventually.be.fulfilled;
     expect(getFlag(ExperimentFlag.RuntimeVersionNames)).to.deep.equal([]);
+  });
+
+  it('returns empty experiment IDs when no IDs are returned', async () => {
+    const getExperimentStateRanPromise = stubGetExperimentStateResponse(
+      // Ensure flags are empty
+      new Map(),
+    );
+
+    provider.on();
+
+    await expect(getExperimentStateRanPromise).to.eventually.be.fulfilled;
+    expect(getExperimentIds()).to.be.empty;
   });
 
   it('updates flags when state changes', async () => {
@@ -209,11 +232,12 @@ describe('ExperimentStateProvider', () => {
 
   function stubGetExperimentStateResponse(
     experiments: Map<ExperimentFlag, ExperimentFlagValue>,
+    selectedIds?: number[],
   ): Promise<void> {
     const runGetExperimentState = new Deferred<void>();
     colabClientStub.getExperimentState.callsFake(async () => {
       runGetExperimentState.resolve();
-      return Promise.resolve({ experiments });
+      return Promise.resolve({ experiments, selectedIds });
     });
     return runGetExperimentState.promise;
   }

--- a/src/colab/resource-monitor/resource-tree.vscode.test.ts
+++ b/src/colab/resource-monitor/resource-tree.vscode.test.ts
@@ -97,7 +97,7 @@ describe('ResourceTreeProvider', () => {
   });
 
   afterEach(() => {
-    FLAGS_TEST_ONLY.resetFlagsForTest();
+    FLAGS_TEST_ONLY.resetExperimentsForTest();
     tree.dispose();
     sinon.restore();
   });

--- a/src/colab/server-picker.unit.test.ts
+++ b/src/colab/server-picker.unit.test.ts
@@ -71,7 +71,7 @@ describe('ServerPicker', () => {
 
   afterEach(() => {
     sinon.restore();
-    TEST_ONLY.resetFlagsForTest();
+    TEST_ONLY.resetExperimentsForTest();
   });
 
   describe('prompt', () => {

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -297,7 +297,7 @@ describe('AssignmentManager', () => {
   });
 
   afterEach(() => {
-    EXPERIMENT_TEST.resetFlagsForTest();
+    EXPERIMENT_TEST.resetExperimentsForTest();
     fakeClock.restore();
     sinon.restore();
   });

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -183,7 +183,7 @@ describe('ColabJupyterServerProvider', () => {
   });
 
   afterEach(() => {
-    EXPERIMENT_TEST.resetFlagsForTest();
+    EXPERIMENT_TEST.resetExperimentsForTest();
     sinon.restore();
   });
 

--- a/src/telemetry/api.ts
+++ b/src/telemetry/api.ts
@@ -17,6 +17,8 @@ export type ColabLogEvent = ColabLogEventBase &
   ColabEvent & {
     /** The timestamp of the event as an ISO string. */
     timestamp: string;
+    /** The selected experiment IDs for the event. */
+    experiment_ids: readonly number[];
   };
 
 /**

--- a/src/telemetry/client.unit.test.ts
+++ b/src/telemetry/client.unit.test.ts
@@ -28,6 +28,7 @@ const DEFAULT_LOG: ColabLogEvent = {
   timestamp: new Date(NOW).toISOString(),
   ui_kind: 'UI_KIND_DESKTOP',
   vscode_version: '1.108.1',
+  experiment_ids: [],
 };
 const LOG_RESPONSE_FLUSH_INTERVAL = 15 * 60 * 1000;
 const LOG_RESPONSE = {

--- a/src/telemetry/client.unit.test.ts
+++ b/src/telemetry/client.unit.test.ts
@@ -59,7 +59,7 @@ describe('ClearcutClient', () => {
 
   afterEach(() => {
     sinon.restore();
-    FLAGS_TEST_ONLY.resetFlagsForTest();
+    FLAGS_TEST_ONLY.resetExperimentsForTest();
   });
 
   describe('log', () => {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -7,6 +7,7 @@ import assert from 'assert';
 import vscode from 'vscode';
 import { Disposable } from 'vscode';
 import { AuthType } from '../colab/client/v1/api';
+import { getExperimentIds } from '../colab/experiment-state';
 import { SubscriptionTier as ColabSubscriptionTier } from '../colab/types';
 import { COLAB_EXT_IDENTIFIER } from '../config/constants';
 import { getPackageInfo } from '../config/package-info';
@@ -217,6 +218,7 @@ function log(event: ColabEvent) {
     ...baseLog,
     ...event,
     timestamp: new Date().toISOString(),
+    experiment_ids: getExperimentIds(),
   });
 }
 

--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -9,6 +9,7 @@ import sinon, { SinonSpy, SinonFakeTimers } from 'sinon';
 import vscode from 'vscode';
 import { Disposable } from 'vscode';
 import { AuthType } from '../colab/client/v1/api';
+import { TEST_ONLY as EXPERIMENTS_TEST_ONLY } from '../colab/experiment-state';
 import { SubscriptionTier as ColabSubscriptionTier } from '../colab/types';
 import { COLAB_EXT_IDENTIFIER } from '../config/constants';
 import { JUPYTER_EXT_IDENTIFIER } from '../jupyter/jupyter-extension';
@@ -57,6 +58,7 @@ describe('Telemetry Module', () => {
   });
 
   afterEach(() => {
+    EXPERIMENTS_TEST_ONLY.resetExperimentsForTest();
     sinon.restore();
     disposeTelemetry?.dispose();
   });
@@ -133,12 +135,17 @@ describe('Telemetry Module', () => {
 
   describe('log interfaces', () => {
     const PLATFORM = 'darwin';
-    let baseLog: ColabLogEventBase & { timestamp: string };
+    const EXPERIMENT_IDS = [1, 2, 3] as const;
+    let baseLog: ColabLogEventBase & {
+      timestamp: string;
+      experiment_ids: readonly number[];
+    };
     let logStub: SinonSpy;
 
     beforeEach(() => {
       logStub = sinon.stub(ClearcutClient.prototype, 'log');
       sinon.stub(process, 'platform').get(() => PLATFORM);
+      EXPERIMENTS_TEST_ONLY.setExperimentIdsForTest(EXPERIMENT_IDS);
       baseLog = {
         app_name: 'VS Code',
         extension_version: VERSION_COLAB,
@@ -148,6 +155,7 @@ describe('Telemetry Module', () => {
         ui_kind: 'UI_KIND_DESKTOP',
         vscode_version: VERSION_VSCODE,
         timestamp: new Date(NOW).toISOString(),
+        experiment_ids: EXPERIMENT_IDS,
       };
       disposeTelemetry = initializeTelemetry(vs.asVsCode());
     });

--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -9,7 +9,7 @@ import sinon, { SinonSpy, SinonFakeTimers } from 'sinon';
 import vscode from 'vscode';
 import { Disposable } from 'vscode';
 import { AuthType } from '../colab/client/v1/api';
-import { TEST_ONLY as EXPERIMENTS_TEST_ONLY } from '../colab/experiment-state';
+import { TEST_ONLY as EXPERIMENT_TEST_ONLY } from '../colab/experiment-state';
 import { SubscriptionTier as ColabSubscriptionTier } from '../colab/types';
 import { COLAB_EXT_IDENTIFIER } from '../config/constants';
 import { JUPYTER_EXT_IDENTIFIER } from '../jupyter/jupyter-extension';
@@ -58,7 +58,7 @@ describe('Telemetry Module', () => {
   });
 
   afterEach(() => {
-    EXPERIMENTS_TEST_ONLY.resetExperimentsForTest();
+    EXPERIMENT_TEST_ONLY.resetExperimentsForTest();
     sinon.restore();
     disposeTelemetry?.dispose();
   });
@@ -145,7 +145,7 @@ describe('Telemetry Module', () => {
     beforeEach(() => {
       logStub = sinon.stub(ClearcutClient.prototype, 'log');
       sinon.stub(process, 'platform').get(() => PLATFORM);
-      EXPERIMENTS_TEST_ONLY.setExperimentIdsForTest(EXPERIMENT_IDS);
+      EXPERIMENT_TEST_ONLY.setExperimentIdsForTest(EXPERIMENT_IDS);
       baseLog = {
         app_name: 'VS Code',
         extension_version: VERSION_COLAB,

--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -491,7 +491,7 @@ describe('Telemetry Module', () => {
       EXPERIMENT_TEST_ONLY.setExperimentIdsForTest([1, 2]);
       telemetry.logAutoConnect();
       EXPERIMENT_TEST_ONLY.setExperimentIdsForTest([2, 3, 4]);
-      telemetry.logAutoConnect();
+      telemetry.logRemoveServer();
 
       const calls = logStub.getCalls();
       expect(calls).to.have.lengthOf(3);

--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -135,7 +135,6 @@ describe('Telemetry Module', () => {
 
   describe('log interfaces', () => {
     const PLATFORM = 'darwin';
-    const EXPERIMENT_IDS = [1, 2, 3] as const;
     let baseLog: ColabLogEventBase & {
       timestamp: string;
       experiment_ids: readonly number[];
@@ -145,7 +144,6 @@ describe('Telemetry Module', () => {
     beforeEach(() => {
       logStub = sinon.stub(ClearcutClient.prototype, 'log');
       sinon.stub(process, 'platform').get(() => PLATFORM);
-      EXPERIMENT_TEST_ONLY.setExperimentIdsForTest(EXPERIMENT_IDS);
       baseLog = {
         app_name: 'VS Code',
         extension_version: VERSION_COLAB,
@@ -155,7 +153,7 @@ describe('Telemetry Module', () => {
         ui_kind: 'UI_KIND_DESKTOP',
         vscode_version: VERSION_VSCODE,
         timestamp: new Date(NOW).toISOString(),
-        experiment_ids: EXPERIMENT_IDS,
+        experiment_ids: [],
       };
       disposeTelemetry = initializeTelemetry(vs.asVsCode());
     });
@@ -484,6 +482,31 @@ describe('Telemetry Module', () => {
           uploaded_bytes: 1024,
         },
       });
+    });
+
+    it('logs experiment IDs when available', () => {
+      // Changes experiment IDs between calls to ensure that the correct IDs are
+      // logged.
+      telemetry.logActivation();
+      EXPERIMENT_TEST_ONLY.setExperimentIdsForTest([1, 2]);
+      telemetry.logAutoConnect();
+      EXPERIMENT_TEST_ONLY.setExperimentIdsForTest([2, 3, 4]);
+      telemetry.logAutoConnect();
+
+      const calls = logStub.getCalls();
+      expect(calls).to.have.lengthOf(3);
+      sinon.assert.calledWithMatch(
+        calls[0],
+        sinon.match({ experiment_ids: [] }),
+      );
+      sinon.assert.calledWithMatch(
+        calls[1],
+        sinon.match({ experiment_ids: [1, 2] }),
+      );
+      sinon.assert.calledWithMatch(
+        calls[2],
+        sinon.match({ experiment_ids: [2, 3, 4] }),
+      );
     });
   });
 });


### PR DESCRIPTION
* **Why**? With selected `experiment_ids` logged, when I start ramping `EnablePublicApi` feature, I can easily monitor error rates between the *treatment* and *control* arms.
* This PR depends on cl/966174941 and cl/966077262 to be rolled out to Prod first.

---

Internal tracking bug: b/523943653