### PR TITLE
chore: remove redundant eslint-disable.

### DIFF
--- a/scripts/generate-config.mts
+++ b/scripts/generate-config.mts
@@ -87,7 +87,6 @@ const output = `${licenseHeader}
 // Generate with \`npm run generate-config\` after updating environment
 // variables (see \`.env.template\`).
 
-/* eslint-disable @cspell/spellchecker */
 export const CONFIG = ${JSON.stringify(config, null, 2)} as const;
 `;
 


### PR DESCRIPTION
Generates into `colab-config.ts` which produces a warning of the unused lint.