### PR TITLE
fix: cleanly abort tasks

### DIFF
--- a/src/common/task-runner.ts
+++ b/src/common/task-runner.ts
@@ -296,20 +296,29 @@ export class SequentialTaskRunner implements Disposable {
     graceMs: number,
     taskName: string,
   ): Promise<void> {
+    // Cleanup must hang off a mirror of `task` that never rejects. Attaching
+    // `.finally()` directly to `task` creates derived promises that adopt its
+    // rejection, and `Promise.race` below only observes `task` itself, so
+    // those derived rejections escape as process-level `unhandledRejection`s
+    // even though the caller catches the task failure.
+    const settled = task.catch(() => {
+      // Swallowed here. The failure is still surfaced by the race below.
+    });
+
     const abortHandler = new Promise<void>((_, reject) => {
       const onAbort = () => {
         const graceTimeout = setTimeout(() => {
           reject(new NonGracefulAbandonError(taskName, graceMs));
         }, graceMs);
 
-        void task.finally(() => {
+        void settled.then(() => {
           clearTimeout(graceTimeout);
         });
       };
 
       signal.addEventListener('abort', onAbort, { once: true });
 
-      void task.finally(() => {
+      void settled.then(() => {
         signal.removeEventListener('abort', onAbort);
       });
     });

--- a/src/common/task-runner.unit.test.ts
+++ b/src/common/task-runner.unit.test.ts
@@ -612,5 +612,30 @@ describe('SequentialTaskRunner', () => {
         new RegExp(`Error.*Task "${testTask.name}".*grace period`),
       );
     });
+
+    it('does not leak an unhandled rejection when an aborted task rejects', async () => {
+      const unhandled: unknown[] = [];
+      const capture = (reason: unknown) => {
+        unhandled.push(reason);
+      };
+      process.on('unhandledRejection', capture);
+
+      try {
+        // Time out the in-flight task, then have it reject with the abort
+        // error, mirroring how `node-fetch` rejects on `AbortSignal`.
+        await tickPast(TASK_TIMEOUT_MS);
+        await expect(run.aborted).to.eventually.be.fulfilled;
+        run.reject(new Error('The user aborted a request.'));
+        await tickPast(ABANDON_GRACE_MS);
+
+        // Node only reports unhandled rejections once the microtask queue has
+        // drained, so yield to a real timer the fake clock does not stub.
+        await new Promise((resolve) => setImmediate(resolve));
+      } finally {
+        process.off('unhandledRejection', capture);
+      }
+
+      expect(unhandled).to.be.empty;
+    });
   });
 });


### PR DESCRIPTION
When going through the logs, this was easily the most frequent error.