### PR TITLE
fix: tolerate 404 errors from deleteRuntime

### DIFF
--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -36,6 +36,7 @@ import {
   ConnectionInfo,
   CreateRuntimeOperationFromJSON,
   Runtime,
+  ResponseError,
   instanceOfRuntime,
 } from '../colab/client/v2/generated/colab';
 import { REMOVE_SERVER } from '../colab/commands/constants';
@@ -603,10 +604,18 @@ export class AssignmentManager implements Disposable {
     if (!isColabAssignedServer(server)) {
       const enablePublicApi = getFlag(ExperimentFlag.EnablePublicApi);
       if (enablePublicApi) {
-        await this.colabApiClient.colab.deleteRuntime(
-          { runtime: server.id },
-          { signal },
-        );
+        try {
+          await this.colabApiClient.colab.deleteRuntime(
+            { runtime: server.id },
+            { signal },
+          );
+        } catch (error: unknown) {
+          const isNotFound =
+            error instanceof ResponseError && error.response.status === 404;
+          if (!isNotFound) {
+            throw error;
+          }
+        }
       } else {
         await this.colabClient.unassign(server.endpoint, signal);
       }

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -604,18 +604,7 @@ export class AssignmentManager implements Disposable {
     if (!isColabAssignedServer(server)) {
       const enablePublicApi = getFlag(ExperimentFlag.EnablePublicApi);
       if (enablePublicApi) {
-        try {
-          await this.colabApiClient.colab.deleteRuntime(
-            { runtime: server.id },
-            { signal },
-          );
-        } catch (error: unknown) {
-          const isNotFound =
-            error instanceof ResponseError && error.response.status === 404;
-          if (!isNotFound) {
-            throw error;
-          }
-        }
+        await this.deleteRuntime(server.id, signal);
       } else {
         await this.colabClient.unassign(server.endpoint, signal);
       }
@@ -634,10 +623,7 @@ export class AssignmentManager implements Disposable {
       await this.colabClient.unassign(server.endpoint, signal);
     } else {
       // Otherwise, use the new v2 client to delete the runtime.
-      await this.colabApiClient.colab.deleteRuntime(
-        { runtime: server.id },
-        { signal },
-      );
+      await this.deleteRuntime(server.id, signal);
     }
 
     const removed = await this.storage.remove(server.id);
@@ -1128,6 +1114,26 @@ export class AssignmentManager implements Disposable {
       `${MISSING_OPERATION_RESPONSE_ERR_MSG}: ${operationId}`,
     );
     return createRuntimeOperation.response;
+  }
+
+  /**
+   * Deletes a runtime, treating an already-deleted runtime as success.
+   *
+   * @param id - The ID of the runtime to delete.
+   * @param signal - The cancellation signal.
+   */
+  private async deleteRuntime(id: string, signal?: AbortSignal): Promise<void> {
+    try {
+      await this.colabApiClient.colab.deleteRuntime(
+        { runtime: id },
+        { signal },
+      );
+    } catch (error: unknown) {
+      if (!(error instanceof ResponseError && error.response.status === 404)) {
+        throw error;
+      }
+      log.trace(`Runtime ${id} was already deleted`, error);
+    }
   }
 }
 

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -2932,6 +2932,42 @@ describe('AssignmentManager', () => {
             }
             sinon.assert.notCalled(assignmentChangeListener);
           });
+
+          if (!isV1Server) {
+            it('stops tracking the server when the runtime is already gone', async () => {
+              jupyterStub.sessions.list.resolves([]);
+              deleteRuntimeStub.rejects(
+                new ResponseError(new Response(null, { status: 404 })),
+              );
+
+              await assignmentManager.unassignServer(server);
+
+              const serversAfter =
+                await assignmentManager.getLastKnownAssignedServers();
+              expect(serversAfter).to.be.empty;
+              sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+                added: [],
+                removed: [{ server, userInitiated: true }],
+                changed: [],
+              });
+            });
+
+            it('keeps the server tracked on a non-404 response error', async () => {
+              jupyterStub.sessions.list.resolves([]);
+              deleteRuntimeStub.rejects(
+                new ResponseError(new Response(null, { status: 500 }), '☢️'),
+              );
+
+              await expect(
+                assignmentManager.unassignServer(server),
+              ).to.be.rejectedWith('☢️');
+
+              const serversAfter =
+                await assignmentManager.getLastKnownAssignedServers();
+              expect(serversAfter).to.have.lengthOf(1);
+              sinon.assert.notCalled(assignmentChangeListener);
+            });
+          }
         });
       });
 

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -30,6 +30,7 @@ import {
 import {
   ColaboratoryApi,
   CreateRuntimeRequest,
+  ResponseError,
   Runtime,
   Shape as ApiShape,
   Variant as ApiVariant,
@@ -2960,6 +2961,58 @@ describe('AssignmentManager', () => {
             sinon.assert.notCalled(deleteRuntimeStub);
           }
         });
+
+        if (enablePublicApi) {
+          it('ignores a 404 from deleteRuntime', async () => {
+            const remoteServer = {
+              id: 'test-id',
+              endpoint: 'test-endpoint',
+              label: 'name',
+              variant: Variant.DEFAULT,
+            };
+            deleteRuntimeStub.rejects(
+              new ResponseError(new Response(null, { status: 404 })),
+            );
+
+            await assignmentManager.unassignServer(remoteServer);
+
+            sinon.assert.calledOnceWithMatch(
+              deleteRuntimeStub,
+              sinon.match({ runtime: remoteServer.id }),
+              sinon.match.any,
+            );
+          });
+
+          it('rethrows non-404 errors from deleteRuntime', async () => {
+            const remoteServer = {
+              id: 'test-id',
+              endpoint: 'test-endpoint',
+              label: 'name',
+              variant: Variant.DEFAULT,
+            };
+            deleteRuntimeStub.rejects(
+              new ResponseError(new Response(null, { status: 500 }), '☢️'),
+            );
+
+            await expect(
+              assignmentManager.unassignServer(remoteServer),
+            ).to.be.rejectedWith('☢️');
+          });
+
+          it('rethrows non-response errors from deleteRuntime', async () => {
+            const remoteServer = {
+              id: 'test-id',
+              endpoint: 'test-endpoint',
+              label: 'name',
+              variant: Variant.DEFAULT,
+            };
+            deleteRuntimeStub.rejects(new Error('💩'));
+
+            await expect(
+              assignmentManager.unassignServer(remoteServer),
+            ).to.be.rejectedWith('💩');
+          });
+        }
       });
     });
   });


### PR DESCRIPTION
If the server has already been deleted, removing the assignment should still succeed.