### PR TITLE
refactor: clean up `EnablePublicApi` feature flag + unused private API calls

### DIFF
--- a/src/colab/client/v1/api.ts
+++ b/src/colab/client/v1/api.ts
@@ -24,16 +24,7 @@
  */
 
 import { z } from 'zod';
-import { Kernel as GeneratedKernel } from '../../../jupyter/client/generated';
 import { Shape, SubscriptionTier, Variant } from '../../types';
-
-export enum SubscriptionState {
-  UNSUBSCRIBED = 1,
-  RECURRING = 2,
-  NON_RECURRING = 3,
-  PENDING_ACTIVATION = 4,
-  DECLINED = 5,
-}
 
 enum ColabSubscriptionTier {
   UNKNOWN = 0,
@@ -48,25 +39,10 @@ enum ColabGapiSubscriptionTier {
   PRO_PLUS = 'SUBSCRIPTION_TIER_PRO_PLUS',
 }
 
-export enum Outcome {
-  UNDEFINED_OUTCOME = 0,
-  QUOTA_DENIED_REQUESTED_VARIANTS = 1,
-  QUOTA_EXCEEDED_USAGE_TIME = 2,
-  // QUOTA_EXCEEDED_USAGE_TIME_REFUND_MIGHT_UNBLOCK (3) is deprecated.
-  SUCCESS = 4,
-  DENYLISTED = 5,
-}
-
 enum ColabGapiVariant {
   UNSPECIFIED = 'VARIANT_UNSPECIFIED',
   GPU = 'VARIANT_GPU',
   TPU = 'VARIANT_TPU',
-}
-
-enum ColabGapiShape {
-  UNSPECIFIED = 'SHAPE_UNSPECIFIED',
-  STANDARD = 'SHAPE_DEFAULT',
-  HIGHMEM = 'SHAPE_HIGH_MEM',
 }
 
 /** Colab supported auth types. */
@@ -113,21 +89,6 @@ function normalizeVariant(variant: ColabGapiVariant): Variant {
   }
 }
 
-/**
- * Normalize the similar but different GAPI representation for the shape.
- *
- * @param shape - the machine shape as represented by the Colab Google API.
- * @returns the normalized machine shape.
- */
-function normalizeShape(shape: ColabGapiShape): Shape {
-  switch (shape) {
-    case ColabGapiShape.HIGHMEM:
-      return Shape.HIGHMEM;
-    default:
-      return Shape.STANDARD;
-  }
-}
-
 export const Accelerator = z.object({
   /** The variant of the assignment. */
   variant: z.enum(ColabGapiVariant).transform(normalizeVariant),
@@ -140,31 +101,20 @@ export const Accelerator = z.object({
 
 /**
  * The schema for top level information about a user's tier, usage and
- * availability in Colab.
+ * availability in Colab when CCU consumption info is requested (consumption
+ * fields are required).
  */
-export const UserInfoSchema = z.object({
+export const ConsumptionUserInfoSchema = z.object({
   /** The subscription tier. */
   subscriptionTier: z
     .enum(ColabGapiSubscriptionTier)
     .transform(normalizeSubTier),
   /** The paid Colab Compute Units balance. */
-  paidComputeUnitsBalance: z.number().optional(),
+  paidComputeUnitsBalance: z.number(),
   /** The eligible machine accelerators. */
   eligibleAccelerators: z.array(Accelerator),
   /** The ineligible machine accelerators. */
   ineligibleAccelerators: z.array(Accelerator),
-});
-/** Colab user information. */
-export type UserInfo = z.infer<typeof UserInfoSchema>;
-
-/**
- * The schema for top level information about a user's tier, usage and
- * availability in Colab when CCU consumption info is requested (consumption
- * fields are required).
- */
-export const ConsumptionUserInfoSchema = UserInfoSchema.required({
-  paidComputeUnitsBalance: true,
-}).extend({
   /**
    * The current rate of consumption of the user's CCUs (paid or free) based on
    * all assigned VMs.
@@ -211,194 +161,6 @@ export const ConsumptionUserInfoSchema = UserInfoSchema.required({
 });
 /** Colab consumption user information. */
 export type ConsumptionUserInfo = z.infer<typeof ConsumptionUserInfoSchema>;
-
-/** The response when getting an assignment. */
-export const GetAssignmentResponseSchema = z
-  .object({
-    /** The pool's accelerator. */
-    acc: z.string().toUpperCase(),
-    /** The notebook ID hash. */
-    nbh: z.string(),
-    /** Whether or not Recaptcha should prompt. */
-    p: z.boolean(),
-    /** XSRF token for assignment posting. */
-    token: z.string(),
-    /** The variant of the assignment. */
-    variant: z.enum(Variant),
-  })
-  .transform(({ acc, nbh, p, token, ...rest }) => ({
-    ...rest,
-    /** The pool's accelerator. */
-    accelerator: acc,
-    /** The notebook ID hash. */
-    notebookIdHash: nbh,
-    /** Whether or not Recaptcha should prompt. */
-    shouldPromptRecaptcha: p,
-    /** XSRF token for assignment posting. */
-    xsrfToken: token,
-  }));
-/** The response when getting an assignment. */
-export type GetAssignmentResponse = z.infer<typeof GetAssignmentResponseSchema>;
-
-export const RuntimeProxyInfoSchema = z.object({
-  /** Token for the runtime proxy. */
-  token: z.string(),
-  /** Token expiration time in seconds. */
-  tokenExpiresInSeconds: z.number(),
-  /** URL of the runtime proxy. */
-  url: z.string(),
-});
-
-export const RuntimeProxyTokenSchema = z
-  .object({
-    /** Token for the runtime proxy. */
-    token: z.string(),
-    /** Token TTL, serialized from `google.protobuf.Duration` as string. */
-    tokenTtl: z.string(),
-    /** URL of the runtime proxy. */
-    url: z.string(),
-  })
-  .transform(({ tokenTtl, ...rest }) => {
-    // Convert from string with 's' suffix to number of seconds and rename to
-    // match `RuntimeProxyInfoSchema`.
-    const tokenExpiresInSeconds = Number(tokenTtl.slice(0, -1));
-    return {
-      ...rest,
-      tokenExpiresInSeconds:
-        Number.isNaN(tokenExpiresInSeconds) || tokenExpiresInSeconds <= 0
-          ? DEFAULT_TOKEN_TTL_SECONDS
-          : tokenExpiresInSeconds,
-    };
-  });
-export type RuntimeProxyToken = z.infer<typeof RuntimeProxyTokenSchema>;
-
-/** The response when creating an assignment. */
-export const PostAssignmentResponseSchema = z.object({
-  /** The assigned accelerator. */
-  accelerator: z.string().toUpperCase().optional(),
-  /** The endpoint URL. */
-  endpoint: z.string().optional(),
-  /** Frontend idle timeout in seconds. */
-  fit: z.number().optional(),
-  /** Whether the backend is trusted. */
-  allowedCredentials: z.boolean().optional(),
-  /** The subscription state. */
-  sub: z.enum(SubscriptionState).optional(),
-  /** The subscription tier. */
-  subTier: z.enum(ColabSubscriptionTier).transform(normalizeSubTier).optional(),
-  /** The outcome of the assignment. */
-  outcome: z.enum(Outcome).optional(),
-  /** The variant of the assignment. */
-  // On GET, this is a string (enum) but on POST this is a number.
-  // Normalize it to the string-based enum.
-  variant: z.preprocess((val) => {
-    if (typeof val === 'number') {
-      switch (val) {
-        case 0:
-          return Variant.DEFAULT;
-        case 1:
-          return Variant.GPU;
-        case 2:
-          return Variant.TPU;
-      }
-    }
-    return val;
-  }, z.enum(Variant).optional()),
-  /** The machine shape. */
-  machineShape: z.enum(Shape).optional(),
-  /** Information about the runtime proxy. */
-  runtimeProxyInfo: RuntimeProxyInfoSchema.optional(),
-});
-/** The response when creating an assignment. */
-export type PostAssignmentResponse = z.infer<
-  typeof PostAssignmentResponseSchema
->;
-
-/** The schema of an assignment when listing all. */
-export const ListedAssignmentSchema = z.object({
-  /** The endpoint URL. */
-  endpoint: z.string(),
-  /** The assigned accelerator. */
-  accelerator: z.string().toUpperCase(),
-  /** The variant of the assignment. */
-  variant: z.enum(ColabGapiVariant).transform(normalizeVariant),
-  /** The machine shape. */
-  machineShape: z.enum(ColabGapiShape).transform(normalizeShape),
-  /** Information about the runtime proxy. */
-  runtimeProxyInfo: RuntimeProxyTokenSchema.optional(),
-  /** Runtime version label. */
-  runtimeVersionLabel: z.string().optional(),
-  /**
-   * Notebook ID hash.
-   *
-   * This should always be present, but added as a optional field to avoid
-   * breaking changes.
-   */
-  notebookIdHash: z.string().optional(),
-});
-/** An abbreviated, listed assignment in Colab. */
-export type ListedAssignment = z.infer<typeof ListedAssignmentSchema>;
-
-/** The schema of the Colab API's list assignments endpoint. */
-export const ListedAssignmentsSchema = z.object({
-  assignments: z
-    .array(ListedAssignmentSchema)
-    .optional()
-    .transform((assignments) => assignments ?? []),
-});
-/** Abbreviated, listed assignments in Colab. */
-export type ListedAssignments = z.infer<typeof ListedAssignmentsSchema>;
-
-/** A machine assignment in Colab. */
-export const AssignmentSchema = PostAssignmentResponseSchema.omit({
-  outcome: true,
-})
-  // fit, sub, subTier and runtimeProxyInfo come back on POST but not when
-  // listing all.
-  .required({
-    accelerator: true,
-    endpoint: true,
-    variant: true,
-    machineShape: true,
-    runtimeProxyInfo: true,
-  })
-  .transform(({ fit, sub, subTier, ...rest }) => ({
-    ...rest,
-    /** The idle timeout in seconds. */
-    idleTimeoutSec: fit,
-    /** The subscription state. */
-    subscriptionState: sub,
-    /** The subscription tier. */
-    subscriptionTier: subTier,
-  }));
-/** A machine assignment in Colab. */
-export type Assignment = z.infer<typeof AssignmentSchema>;
-
-/** A Colab Jupyter kernel returned from the Colab API. */
-// This can be obtained by querying the Jupyter REST API's /api/spec.yaml
-// endpoint.
-export const KernelSchema: z.ZodType<GeneratedKernel> = z
-  .object({
-    /** The UUID of the kernel. */
-    id: z.string(),
-    /** The kernel spec name. */
-    name: z.string(),
-    /** The ISO 8601 timestamp for the last-seen activity on the kernel. */
-    last_activity: z.iso.datetime(),
-    /** The current execution state of the kernel. */
-    execution_state: z.string(),
-    /** The number of active connections to the kernel. */
-    connections: z.number(),
-  })
-  .transform(({ last_activity, execution_state, ...rest }) => ({
-    ...rest,
-    /** The ISO 8601 timestamp for the last-seen activity on the kernel. */
-    lastActivity: last_activity,
-    /** The current execution state of the kernel. */
-    executionState: execution_state,
-  }));
-/** A Colab Jupyter kernel. */
-export type Kernel = z.infer<typeof KernelSchema>;
 
 /** Information about memory usage on a Colab runtime. */
 export const MemorySchema = z
@@ -532,29 +294,8 @@ export function shapeToMachineShape(shape: Shape): string {
   }
 }
 
-const HIGHMEM_ONLY_ACCELERATORS: Set<string> = new Set<string>([
-  'L4',
-  'V28',
-  'V5E1',
-  'V6E1',
-]);
-
-/**
- * Determines if the provided accelerator is one that requires a high-memory
- * machine shape.
- *
- * @param accelerator - The accelerator to check.
- * @returns Whether the accelerator requires a high-memory machine shape.
- */
-export function isHighMemOnlyAccelerator(accelerator?: string): boolean {
-  return (
-    accelerator !== undefined && HIGHMEM_ONLY_ACCELERATORS.has(accelerator)
-  );
-}
-
 /** The experiment flags supported by the Colab extension. */
 export enum ExperimentFlag {
-  EnablePublicApi = 'enable_public_api_vscode',
   EnableTelemetry = 'enable_vscode_telemetry',
   ResourcePollIntervalMs = 'resource_poll_interval_ms',
   RuntimeVersionNames = 'runtime_version_names',
@@ -565,7 +306,6 @@ export const EXPERIMENT_FLAG_DEFAULT_VALUES: Record<
   ExperimentFlag,
   ExperimentFlagValue
 > = {
-  [ExperimentFlag.EnablePublicApi]: false,
   [ExperimentFlag.EnableTelemetry]: false,
   [ExperimentFlag.ResourcePollIntervalMs]: 10000,
   [ExperimentFlag.RuntimeVersionNames]: [],
@@ -604,5 +344,3 @@ export const ExperimentStateSchema = z.object({
 });
 /** The experiment state response. */
 export type ExperimentState = z.infer<typeof ExperimentStateSchema>;
-
-const DEFAULT_TOKEN_TTL_SECONDS = 3600;

--- a/src/colab/client/v1/index.ts
+++ b/src/colab/client/v1/index.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { UUID } from 'crypto';
 import * as https from 'https';
 import fetch, { Headers, Request, RequestInit, Response } from 'node-fetch';
 import { z } from 'zod';
@@ -17,14 +16,6 @@ import {
   createErrorMiddleware,
 } from '../../../common/middleware';
 import { ColabAssignedServer } from '../../../jupyter/servers';
-import { uuidToWebSafeBase64 } from '../../../utils/uuid';
-import {
-  AcceleratorUnavailableError,
-  ColabRequestError,
-  DenylistedError,
-  InsufficientQuotaError,
-  TooManyAssignmentsError,
-} from '../../errors';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
@@ -33,52 +24,19 @@ import {
   COLAB_VS_CODE_EXTENSION_VERSION,
   COLAB_XSRF_TOKEN_HEADER,
 } from '../../headers';
-import { Shape, Variant } from '../../types';
 import {
-  Assignment,
   AuthType,
-  GetAssignmentResponse,
-  AssignmentSchema,
-  GetAssignmentResponseSchema,
-  UserInfo,
-  UserInfoSchema,
   ConsumptionUserInfo,
   ConsumptionUserInfoSchema,
-  PostAssignmentResponse,
-  Outcome,
-  PostAssignmentResponseSchema,
-  ListedAssignmentsSchema,
-  ListedAssignment,
-  RuntimeProxyToken,
-  RuntimeProxyTokenSchema,
   CredentialsPropagationResult,
   CredentialsPropagationResultSchema,
   ExperimentStateSchema,
   ExperimentState,
-  isHighMemOnlyAccelerator,
   Resources,
   ResourcesSchema,
 } from './api';
 
 const TUN_ENDPOINT = '/tun/m';
-
-// To discriminate the type of GET assignment responses.
-interface AssignmentToken extends GetAssignmentResponse {
-  kind: 'to_assign';
-}
-
-// To discriminate the type of GET assignment responses.
-interface AssignedAssignment extends Assignment {
-  kind: 'assigned';
-}
-
-// Options for assign method.
-interface AssignParams {
-  variant: Variant;
-  accelerator?: string;
-  shape?: Shape;
-  version?: string;
-}
 
 /**
  * A client for interacting with the Colab APIs.
@@ -146,20 +104,6 @@ export class ColabClient {
   }
 
   /**
-   * Gets the current user information.
-   *
-   * @param signal - Optional {@link AbortSignal} to cancel the request.
-   * @returns The current user information.
-   */
-  async getUserInfo(signal?: AbortSignal): Promise<UserInfo> {
-    return await this.issueRequest(
-      new URL('v1/user-info', this.colabGapiDomain),
-      { method: 'GET', signal },
-      UserInfoSchema,
-    );
-  }
-
-  /**
    * Gets the current user with Colab Compute Units (CCU) information.
    *
    * @param signal - Optional {@link AbortSignal} to cancel the request.
@@ -175,147 +119,6 @@ export class ColabClient {
       { method: 'GET', signal },
       ConsumptionUserInfoSchema,
     );
-  }
-
-  /**
-   * Returns the existing machine assignment if one exists, or creates one if it
-   * does not.
-   *
-   * @param notebookHash - Represents a web-safe base-64 encoded SHA256 digest.
-   * This value should always be a string of length 44.
-   * @param params - The assignment parameters {@link AssignParams} like
-   * variant, accelerator, shape and version.
-   * @param signal - Optional {@link AbortSignal} to cancel the request.
-   * @returns The assignment which is assigned to the user.
-   * @throws TooManyAssignmentsError if the user has too many assignments.
-   * @throws AcceleratorUnavailableError if the requested machine accelerator is
-   * unavailable.
-   * @throws InsufficientQuotaError if the user lacks the quota to assign.
-   * @throws DenylistedError if the user has been banned.
-   */
-  async assign(
-    notebookHash: UUID,
-    params: AssignParams,
-    signal?: AbortSignal,
-  ): Promise<{ assignment: Assignment; isNew: boolean }> {
-    const assignment = await this.getAssignment(notebookHash, params, signal);
-    switch (assignment.kind) {
-      case 'assigned': {
-        // Not required, but we want to remove the type field we use internally
-        // to discriminate the union of types returned from getAssignment.
-        const { kind: _, ...rest } = assignment;
-        return { assignment: rest, isNew: false };
-      }
-      case 'to_assign': {
-        let res: PostAssignmentResponse;
-        try {
-          res = await this.postAssignment(
-            notebookHash,
-            assignment.xsrfToken,
-            params,
-            signal,
-          );
-        } catch (error) {
-          // Check for Precondition Failed
-          if (
-            error instanceof ColabRequestError &&
-            error.response.status === 412
-          ) {
-            throw new TooManyAssignmentsError(error.message);
-          }
-          // Check for no machine availability.
-          if (
-            error instanceof ColabRequestError &&
-            error.response.status === 503
-          ) {
-            throw new AcceleratorUnavailableError(
-              params.accelerator ?? 'default',
-            );
-          }
-          throw error;
-        }
-
-        switch (res.outcome) {
-          case Outcome.QUOTA_DENIED_REQUESTED_VARIANTS:
-          case Outcome.QUOTA_EXCEEDED_USAGE_TIME:
-            throw new InsufficientQuotaError(
-              'You have insufficient quota to assign this server.',
-            );
-          case Outcome.DENYLISTED:
-            // TODO: Consider adding a mechanism to send feedback as part of an
-            // appeal.
-            throw new DenylistedError(
-              'This account has been blocked from accessing Colab servers due to suspected abusive activity. This does not impact access to other Google products. Review the [usage limitations](https://research.google.com/colaboratory/faq.html#limitations-and-restrictions).',
-            );
-          case Outcome.UNDEFINED_OUTCOME:
-          case Outcome.SUCCESS:
-          case undefined:
-            return {
-              assignment: AssignmentSchema.parse(res),
-              isNew: true,
-            };
-        }
-      }
-    }
-  }
-
-  /**
-   * Unassigns the specified machine assignment.
-   *
-   * @param endpoint - The endpoint to unassign.
-   * @param signal - Optional {@link AbortSignal} to cancel the request.
-   */
-  async unassign(endpoint: string, signal?: AbortSignal): Promise<void> {
-    const url = new URL(
-      `${TUN_ENDPOINT}/unassign/${endpoint}`,
-      this.colabDomain,
-    );
-    const { token } = await this.issueRequest(
-      url,
-      { method: 'GET', signal },
-      z.object({ token: z.string() }),
-    );
-    await this.issueRequest(url, {
-      method: 'POST',
-      headers: { [COLAB_XSRF_TOKEN_HEADER.key]: token },
-      signal,
-    });
-  }
-
-  /**
-   * Refreshes the connection for the given endpoint.
-   *
-   * @param endpoint - The server endpoint to refresh the connection for.
-   * @param signal - Optional {@link AbortSignal} to cancel the request.
-   * @returns The refreshed runtime proxy information.
-   */
-  async refreshConnection(
-    endpoint: string,
-    signal?: AbortSignal,
-  ): Promise<RuntimeProxyToken> {
-    const url = new URL('v1/runtime-proxy-token', this.colabGapiDomain);
-    url.searchParams.set('endpoint', endpoint);
-    url.searchParams.set('port', '8080');
-    return await this.issueRequest(
-      url,
-      { method: 'GET', signal },
-      RuntimeProxyTokenSchema,
-    );
-  }
-
-  /**
-   * Lists all assignments.
-   *
-   * @param signal - Optional {@link AbortSignal} to cancel the request.
-   * @returns The list of assignments.
-   */
-  async listAssignments(signal?: AbortSignal): Promise<ListedAssignment[]> {
-    const response = await this.issueRequest(
-      new URL('v1/assignments', this.colabGapiDomain),
-      { method: 'GET', signal },
-      ListedAssignmentsSchema,
-    );
-    return response.assignments;
   }
 
   /**
@@ -435,69 +238,6 @@ export class ColabClient {
     return expState;
   }
 
-  private async getAssignment(
-    notebookHash: UUID,
-    params: AssignParams,
-    signal?: AbortSignal,
-  ): Promise<AssignmentToken | AssignedAssignment> {
-    const url = this.buildAssignUrl(notebookHash, params);
-    const response = await this.issueRequest(
-      url,
-      { method: 'GET', signal },
-      z.union([GetAssignmentResponseSchema, AssignmentSchema]),
-    );
-    if ('xsrfToken' in response) {
-      return { ...response, kind: 'to_assign' };
-    } else {
-      return { ...response, kind: 'assigned' };
-    }
-  }
-
-  private async postAssignment(
-    notebookHash: UUID,
-    xsrfToken: string,
-    params: AssignParams,
-    signal?: AbortSignal,
-  ): Promise<PostAssignmentResponse> {
-    const url = this.buildAssignUrl(notebookHash, params);
-    return await this.issueRequest(
-      url,
-      {
-        method: 'POST',
-        headers: { [COLAB_XSRF_TOKEN_HEADER.key]: xsrfToken },
-        signal,
-      },
-      PostAssignmentResponseSchema,
-    );
-  }
-
-  private buildAssignUrl(
-    notebookHash: UUID,
-    { variant, accelerator, shape, version }: AssignParams,
-  ): URL {
-    const url = new URL(`${TUN_ENDPOINT}/assign`, this.colabDomain);
-    url.searchParams.set('nbh', uuidToWebSafeBase64(notebookHash));
-    if (variant !== Variant.DEFAULT) {
-      url.searchParams.set('variant', variant);
-    }
-    if (accelerator) {
-      url.searchParams.set('accelerator', accelerator);
-    }
-    const shapeURLParam = mapShapeToURLParam(
-      // High mem only accelerators only have one shape option
-      isHighMemOnlyAccelerator(accelerator)
-        ? Shape.STANDARD
-        : (shape ?? Shape.STANDARD),
-    );
-    if (shapeURLParam) {
-      url.searchParams.set('shape', shapeURLParam);
-    }
-    if (version) {
-      url.searchParams.set('runtime_version_label', version);
-    }
-    return url;
-  }
-
   /**
    * Issues a request to the given endpoint, adding the necessary headers and
    * handling errors.
@@ -566,14 +306,5 @@ export class ColabClient {
     return schema
       ? fetchAndParse(fetchImpl, endpoint.toString(), schema, requestInit)
       : fetchImpl(endpoint.toString(), requestInit).then(() => undefined);
-  }
-}
-
-function mapShapeToURLParam(shape: Shape): string | undefined {
-  switch (shape) {
-    case Shape.HIGHMEM:
-      return 'hm';
-    default:
-      return undefined;
   }
 }

--- a/src/colab/client/v1/index.unit.test.ts
+++ b/src/colab/client/v1/index.unit.test.ts
@@ -11,13 +11,6 @@ import { SinonStub, SinonMatcher } from 'sinon';
 import * as sinon from 'sinon';
 import { ColabAssignedServer } from '../../../jupyter/servers';
 import { TestUri } from '../../../test/helpers/uri';
-import { uuidToWebSafeBase64 } from '../../../utils/uuid';
-import {
-  AcceleratorUnavailableError,
-  DenylistedError,
-  InsufficientQuotaError,
-  TooManyAssignmentsError,
-} from '../../errors';
 import {
   ACCEPT_JSON_HEADER,
   AUTHORIZATION_HEADER,
@@ -28,18 +21,8 @@ import {
   COLAB_VS_CODE_EXTENSION_VERSION,
   COLAB_XSRF_TOKEN_HEADER,
 } from '../../headers';
-import { Shape, SubscriptionTier, Variant } from '../../types';
-import {
-  Assignment,
-  SubscriptionState,
-  Outcome,
-  RuntimeProxyToken,
-  AuthType,
-  ExperimentFlag,
-  ConsumptionUserInfo,
-  UserInfo,
-  ListedAssignment,
-} from './api';
+import { SubscriptionTier, Variant } from '../../types';
+import { AuthType, ExperimentFlag, ConsumptionUserInfo } from './api';
 import { ColabClient } from '.';
 
 const COLAB_HOST = 'colab.example.com';
@@ -47,28 +30,6 @@ const GOOGLE_APIS_HOST = 'colab.example.googleapis.com';
 const BEARER_TOKEN = 'access-token';
 const APP_NAME = 'mock-app';
 const EXTENSION_VERSION = '1.2.3';
-const NOTEBOOK_HASH = randomUUID();
-const DEFAULT_ASSIGNMENT_RESPONSE = {
-  accelerator: 'A100',
-  endpoint: 'mock-server',
-  fit: 30,
-  sub: SubscriptionState.UNSUBSCRIBED,
-  subTier: SubscriptionTier.NONE,
-  variant: Variant.GPU,
-  machineShape: Shape.STANDARD,
-  runtimeProxyInfo: {
-    token: 'mock-token',
-    tokenExpiresInSeconds: 42,
-    url: 'https://mock-url.com',
-  },
-};
-const { fit, sub, subTier, ...rest } = DEFAULT_ASSIGNMENT_RESPONSE;
-const DEFAULT_ASSIGNMENT: Assignment = {
-  ...rest,
-  idleTimeoutSec: fit,
-  subscriptionState: sub,
-  subscriptionTier: subTier,
-};
 
 describe('ColabClient', () => {
   let fetchStub: sinon.SinonStubbedMember<typeof fetch>;
@@ -93,60 +54,6 @@ describe('ColabClient', () => {
 
   afterEach(() => {
     sinon.restore();
-  });
-
-  it('successfully gets user info', async () => {
-    const mockResponse = {
-      subscriptionTier: 'SUBSCRIPTION_TIER_PRO',
-      eligibleAccelerators: [
-        {
-          variant: 'VARIANT_GPU',
-          models: ['T4', 'A100', 'L4'],
-        },
-        {
-          variant: 'VARIANT_TPU',
-          models: ['V5E1', 'V6E1', 'V28'],
-        },
-      ],
-      ineligibleAccelerators: [
-        { variant: 'VARIANT_GPU' },
-        { variant: 'VARIANT_TPU' },
-      ],
-    };
-    fetchStub
-      .withArgs(
-        urlMatcher({
-          method: 'GET',
-          host: GOOGLE_APIS_HOST,
-          path: '/v1/user-info',
-          withAuthUser: false,
-        }),
-      )
-      .resolves(
-        new Response(withXSSI(JSON.stringify(mockResponse)), { status: 200 }),
-      );
-
-    const response = client.getUserInfo();
-
-    const expectedResponse: UserInfo = {
-      subscriptionTier: SubscriptionTier.PRO,
-      eligibleAccelerators: [
-        {
-          variant: Variant.GPU,
-          models: ['T4', 'A100', 'L4'],
-        },
-        {
-          variant: Variant.TPU,
-          models: ['V5E1', 'V6E1', 'V28'],
-        },
-      ],
-      ineligibleAccelerators: [
-        { variant: Variant.GPU, models: [] },
-        { variant: Variant.TPU, models: [] },
-      ],
-    };
-    await expect(response).to.eventually.deep.equal(expectedResponse);
-    sinon.assert.calledOnce(fetchStub);
   });
 
   it('successfully gets consumption user info', async () => {
@@ -230,461 +137,6 @@ describe('ColabClient', () => {
     sinon.assert.calledOnce(fetchStub);
   });
 
-  describe('assignment', () => {
-    const ASSIGN_PATH = '/tun/m/assign';
-    let wireNbh: string;
-    let queryParams: Record<string, string | RegExp>;
-
-    beforeEach(() => {
-      wireNbh = uuidToWebSafeBase64(NOTEBOOK_HASH);
-      queryParams = {
-        nbh: wireNbh,
-      };
-    });
-
-    it('resolves an existing assignment', async () => {
-      fetchStub
-        .withArgs(
-          urlMatcher({
-            method: 'GET',
-            host: COLAB_HOST,
-            path: ASSIGN_PATH,
-            queryParams,
-          }),
-        )
-        .resolves(
-          new Response(withXSSI(JSON.stringify(DEFAULT_ASSIGNMENT_RESPONSE)), {
-            status: 200,
-          }),
-        );
-
-      await expect(
-        client.assign(NOTEBOOK_HASH, {
-          variant: Variant.GPU,
-          accelerator: 'A100',
-        }),
-      ).to.eventually.deep.equal({
-        assignment: DEFAULT_ASSIGNMENT,
-        isNew: false,
-      });
-
-      sinon.assert.calledOnce(fetchStub);
-    });
-
-    describe('without an existing assignment', () => {
-      beforeEach(() => {
-        const mockGetResponse = {
-          acc: 'NONE',
-          nbh: wireNbh,
-          p: false,
-          token: 'mock-xsrf-token',
-          variant: Variant.DEFAULT,
-        };
-        fetchStub
-          .withArgs(
-            urlMatcher({
-              method: 'GET',
-              host: COLAB_HOST,
-              path: ASSIGN_PATH,
-              queryParams,
-            }),
-          )
-          .resolves(
-            new Response(withXSSI(JSON.stringify(mockGetResponse)), {
-              status: 200,
-            }),
-          );
-      });
-
-      const assignmentTests: [Variant, string?, Shape?, string?][] = [
-        [Variant.DEFAULT, undefined],
-        [Variant.GPU, 'T4'],
-        [Variant.TPU, 'V28', Shape.STANDARD],
-        [Variant.DEFAULT, undefined, Shape.HIGHMEM],
-        [Variant.GPU, 'A100', Shape.HIGHMEM],
-        [Variant.TPU, 'V6E1', Shape.STANDARD, ''],
-        [Variant.GPU, 'T4', Shape.STANDARD, 'v2'],
-      ];
-      for (const [variant, accelerator, shape, version] of assignmentTests) {
-        const assignment = `${variant}${accelerator ? ` (${accelerator})` : ''} with shape ${String(shape ?? Shape.STANDARD)}${version ? ` and version ${version}` : ''}`;
-
-        it(`creates a new ${assignment}`, async () => {
-          const postQueryParams: Record<string, string | RegExp> = {
-            ...queryParams,
-          };
-          if (variant !== Variant.DEFAULT) {
-            postQueryParams.variant = variant;
-          }
-          if (accelerator) {
-            postQueryParams.accelerator = accelerator;
-          }
-          if (shape === Shape.HIGHMEM) {
-            postQueryParams.shape = 'hm';
-          }
-          if (version) {
-            postQueryParams.runtime_version_label = version;
-          }
-          const assignmentResponse = {
-            ...DEFAULT_ASSIGNMENT_RESPONSE,
-            variant,
-            accelerator: accelerator ?? 'NONE',
-            ...(shape === Shape.HIGHMEM ? { machineShape: Shape.HIGHMEM } : {}),
-          };
-          fetchStub
-            .withArgs(
-              urlMatcher({
-                method: 'POST',
-                host: COLAB_HOST,
-                path: ASSIGN_PATH,
-                queryParams: postQueryParams,
-                otherHeaders: {
-                  [COLAB_XSRF_TOKEN_HEADER.key]: 'mock-xsrf-token',
-                },
-              }),
-            )
-            .resolves(
-              new Response(withXSSI(JSON.stringify(assignmentResponse)), {
-                status: 200,
-              }),
-            );
-
-          const expectedAssignment: Assignment = {
-            ...DEFAULT_ASSIGNMENT,
-            variant,
-            accelerator: accelerator ?? 'NONE',
-            ...(shape === Shape.HIGHMEM ? { machineShape: Shape.HIGHMEM } : {}),
-          };
-          await expect(
-            client.assign(NOTEBOOK_HASH, {
-              variant,
-              accelerator,
-              shape,
-              version,
-            }),
-          ).to.eventually.deep.equal({
-            assignment: expectedAssignment,
-            isNew: true,
-          });
-
-          sinon.assert.calledTwice(fetchStub);
-        });
-      }
-
-      it('creates a new assignment with default shape if accelerator is high mem only', async () => {
-        fetchStub
-          .withArgs(
-            urlMatcher({
-              method: 'POST',
-              host: COLAB_HOST,
-              path: ASSIGN_PATH,
-              queryParams: {
-                ...queryParams,
-                variant: Variant.GPU,
-                accelerator: 'L4',
-              },
-              otherHeaders: {
-                [COLAB_XSRF_TOKEN_HEADER.key]: 'mock-xsrf-token',
-              },
-            }),
-          )
-          .resolves(
-            new Response(
-              withXSSI(
-                JSON.stringify({
-                  ...DEFAULT_ASSIGNMENT_RESPONSE,
-                  variant: Variant.GPU,
-                  accelerator: 'L4',
-                }),
-              ),
-              {
-                status: 200,
-              },
-            ),
-          );
-
-        const expectedAssignment: Assignment = {
-          ...DEFAULT_ASSIGNMENT,
-          variant: Variant.GPU,
-          accelerator: 'L4',
-          machineShape: Shape.STANDARD,
-        };
-        await expect(
-          client.assign(NOTEBOOK_HASH, {
-            variant: Variant.GPU,
-            accelerator: 'L4',
-            shape: Shape.HIGHMEM,
-          }),
-        ).to.eventually.deep.equal({
-          assignment: expectedAssignment,
-          isNew: true,
-        });
-
-        sinon.assert.calledTwice(fetchStub);
-      });
-
-      it('rejects when assignments exceed limit', async () => {
-        fetchStub
-          .withArgs(
-            urlMatcher({
-              method: 'POST',
-              host: COLAB_HOST,
-              path: ASSIGN_PATH,
-              queryParams,
-              otherHeaders: {
-                'X-Goog-Colab-Token': 'mock-xsrf-token',
-              },
-            }),
-          )
-          .resolves(new Response(undefined, { status: 412 }));
-
-        await expect(
-          client.assign(NOTEBOOK_HASH, { variant: Variant.DEFAULT }),
-        ).to.eventually.be.rejectedWith(TooManyAssignmentsError);
-      });
-
-      it('rejects when accelerator is unavailable', async () => {
-        fetchStub
-          .withArgs(
-            urlMatcher({
-              method: 'POST',
-              host: COLAB_HOST,
-              path: ASSIGN_PATH,
-              queryParams,
-              otherHeaders: {
-                'X-Goog-Colab-Token': 'mock-xsrf-token',
-              },
-            }),
-          )
-          .resolves(new Response(undefined, { status: 503 }));
-
-        await expect(
-          client.assign(NOTEBOOK_HASH, {
-            variant: Variant.GPU,
-            accelerator: 'H100',
-          }),
-        ).to.eventually.be.rejectedWith(AcceleratorUnavailableError, /H100/);
-      });
-
-      for (const quotaTest of [
-        {
-          reason: 'request variant unavailable',
-          outcome: Outcome.QUOTA_DENIED_REQUESTED_VARIANTS,
-        },
-        {
-          reason: 'usage time exceeded',
-          outcome: Outcome.QUOTA_EXCEEDED_USAGE_TIME,
-        },
-      ]) {
-        it(`rejects when quota is exceeded due to ${quotaTest.reason}`, async () => {
-          fetchStub
-            .withArgs(
-              urlMatcher({
-                method: 'POST',
-                host: COLAB_HOST,
-                path: ASSIGN_PATH,
-                queryParams,
-                otherHeaders: {
-                  'X-Goog-Colab-Token': 'mock-xsrf-token',
-                },
-              }),
-            )
-            .resolves(
-              new Response(
-                withXSSI(
-                  JSON.stringify({
-                    outcome: quotaTest.outcome,
-                  }),
-                ),
-                {
-                  status: 200,
-                },
-              ),
-            );
-
-          await expect(
-            client.assign(NOTEBOOK_HASH, { variant: Variant.DEFAULT }),
-          ).to.eventually.be.rejectedWith(
-            InsufficientQuotaError,
-            /insufficient quota/,
-          );
-        });
-      }
-
-      it('rejects when user is banned', async () => {
-        fetchStub
-          .withArgs(
-            urlMatcher({
-              method: 'POST',
-              host: COLAB_HOST,
-              path: ASSIGN_PATH,
-              queryParams,
-              otherHeaders: {
-                'X-Goog-Colab-Token': 'mock-xsrf-token',
-              },
-            }),
-          )
-          .resolves(
-            new Response(
-              withXSSI(
-                JSON.stringify({
-                  outcome: Outcome.DENYLISTED,
-                }),
-              ),
-              {
-                status: 200,
-              },
-            ),
-          );
-
-        await expect(
-          client.assign(NOTEBOOK_HASH, { variant: Variant.DEFAULT }),
-        ).to.eventually.be.rejectedWith(DenylistedError, /blocked/);
-      });
-    });
-  });
-
-  it('successfully lists multiple assignments', async () => {
-    const mockAssignment1 = {
-      endpoint: 'm-s-foo-1',
-      accelerator: 'A100',
-      variant: 'VARIANT_UNSPECIFIED',
-      machineShape: 'SHAPE_UNSPECIFIED',
-      runtimeProxyInfo: {
-        token: 'new_token',
-        tokenTtl: '3600s',
-        url: 'https://8080-m-s-foo-1.bar.prod.colab.dev',
-      },
-    };
-    const mockAssignment2 = {
-      endpoint: 'm-s-foo-2',
-      accelerator: 'T4',
-      variant: 'VARIANT_GPU',
-      machineShape: 'SHAPE_DEFAULT',
-      runtimeProxyInfo: {
-        token: 'new_token',
-        tokenTtl: '3600s',
-        url: 'https://8080-m-s-foo-2.bar.prod.colab.dev',
-      },
-    };
-    const mockAssignment3 = {
-      endpoint: 'm-s-foo-3',
-      accelerator: 'V28',
-      variant: 'VARIANT_TPU',
-      machineShape: 'SHAPE_HIGH_MEM',
-      runtimeProxyInfo: {
-        token: 'new_token',
-        tokenTtl: '3600s',
-        url: 'https://8080-m-s-foo-3.bar.prod.colab.dev',
-      },
-    };
-    fetchStub
-      .withArgs(
-        urlMatcher({
-          method: 'GET',
-          host: GOOGLE_APIS_HOST,
-          path: '/v1/assignments',
-          withAuthUser: false,
-        }),
-      )
-      .resolves(
-        new Response(
-          withXSSI(
-            JSON.stringify({
-              assignments: [mockAssignment1, mockAssignment2, mockAssignment3],
-            }),
-          ),
-          { status: 200 },
-        ),
-      );
-
-    const results = client.listAssignments();
-
-    const expectedAssignment1: ListedAssignment = {
-      endpoint: mockAssignment1.endpoint,
-      accelerator: mockAssignment1.accelerator,
-      variant: Variant.DEFAULT,
-      machineShape: Shape.STANDARD,
-      runtimeProxyInfo: {
-        token: mockAssignment1.runtimeProxyInfo.token,
-        tokenExpiresInSeconds: 3600,
-        url: mockAssignment1.runtimeProxyInfo.url,
-      },
-    };
-    const expectedAssignment2: ListedAssignment = {
-      endpoint: mockAssignment2.endpoint,
-      accelerator: mockAssignment2.accelerator,
-      variant: Variant.GPU,
-      machineShape: Shape.STANDARD,
-      runtimeProxyInfo: {
-        token: mockAssignment2.runtimeProxyInfo.token,
-        tokenExpiresInSeconds: 3600,
-        url: mockAssignment2.runtimeProxyInfo.url,
-      },
-    };
-    const expectedAssignment3: ListedAssignment = {
-      endpoint: mockAssignment3.endpoint,
-      accelerator: mockAssignment3.accelerator,
-      variant: Variant.TPU,
-      machineShape: Shape.HIGHMEM,
-      runtimeProxyInfo: {
-        token: mockAssignment3.runtimeProxyInfo.token,
-        tokenExpiresInSeconds: 3600,
-        url: mockAssignment3.runtimeProxyInfo.url,
-      },
-    };
-    await expect(results).to.eventually.deep.equal([
-      expectedAssignment1,
-      expectedAssignment2,
-      expectedAssignment3,
-    ]);
-    sinon.assert.calledOnce(fetchStub);
-  });
-
-  it('successfully lists undefined assignments', async () => {
-    fetchStub
-      .withArgs(
-        urlMatcher({
-          method: 'GET',
-          host: GOOGLE_APIS_HOST,
-          path: '/v1/assignments',
-          withAuthUser: false,
-        }),
-      )
-      .resolves(new Response(withXSSI(JSON.stringify({})), { status: 200 }));
-
-    const results = client.listAssignments();
-
-    await expect(results).to.eventually.to.empty;
-    sinon.assert.calledOnce(fetchStub);
-  });
-
-  it('successfully unassigns the specified assignment', async () => {
-    const endpoint = 'mock-server';
-    const path = `/tun/m/unassign/${endpoint}`;
-    const token = 'mock-xsrf-token';
-    fetchStub
-      .withArgs(urlMatcher({ method: 'GET', host: COLAB_HOST, path }))
-      .resolves(
-        new Response(withXSSI(JSON.stringify({ token })), { status: 200 }),
-      );
-    fetchStub
-      .withArgs(
-        urlMatcher({
-          method: 'POST',
-          host: COLAB_HOST,
-          path,
-          otherHeaders: {
-            [COLAB_XSRF_TOKEN_HEADER.key]: token,
-          },
-        }),
-      )
-      .resolves(new Response(undefined, { status: 200 }));
-
-    await expect(client.unassign(endpoint)).to.eventually.be.fulfilled;
-
-    sinon.assert.calledTwice(fetchStub);
-  });
-
   describe('with an assigned server', () => {
     const assignedServerUrl = new URL(
       'https://8080-m-s-foo.bar.prod.colab.dev',
@@ -693,7 +145,7 @@ describe('ColabClient', () => {
 
     beforeEach(() => {
       assignedServer = {
-        id: randomUUID(),
+        id: `r-${randomUUID()}`,
         label: 'foo',
         variant: Variant.DEFAULT,
         accelerator: undefined,
@@ -705,50 +157,6 @@ describe('ColabClient', () => {
         },
         dateAssigned: new Date(),
       };
-    });
-
-    const tests = [
-      { tokenTtl: '3.1415926s', expectedExpiry: 3.1415926 },
-      { tokenTtl: '-100s', expectedExpiry: 3600 },
-      { tokenTtl: 'bad_data', expectedExpiry: 3600 },
-      { tokenTtl: '', expectedExpiry: 3600 },
-    ];
-    tests.forEach(({ tokenTtl, expectedExpiry }) => {
-      it(`successfully refreshes the connection (token_ttl: '${tokenTtl}')`, async () => {
-        const path = '/v1/runtime-proxy-token';
-        const rawRuntimeProxyToken = {
-          token: 'new',
-          tokenTtl,
-          url: assignedServerUrl.toString(),
-        };
-        fetchStub
-          .withArgs(
-            urlMatcher({
-              method: 'GET',
-              host: GOOGLE_APIS_HOST,
-              path,
-              queryParams: {
-                endpoint: assignedServer.endpoint,
-                port: '8080',
-              },
-              withAuthUser: false,
-            }),
-          )
-          .resolves(
-            new Response(withXSSI(JSON.stringify(rawRuntimeProxyToken)), {
-              status: 200,
-            }),
-          );
-
-        const response = client.refreshConnection(assignedServer.endpoint);
-
-        const newConnectionInfo: RuntimeProxyToken = {
-          url: rawRuntimeProxyToken.url,
-          token: rawRuntimeProxyToken.token,
-          tokenExpiresInSeconds: expectedExpiry,
-        };
-        await expect(response).to.eventually.deep.equal(newConnectionInfo);
-      });
     });
 
     it('successfully gets resources by server', async () => {
@@ -847,6 +255,7 @@ describe('ColabClient', () => {
           method: 'GET',
           host: GOOGLE_APIS_HOST,
           path: '/v1/user-info',
+          queryParams: { get_ccu_consumption_info: 'true' },
           withAuthUser: false,
         }),
       )
@@ -860,16 +269,22 @@ describe('ColabClient', () => {
               subscriptionTier: 'SUBSCRIPTION_TIER_NONE',
               eligibleAccelerators: [],
               ineligibleAccelerators: [],
+              paidComputeUnitsBalance: 1,
+              consumptionRateHourly: 2,
+              assignmentsCount: 3,
             }),
           ),
           { status: 200 },
         ),
       );
 
-    await expect(client.getUserInfo()).to.eventually.deep.equal({
+    await expect(client.getConsumptionUserInfo()).to.eventually.deep.equal({
       subscriptionTier: SubscriptionTier.NONE,
       eligibleAccelerators: [],
       ineligibleAccelerators: [],
+      paidComputeUnitsBalance: 1,
+      consumptionRateHourly: 2,
+      assignmentsCount: 3,
     });
 
     sinon.assert.calledTwice(fetchStub);

--- a/src/colab/client/v1/index.unit.test.ts
+++ b/src/colab/client/v1/index.unit.test.ts
@@ -25,7 +25,12 @@ import {
   CONTENT_TYPE_JSON_HEADER,
 } from '../../headers';
 import { SubscriptionTier, Variant } from '../../types';
-import { AuthType, ExperimentFlag, ConsumptionUserInfo, OnePlatformError } from './api';
+import {
+  AuthType,
+  ExperimentFlag,
+  ConsumptionUserInfo,
+  OnePlatformError,
+} from './api';
 import { ColabClient } from '.';
 
 const COLAB_HOST = 'colab.example.com';

--- a/src/colab/client/v2/index.ts
+++ b/src/colab/client/v2/index.ts
@@ -15,11 +15,7 @@ import {
   TooManyAssignmentsError,
 } from '../../errors';
 import { AUTHORIZATION_HEADER, COLAB_CLIENT_AGENT_HEADER } from '../../headers';
-import {
-  Shape as CommonShape,
-  SubscriptionTier as CommonSubscriptionTier,
-  Variant as CommonVariant,
-} from '../../types';
+import { Shape as CommonShape, Variant as CommonVariant } from '../../types';
 import {
   ColaboratoryApi,
   Configuration as ColabConfig,
@@ -32,7 +28,6 @@ import {
   ResponseContext,
   Runtime,
   Shape,
-  SubscriptionTier,
   Variant,
 } from './generated/colab';
 import {
@@ -74,28 +69,6 @@ export function createColabApiClient(
   onAuthError?: () => Promise<void>,
 ): ColabApiClient {
   return new ColabApiClientImpl(basePath, getAccessToken, onAuthError);
-}
-
-/**
- * Normalizes the API {@link SubscriptionTier} to the common
- * {@link CommonSubscriptionTier}.
- *
- * @param tier - Subscription tier returned from public Colab API.
- * @returns Normalized common subscription tier value.
- */
-export function normalizeSubscriptionTier(
-  tier: SubscriptionTier,
-): CommonSubscriptionTier {
-  switch (tier) {
-    case SubscriptionTier.SubscriptionTierFree:
-      return CommonSubscriptionTier.NONE;
-    case SubscriptionTier.SubscriptionTierPro:
-      return CommonSubscriptionTier.PRO;
-    case SubscriptionTier.SubscriptionTierProPlus:
-      return CommonSubscriptionTier.PRO_PLUS;
-    default:
-      throw new Error(`Unknown subscription tier: ${tier}`);
-  }
 }
 
 /**

--- a/src/colab/client/v2/index.unit.test.ts
+++ b/src/colab/client/v2/index.unit.test.ts
@@ -19,18 +19,8 @@ import {
   TooManyAssignmentsError,
 } from '../../errors';
 import { AUTHORIZATION_HEADER, COLAB_CLIENT_AGENT_HEADER } from '../../headers';
-import {
-  Shape as CommonShape,
-  SubscriptionTier as CommonSubscriptionTier,
-  Variant as CommonVariant,
-} from '../../types';
-import {
-  FetchAPI,
-  Key,
-  Shape,
-  SubscriptionTier,
-  Variant,
-} from './generated/colab';
+import { Shape as CommonShape, Variant as CommonVariant } from '../../types';
+import { FetchAPI, Key, Shape, Variant } from './generated/colab';
 import { Operation } from './generated/operations';
 import {
   ColabApiClient,
@@ -38,7 +28,6 @@ import {
   denormalizeShape,
   denormalizeVariant,
   normalizeShape,
-  normalizeSubscriptionTier,
   normalizeVariant,
   throwIfOperationError,
 } from '.';
@@ -1210,34 +1199,6 @@ describe('ColabApiClient', () => {
         });
       });
     });
-  });
-});
-
-describe('normalizeSubscriptionTier', () => {
-  const tests = [
-    {
-      input: SubscriptionTier.SubscriptionTierFree,
-      expected: CommonSubscriptionTier.NONE,
-    },
-    {
-      input: SubscriptionTier.SubscriptionTierPro,
-      expected: CommonSubscriptionTier.PRO,
-    },
-    {
-      input: SubscriptionTier.SubscriptionTierProPlus,
-      expected: CommonSubscriptionTier.PRO_PLUS,
-    },
-  ];
-  tests.forEach(({ input, expected }) => {
-    it(`normalizes ${input}`, () => {
-      expect(normalizeSubscriptionTier(input)).to.equal(expected);
-    });
-  });
-
-  it('throws an error if unspecified', () => {
-    expect(() =>
-      normalizeSubscriptionTier(SubscriptionTier.SubscriptionTierUnspecified),
-    ).to.throw(/Unknown subscription tier:/);
   });
 });
 

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -5,7 +5,7 @@
  */
 
 import assert from 'assert';
-import { randomUUID, UUID } from 'crypto';
+import { randomUUID } from 'crypto';
 import fetch, {
   Headers,
   Request,
@@ -15,14 +15,7 @@ import fetch, {
 } from 'node-fetch';
 import vscode, { Disposable } from 'vscode';
 import { ColabClient } from '../colab/client/v1';
-import {
-  Assignment,
-  ListedAssignment,
-  RuntimeProxyToken,
-  variantToMachineType,
-  isHighMemOnlyAccelerator,
-  ExperimentFlag,
-} from '../colab/client/v1/api';
+import { variantToMachineType } from '../colab/client/v1/api';
 import {
   AssertedRuntime,
   ColabApiClient,
@@ -37,7 +30,6 @@ import {
   CreateRuntimeOperationFromJSON,
   Runtime,
   ResponseError,
-  instanceOfRuntime,
 } from '../colab/client/v2/generated/colab';
 import { REMOVE_SERVER } from '../colab/commands/constants';
 import {
@@ -48,18 +40,16 @@ import {
   TooManyAssignmentsError,
   WaitOperationTimeoutError,
 } from '../colab/errors';
-import { getFlag } from '../colab/experiment-state';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../colab/headers';
-import { Shape, SubscriptionTier, Variant } from '../colab/types';
+import { Shape, Variant } from '../colab/types';
 import { waitForTimeout } from '../common/async';
 import { log } from '../common/logging';
 import { FetchError as JupyterFetchError } from '../jupyter/client/generated';
 import { telemetry } from '../telemetry';
 import { AssignmentOutcome, CommandSource } from '../telemetry/api';
-import { isUUID } from '../utils/uuid';
 import { ProxiedJupyterClient } from './client';
 import { colabProxyWebSocket } from './colab-proxy-websocket';
 import {
@@ -154,56 +144,28 @@ export class AssignmentManager implements Disposable {
     signal?: AbortSignal,
   ): Promise<ColabServerDescriptor[]> {
     this.guardDisposed();
-    const enablePublicApi = getFlag(ExperimentFlag.EnablePublicApi);
-    if (enablePublicApi) {
-      // The new ListRuntimeSpecs API already takes user's subscription tier
-      // into account, returning with the correct eligibility info. The new API
-      // also returns additional high-memory shapes for the Pro users, so we
-      // don't need to manually add them.
-      const response = await this.colabApiClient.colab.listRuntimeSpecs(
-        /* requestParameters= */ {},
-        /* initOverrides= */ { signal },
-      );
-      return (
-        response.runtimeSpecs
-          ?.filter((spec) => spec.eligible)
-          .map((spec) => {
-            const variant = normalizeVariant(spec.key.variant);
-            const shape = normalizeShape(spec.key.shape);
-            const accelerator = spec.key.accelerator;
-            const label =
-              variant === Variant.DEFAULT
-                ? 'Colab CPU'
-                : `Colab ${variant} ${accelerator}`;
-            return { label, variant, accelerator, shape };
-          }) ?? []
-      );
-    }
-
-    const userInfo = await this.colabClient.getUserInfo(signal);
-
-    const eligibleDescriptors: ColabServerDescriptor[] =
-      userInfo.eligibleAccelerators.flatMap((acc) =>
-        acc.models.map((model) => ({
-          label: `Colab ${acc.variant} ${model}`,
-          variant: acc.variant,
-          accelerator: model,
-        })),
-      );
-
-    const defaultDescriptors = [DEFAULT_CPU_SERVER, ...eligibleDescriptors];
-    if (userInfo.subscriptionTier === SubscriptionTier.NONE) {
-      return defaultDescriptors;
-    }
-
-    const proDescriptors = [];
-    for (const descriptor of defaultDescriptors) {
-      if (!isHighMemOnlyAccelerator(descriptor.accelerator)) {
-        proDescriptors.push({ ...descriptor, shape: Shape.STANDARD });
-      }
-      proDescriptors.push({ ...descriptor, shape: Shape.HIGHMEM });
-    }
-    return proDescriptors;
+    // The new ListRuntimeSpecs API already takes user's subscription tier
+    // into account, returning with the correct eligibility info. The new API
+    // also returns additional high-memory shapes for the Pro users, so we
+    // don't need to manually add them.
+    const response = await this.colabApiClient.colab.listRuntimeSpecs(
+      /* requestParameters= */ {},
+      /* initOverrides= */ { signal },
+    );
+    return (
+      response.runtimeSpecs
+        ?.filter((spec) => spec.eligible)
+        .map((spec) => {
+          const variant = normalizeVariant(spec.key.variant);
+          const shape = normalizeShape(spec.key.shape);
+          const accelerator = spec.key.accelerator;
+          const label =
+            variant === Variant.DEFAULT
+              ? 'Colab CPU'
+              : `Colab ${variant} ${accelerator}`;
+          return { label, variant, accelerator, shape };
+        }) ?? []
+    );
   }
 
   /**
@@ -224,10 +186,10 @@ export class AssignmentManager implements Disposable {
       return;
     }
 
-    const live = await this.listLiveAssignments(signal);
+    const live = await this.listAssignedRuntimes(signal);
     await this.reconcileStoredServers(
       stored,
-      live.map((a) => getEndpoint(a)),
+      live.map((r) => r.connectionInfo.endpoint),
     );
   }
 
@@ -289,13 +251,13 @@ export class AssignmentManager implements Disposable {
       return storedServers;
     }
 
-    const allAssignments = await this.listLiveAssignments(signal);
+    const allAssignedRuntimes = await this.listAssignedRuntimes(signal);
 
     if (from === 'extension' || from === 'all') {
       storedServers = (
         await this.reconcileStoredServers(
           storedServers,
-          allAssignments.map((a) => getEndpoint(a)),
+          allAssignedRuntimes.map((r) => r.connectionInfo.endpoint),
         )
       ).map((server) => {
         const c = server.connectionInformation;
@@ -313,7 +275,7 @@ export class AssignmentManager implements Disposable {
     let unownedServers: UnownedServer[] = [];
     if (from === 'external' || from === 'all') {
       unownedServers = await this.getUnownedServers(
-        allAssignments,
+        allAssignedRuntimes,
         storedServers,
         signal,
       );
@@ -370,36 +332,19 @@ export class AssignmentManager implements Disposable {
     const { label, variant, accelerator, shape, version } = descriptor;
     let outcome = AssignmentOutcome.ASSIGNMENT_OUTCOME_UNSPECIFIED;
     let hadFallback = false;
-    const enablePublicApi = getFlag(ExperimentFlag.EnablePublicApi);
     try {
-      let assignmentOrRuntime: Assignment | Runtime;
+      let runtime: Runtime;
       try {
         if (isColabServerDescriptorWithAccelerator(descriptor)) {
-          assignmentOrRuntime = await this.assignWithFallback(
+          runtime = await this.assignWithFallback(
             descriptor,
-            /* id= */ enablePublicApi ? undefined : id,
             /* fallback= */ undefined,
             signal,
           );
-          if (instanceOfRuntime(assignmentOrRuntime)) {
-            hadFallback =
-              assignmentOrRuntime.runtimeSpec.accelerator !==
-              descriptor.accelerator;
-          } else {
-            hadFallback =
-              assignmentOrRuntime.accelerator !== descriptor.accelerator;
-          }
+          hadFallback =
+            runtime.runtimeSpec.accelerator !== descriptor.accelerator;
         } else {
-          if (enablePublicApi) {
-            assignmentOrRuntime = await this.createRuntime(descriptor, signal);
-          } else {
-            ({ assignment: assignmentOrRuntime } =
-              await this.colabClient.assign(
-                id,
-                { variant, accelerator, shape, version },
-                signal,
-              ));
-          }
+          runtime = await this.createRuntime(descriptor, signal);
         }
       } catch (error) {
         log.trace(`Failed assigning server ${id}`, error);
@@ -424,40 +369,23 @@ export class AssignmentManager implements Disposable {
         throw error;
       }
 
-      let server: ColabAssignedServer;
-      if (instanceOfRuntime(assignmentOrRuntime)) {
-        assert(assignmentOrRuntime.name, MISSING_RUNTIME_NAME_ERR_MSG);
-        const runtimeId = trimPrefix(assignmentOrRuntime.name, 'runtimes/');
-        const c = assignmentOrRuntime.connectionInfo;
-        assert(c, `${MISSING_CONNECTION_INFO_ERR_MSG}: ${runtimeId}`);
-        server = this.toAssignedServer(
-          {
-            id: runtimeId,
-            label,
-            variant: normalizeVariant(assignmentOrRuntime.runtimeSpec.variant),
-            accelerator: assignmentOrRuntime.runtimeSpec.accelerator,
-            shape: normalizeShape(assignmentOrRuntime.runtimeSpec.shape),
-            version: assignmentOrRuntime.version,
-          },
-          c.endpoint,
-          c,
-          new Date(),
-        );
-      } else {
-        server = this.toAssignedServer(
-          {
-            id,
-            label,
-            variant: assignmentOrRuntime.variant,
-            accelerator: assignmentOrRuntime.accelerator,
-            shape: assignmentOrRuntime.machineShape,
-            version,
-          },
-          assignmentOrRuntime.endpoint,
-          assignmentOrRuntime.runtimeProxyInfo,
-          new Date(),
-        );
-      }
+      assert(runtime.name, MISSING_RUNTIME_NAME_ERR_MSG);
+      const runtimeId = trimPrefix(runtime.name, 'runtimes/');
+      const c = runtime.connectionInfo;
+      assert(c, `${MISSING_CONNECTION_INFO_ERR_MSG}: ${runtimeId}`);
+      const server = this.toAssignedServer(
+        {
+          id: runtimeId,
+          label,
+          variant: normalizeVariant(runtime.runtimeSpec.variant),
+          accelerator: runtime.runtimeSpec.accelerator,
+          shape: normalizeShape(runtime.runtimeSpec.shape),
+          version: runtime.version,
+        },
+        c.endpoint,
+        c,
+        new Date(),
+      );
       await this.storage.store([server]);
       this.assignmentChange.fire({
         added: [server],
@@ -546,31 +474,16 @@ export class AssignmentManager implements Disposable {
       throw new NotFoundError('Server is not assigned');
     }
 
-    let newConnectionInfo: RuntimeProxyToken | ConnectionInfo;
-    // If the id is in UUID format, it means the server was assigned by the old
-    // v1 client. Use the v1 client to refresh the connection in this case.
-    if (isUUID(id)) {
-      newConnectionInfo = await this.colabClient.refreshConnection(
-        server.endpoint,
-        signal,
-      );
-    } else {
-      // Otherwise, use the new v2 client to get a fresh connection info.
-      const runtime = await this.colabApiClient.colab.getRuntime(
-        { runtime: id },
-        { signal },
-      );
-      assert(
-        runtime.connectionInfo,
-        `${MISSING_CONNECTION_INFO_ERR_MSG}: ${id}`,
-      );
-      newConnectionInfo = runtime.connectionInfo;
-    }
+    const runtime = await this.colabApiClient.colab.getRuntime(
+      { runtime: id },
+      { signal },
+    );
+    assert(runtime.connectionInfo, `${MISSING_CONNECTION_INFO_ERR_MSG}: ${id}`);
 
     const updatedServer = this.toAssignedServer(
       server,
       server.endpoint,
-      newConnectionInfo,
+      runtime.connectionInfo,
       server.dateAssigned,
     );
     await this.storage.store([updatedServer]);
@@ -602,12 +515,7 @@ export class AssignmentManager implements Disposable {
   ): Promise<void> {
     this.guardDisposed();
     if (!isColabAssignedServer(server)) {
-      const enablePublicApi = getFlag(ExperimentFlag.EnablePublicApi);
-      if (enablePublicApi) {
-        await this.deleteRuntime(server.id, signal);
-      } else {
-        await this.colabClient.unassign(server.endpoint, signal);
-      }
+      await this.deleteRuntime(server.id, signal);
       return;
     }
 
@@ -616,15 +524,7 @@ export class AssignmentManager implements Disposable {
       return;
     }
     await this.deleteSessions(server, signal);
-
-    // If the id is in UUID format, it means the server was assigned by the old
-    // v1 client. Use the v1 client to unassign in this case.
-    if (isUUID(server.id)) {
-      await this.colabClient.unassign(server.endpoint, signal);
-    } else {
-      // Otherwise, use the new v2 client to delete the runtime.
-      await this.deleteRuntime(server.id, signal);
-    }
+    await this.deleteRuntime(server.id, signal);
 
     const removed = await this.storage.remove(server.id);
     if (!removed) {
@@ -722,28 +622,15 @@ export class AssignmentManager implements Disposable {
 
   private async assignWithFallback(
     descriptor: ColabServerDescriptorWithAccelerator,
-    id?: UUID,
     fallback?: {
       toAttempt: string[];
       attempted: string[];
     },
     signal?: AbortSignal,
-  ): Promise<Assignment | Runtime> {
-    const { variant, accelerator, shape, version } = descriptor;
+  ): Promise<Runtime> {
+    const { variant, accelerator } = descriptor;
     try {
-      let assignment: Assignment | Runtime;
-      if (id) {
-        // Take the old v1 route if an `id` is passed in.
-        ({ assignment } = await this.colabClient.assign(
-          id,
-          { variant, accelerator, shape, version },
-          signal,
-        ));
-      } else {
-        // Otherwise, take the new v2 route.
-        assignment = await this.createRuntime(descriptor, signal);
-      }
-
+      const runtime = await this.createRuntime(descriptor, signal);
       const original = fallback?.attempted
         ? fallback.attempted[0]
         : accelerator;
@@ -752,7 +639,7 @@ export class AssignmentManager implements Disposable {
           `Requested accelerator "${original}" is unavailable, assigned "${accelerator}"`,
         );
       }
-      return assignment;
+      return runtime;
     } catch (error) {
       if (!(error instanceof AcceleratorUnavailableError)) {
         throw error;
@@ -795,7 +682,6 @@ export class AssignmentManager implements Disposable {
       );
       return this.assignWithFallback(
         { ...descriptor, accelerator: newFallback.toAttempt[0] },
-        id,
         newFallback,
         signal,
       );
@@ -805,7 +691,7 @@ export class AssignmentManager implements Disposable {
   private toAssignedServer(
     server: ColabJupyterServer,
     endpoint: string,
-    connectionInfo: RuntimeProxyToken | ConnectionInfo,
+    connectionInfo: ConnectionInfo,
     dateAssigned: Date,
   ): ColabAssignedServer {
     const { url, token } = connectionInfo;
@@ -814,17 +700,13 @@ export class AssignmentManager implements Disposable {
     headers[COLAB_RUNTIME_PROXY_TOKEN_HEADER.key] = token;
     headers[COLAB_CLIENT_AGENT_HEADER.key] = COLAB_CLIENT_AGENT_HEADER.value;
 
-    const tokenExpiry =
-      'expireTime' in connectionInfo
-        ? connectionInfo.expireTime
-        : new Date(Date.now() + connectionInfo.tokenExpiresInSeconds * 1000);
     const colabServer: ColabAssignedServer = {
       ...server,
       endpoint,
       connectionInformation: {
         baseUrl: this.vs.Uri.parse(url),
         token,
-        tokenExpiry,
+        tokenExpiry: connectionInfo.expireTime,
         headers,
         fetch: colabProxyFetch(token),
       },
@@ -840,7 +722,7 @@ export class AssignmentManager implements Disposable {
   }
 
   private async getUnownedServers(
-    allAssignments: ListedAssignment[] | AssertedRuntime[],
+    allAssignedRuntimes: AssertedRuntime[],
     storedServers: ColabAssignedServer[],
     signal?: AbortSignal,
   ): Promise<UnownedServer[]> {
@@ -848,10 +730,10 @@ export class AssignmentManager implements Disposable {
 
     return (
       await Promise.all(
-        allAssignments
-          .filter((a) => !storedEndpointSet.has(getEndpoint(a)))
-          .map(async (a): Promise<UnownedServer | undefined> => {
-            const endpoint = getEndpoint(a);
+        allAssignedRuntimes
+          .filter((r) => !storedEndpointSet.has(r.connectionInfo.endpoint))
+          .map(async (r): Promise<UnownedServer | undefined> => {
+            const endpoint = r.connectionInfo.endpoint;
             // For any remote servers created in Colab web UI, assuming there
             // is only one session per assignment.
             let label = UNKNOWN_REMOTE_SERVER_NAME;
@@ -860,20 +742,10 @@ export class AssignmentManager implements Disposable {
               `Listing sessions timeout exceeded for endpoint ${endpoint}`,
             );
 
-            let connectionInfo: ConnectionInfo | RuntimeProxyToken;
-            if (instanceOfRuntime(a)) {
-              connectionInfo = a.connectionInfo;
-            } else {
-              if (!a.runtimeProxyInfo) {
-                return toUnownedServer(label, a);
-              }
-              connectionInfo = a.runtimeProxyInfo;
-            }
-
             try {
               const jupyterClient = ProxiedJupyterClient.withStaticConnection(
-                connectionInfo.url,
-                connectionInfo.token,
+                r.connectionInfo.url,
+                r.connectionInfo.token,
               );
               const sessions = await Promise.race([
                 jupyterClient.sessions.list({ signal }),
@@ -904,7 +776,7 @@ export class AssignmentManager implements Disposable {
             } finally {
               timeout.dispose();
             }
-            return toUnownedServer(label, a);
+            return toUnownedServer(label, r);
           }),
       )
     ).filter((s): s is UnownedServer => s !== undefined);
@@ -1019,14 +891,9 @@ export class AssignmentManager implements Disposable {
     });
   }
 
-  private async listLiveAssignments(
+  private async listAssignedRuntimes(
     signal?: AbortSignal,
-  ): Promise<AssertedRuntime[] | ListedAssignment[]> {
-    const enablePublicApi = getFlag(ExperimentFlag.EnablePublicApi);
-    if (!enablePublicApi) {
-      return this.colabClient.listAssignments(signal);
-    }
-
+  ): Promise<AssertedRuntime[]> {
     const runtimes =
       (
         await this.colabApiClient.colab.listRuntimes(
@@ -1225,36 +1092,17 @@ function isColabServerDescriptorWithAccelerator(
 
 function toUnownedServer(
   label: string,
-  assignmentOrRuntime: AssertedRuntime | ListedAssignment,
+  runtime: AssertedRuntime,
 ): UnownedServer {
-  if (instanceOfRuntime(assignmentOrRuntime)) {
-    return {
-      id: trimPrefix(assignmentOrRuntime.name, 'runtimes/'),
-      label,
-      endpoint: assignmentOrRuntime.connectionInfo.endpoint,
-      variant: normalizeVariant(assignmentOrRuntime.runtimeSpec.variant),
-      accelerator: assignmentOrRuntime.runtimeSpec.accelerator,
-      shape: normalizeShape(assignmentOrRuntime.runtimeSpec.shape),
-      version: assignmentOrRuntime.version,
-    };
-  }
   return {
-    id: assignmentOrRuntime.notebookIdHash ?? '',
+    id: trimPrefix(runtime.name, 'runtimes/'),
     label,
-    endpoint: assignmentOrRuntime.endpoint,
-    variant: assignmentOrRuntime.variant,
-    accelerator: assignmentOrRuntime.accelerator,
-    shape: assignmentOrRuntime.machineShape,
-    version: assignmentOrRuntime.runtimeVersionLabel,
+    endpoint: runtime.connectionInfo.endpoint,
+    variant: normalizeVariant(runtime.runtimeSpec.variant),
+    accelerator: runtime.runtimeSpec.accelerator,
+    shape: normalizeShape(runtime.runtimeSpec.shape),
+    version: runtime.version,
   };
-}
-
-function getEndpoint(
-  assignmentOrRuntime: AssertedRuntime | ListedAssignment,
-): string {
-  return instanceOfRuntime(assignmentOrRuntime)
-    ? assignmentOrRuntime.connectionInfo.endpoint
-    : assignmentOrRuntime.endpoint;
 }
 
 function errorToAssignmentOutcome(error: unknown): AssignmentOutcome {

--- a/src/jupyter/assignments.unit.test.ts
+++ b/src/jupyter/assignments.unit.test.ts
@@ -15,14 +15,6 @@ import sinon, {
 import { MessageItem, Uri } from 'vscode';
 import { ColabClient } from '../colab/client/v1';
 import {
-  Assignment,
-  ExperimentFlag,
-  ListedAssignment,
-  RuntimeProxyToken,
-  SubscriptionState,
-  UserInfo,
-} from '../colab/client/v1/api';
-import {
   ColabApiClient,
   denormalizeShape,
   denormalizeVariant,
@@ -38,19 +30,17 @@ import {
 import { ColaboratoryApi as OperationsApi } from '../colab/client/v2/generated/operations';
 import { REMOVE_SERVER } from '../colab/commands/constants';
 import {
-  AcceleratorUnavailableError,
   DenylistedError,
   InsufficientQuotaError,
   NotFoundError,
   TooManyAssignmentsError,
   WaitOperationTimeoutError,
 } from '../colab/errors';
-import { TEST_ONLY as EXPERIMENT_TEST } from '../colab/experiment-state';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../colab/headers';
-import { Shape, SubscriptionTier, Variant } from '../colab/types';
+import { Shape, Variant } from '../colab/types';
 import {
   FetchError as JupyterFetchError,
   ResponseError as JupyterResponseError,
@@ -80,50 +70,12 @@ const NOW = new Date();
 const TOKEN_EXPIRY_MS = 1000 * 60 * 60;
 const LIST_UNOWNED_SESSIONS_TIMEOUT_MS = 3000;
 
-const defaultAssignmentDescriptor: ColabServerDescriptor = {
+const defaultServerDescriptor: ColabServerDescriptor = {
   label: 'Colab GPU A100',
   variant: Variant.GPU,
   accelerator: 'A100',
   shape: Shape.STANDARD,
   version: '2026.04',
-};
-
-const defaultAssignment: Assignment & {
-  runtimeProxyInfo: RuntimeProxyToken;
-  runtimeVersionLabel?: string;
-  notebookIdHash: string;
-} = {
-  accelerator: 'A100',
-  endpoint: 'm-s-foo',
-  idleTimeoutSec: 30,
-  subscriptionState: SubscriptionState.UNSUBSCRIBED,
-  subscriptionTier: SubscriptionTier.NONE,
-  variant: Variant.GPU,
-  machineShape: Shape.STANDARD,
-  runtimeProxyInfo: {
-    token: 'mock-token',
-    tokenExpiresInSeconds: TOKEN_EXPIRY_MS / 1000,
-    url: 'https://example.com',
-  },
-  runtimeVersionLabel: '2026.04',
-  notebookIdHash: 'mock-notebook-id-hash',
-};
-
-const defaultServer: ColabAssignedServer = {
-  ...defaultAssignmentDescriptor,
-  id: randomUUID(),
-  endpoint: defaultAssignment.endpoint,
-  connectionInformation: {
-    baseUrl: TestUri.parse(defaultAssignment.runtimeProxyInfo.url),
-    token: defaultAssignment.runtimeProxyInfo.token,
-    tokenExpiry: new Date(NOW.getTime() + TOKEN_EXPIRY_MS),
-    headers: {
-      [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
-        defaultAssignment.runtimeProxyInfo.token,
-      [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
-    },
-  },
-  dateAssigned: NOW,
 };
 
 const defaultRuntimeId = `r-${randomUUID()}`;
@@ -140,7 +92,7 @@ const defaultRuntime = {
     expireTime: new Date(NOW.getTime() + TOKEN_EXPIRY_MS),
     endpoint: 'm-s-foo',
   },
-  version: defaultAssignmentDescriptor.version,
+  version: defaultServerDescriptor.version,
 } satisfies Runtime;
 const defaultRawRuntime = {
   ...defaultRuntime,
@@ -150,15 +102,21 @@ const defaultRawRuntime = {
   },
 };
 
-const defaultServerV2: ColabAssignedServer = {
-  ...defaultServer,
-  ...defaultAssignmentDescriptor,
+const defaultServer: ColabAssignedServer = {
+  ...defaultServerDescriptor,
   id: defaultRuntimeId,
-};
-
-const defaultLiveFixtures: LiveFixture = {
-  runtime: defaultRuntime,
-  assignment: defaultAssignment,
+  endpoint: defaultRuntime.connectionInfo.endpoint,
+  connectionInformation: {
+    baseUrl: TestUri.parse(defaultRuntime.connectionInfo.url),
+    token: defaultRuntime.connectionInfo.token,
+    tokenExpiry: new Date(NOW.getTime() + TOKEN_EXPIRY_MS),
+    headers: {
+      [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
+        defaultRuntime.connectionInfo.token,
+      [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
+    },
+  },
+  dateAssigned: NOW,
 };
 
 const runtimeWithoutName = {
@@ -189,39 +147,6 @@ describe('AssignmentManager', () => {
   let getRuntimeStub: sinon.SinonStub;
   let listRuntimesStub: sinon.SinonStub;
   let waitOperationStub: sinon.SinonStub;
-
-  /**
-   * Set up the stubs to return the given assignments from both the Colab client
-   * and the server storage.
-   *
-   * The stored server and mocked assignment use {@link defaultServer} and
-   * {@link defaultAssignment} as templates, with fields overridden from the
-   * given assignments.
-   *
-   * @param assignments - The assignments to set up as both stored and returned
-   * by the Colab client.
-   */
-  async function setupAssignments(assignments: ColabServerDescriptor[]) {
-    colabClientStub.listAssignments.resolves(
-      assignments.map(
-        (a): Assignment => ({
-          ...defaultAssignment,
-          variant: a.variant,
-          accelerator: a.accelerator ?? 'NONE',
-        }),
-      ),
-    );
-    await serverStorage.store(
-      assignments.map(
-        (a): ColabAssignedServer => ({
-          ...defaultServer,
-          variant: a.variant,
-          accelerator: a.accelerator ?? 'NONE',
-          label: a.label,
-        }),
-      ),
-    );
-  }
 
   /**
    * Set up the stubs to return the given runtimes from both the Colab client
@@ -298,7 +223,6 @@ describe('AssignmentManager', () => {
   });
 
   afterEach(() => {
-    EXPERIMENT_TEST.resetExperimentsForTest();
     fakeClock.restore();
     sinon.restore();
   });
@@ -318,169 +242,199 @@ describe('AssignmentManager', () => {
       accelerator: 'T4',
     };
 
-    const defaultGpuA100Descriptor = {
-      label: 'Colab GPU A100',
-      variant: Variant.GPU,
-      accelerator: 'A100',
-    };
-
     const defaultTpuV5E1Descriptor = {
       label: 'Colab TPU V5E1',
       variant: Variant.TPU,
       accelerator: 'V5E1',
     };
 
-    const defaultTpuV6E1Descriptor = {
-      label: 'Colab TPU V6E1',
-      variant: Variant.TPU,
-      accelerator: 'V6E1',
+    const defaultCpuSpec = {
+      variant: 'VARIANT_CPU',
+      shape: 'SHAPE_STANDARD',
+      accelerator: 'NONE',
+    };
+    const defaultGpuSpec = {
+      variant: 'VARIANT_GPU',
+      shape: 'SHAPE_STANDARD',
+      accelerator: 'T4',
+    };
+    const defaultTpuSpec = {
+      variant: 'VARIANT_TPU',
+      shape: 'SHAPE_STANDARD',
+      accelerator: 'V5E1',
     };
 
-    describe('with Public API disabled', () => {
-      const mockUserInfo: UserInfo = {
-        subscriptionTier: SubscriptionTier.NONE,
-        paidComputeUnitsBalance: 1,
-        eligibleAccelerators: [
+    beforeEach(() => {
+      listRuntimeSpecsStub.resolves({
+        runtimeSpecs: [
           {
-            variant: Variant.GPU,
-            models: ['T4', 'A100'],
+            key: defaultCpuSpec,
+            eligible: true,
           },
           {
-            variant: Variant.TPU,
-            models: ['V5E1', 'V6E1'],
+            key: defaultGpuSpec,
+            eligible: true,
+          },
+          {
+            key: defaultTpuSpec,
+            eligible: true,
+          },
+          {
+            key: {
+              variant: 'VARIANT_GPU',
+              shape: 'SHAPE_HIGHMEM',
+              accelerator: 'DOES_NOT_MATTER',
+            },
+            eligible: false,
           },
         ],
-        ineligibleAccelerators: [],
-      };
-
-      beforeEach(() => {
-        EXPERIMENT_TEST.setFlagForTest(ExperimentFlag.EnablePublicApi, false);
-      });
-
-      it('returns the default CPU and the eligible servers', async () => {
-        colabClientStub.getUserInfo.resolves(mockUserInfo);
-
-        const servers = await assignmentManager.getAvailableServerDescriptors();
-
-        expect(servers).to.deep.equal([
-          DEFAULT_CPU_SERVER,
-          defaultGpuT4Descriptor,
-          defaultGpuA100Descriptor,
-          defaultTpuV5E1Descriptor,
-          defaultTpuV6E1Descriptor,
-        ]);
-      });
-
-      it('returns the default CPU and the eligible servers for pro users', async () => {
-        colabClientStub.getUserInfo.resolves({
-          ...mockUserInfo,
-          subscriptionTier: SubscriptionTier.PRO,
-        });
-
-        const servers = await assignmentManager.getAvailableServerDescriptors();
-
-        expect(servers).to.deep.equal([
-          { ...DEFAULT_CPU_SERVER, shape: Shape.STANDARD },
-          { ...DEFAULT_CPU_SERVER, shape: Shape.HIGHMEM },
-          { ...defaultGpuT4Descriptor, shape: Shape.STANDARD },
-          { ...defaultGpuT4Descriptor, shape: Shape.HIGHMEM },
-          { ...defaultGpuA100Descriptor, shape: Shape.STANDARD },
-          { ...defaultGpuA100Descriptor, shape: Shape.HIGHMEM },
-          { ...defaultTpuV5E1Descriptor, shape: Shape.HIGHMEM },
-          { ...defaultTpuV6E1Descriptor, shape: Shape.HIGHMEM },
-        ]);
       });
     });
 
-    describe('with Public API enabled', () => {
-      const defaultCpuSpec = {
-        variant: 'VARIANT_CPU',
-        shape: 'SHAPE_STANDARD',
-        accelerator: 'NONE',
-      };
-      const defaultGpuSpec = {
-        variant: 'VARIANT_GPU',
-        shape: 'SHAPE_STANDARD',
-        accelerator: 'T4',
-      };
-      const defaultTpuSpec = {
-        variant: 'VARIANT_TPU',
-        shape: 'SHAPE_STANDARD',
-        accelerator: 'V5E1',
-      };
-
-      beforeEach(() => {
-        EXPERIMENT_TEST.setFlagForTest(ExperimentFlag.EnablePublicApi, true);
-        listRuntimeSpecsStub.resolves({
-          runtimeSpecs: [
-            {
-              key: defaultCpuSpec,
-              eligible: true,
-            },
-            {
-              key: defaultGpuSpec,
-              eligible: true,
-            },
-            {
-              key: defaultTpuSpec,
-              eligible: true,
-            },
-            {
-              key: {
-                variant: 'VARIANT_GPU',
-                shape: 'SHAPE_HIGHMEM',
-                accelerator: 'DOES_NOT_MATTER',
-              },
-              eligible: false,
-            },
-          ],
-        });
-      });
-
-      it('returns the eligible server specs', async () => {
-        await expect(
-          assignmentManager.getAvailableServerDescriptors(),
-        ).to.eventually.deep.equal([
-          { ...DEFAULT_CPU_SERVER, shape: Shape.STANDARD, accelerator: 'NONE' },
-          { ...defaultGpuT4Descriptor, shape: Shape.STANDARD },
-          { ...defaultTpuV5E1Descriptor, shape: Shape.STANDARD },
-        ]);
-      });
+    it('returns the eligible server specs', async () => {
+      await expect(
+        assignmentManager.getAvailableServerDescriptors(),
+      ).to.eventually.deep.equal([
+        { ...DEFAULT_CPU_SERVER, shape: Shape.STANDARD, accelerator: 'NONE' },
+        { ...defaultGpuT4Descriptor, shape: Shape.STANDARD },
+        { ...defaultTpuV5E1Descriptor, shape: Shape.STANDARD },
+      ]);
     });
   });
 
   describe('reconcileAssignedServers', () => {
-    forEachPublicApiFlag((enablePublicApi) => {
-      it('throws after being disposed', async () => {
-        assignmentManager.dispose();
+    it('throws after being disposed', async () => {
+      assignmentManager.dispose();
 
-        await expect(
-          assignmentManager.reconcileAssignedServers(),
-        ).to.be.rejectedWith(/disposed/);
+      await expect(
+        assignmentManager.reconcileAssignedServers(),
+      ).to.be.rejectedWith(/disposed/);
+    });
+
+    it('does nothing when there are no stored servers', async () => {
+      await assignmentManager.reconcileAssignedServers();
+
+      sinon.assert.notCalled(vsCodeStub.commands.executeCommand);
+      sinon.assert.notCalled(assignmentChangeListener);
+      sinon.assert.notCalled(vsCodeStub.window.showInformationMessage);
+    });
+
+    it('does nothing when no servers need reconciling', async () => {
+      await serverStorage.store([defaultServer]);
+      listRuntimesStub.resolves({ runtimes: [defaultRuntime] });
+
+      await assignmentManager.reconcileAssignedServers();
+
+      sinon.assert.notCalled(vsCodeStub.commands.executeCommand);
+      sinon.assert.notCalled(assignmentChangeListener);
+      sinon.assert.notCalled(vsCodeStub.window.showInformationMessage);
+    });
+
+    it('reconciles a single assigned server when it is the only one', async () => {
+      await serverStorage.store([defaultServer]);
+      listRuntimesStub.resolves({ runtimes: [] });
+
+      await assignmentManager.reconcileAssignedServers();
+
+      await expect(assignmentManager.getServers('extension')).to.eventually.be
+        .empty;
+      sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+        added: [],
+        removed: [{ server: defaultServer, userInitiated: false }],
+        changed: [],
+      });
+      sinon.assert.calledOnceWithMatch(
+        vsCodeStub.window.showInformationMessage,
+        sinon.match(/notebooks Colab GPU A100 was/),
+      );
+    });
+
+    it('prunes server without connection info', async () => {
+      await serverStorage.store([defaultServer]);
+      listRuntimesStub.resolves({
+        runtimes: [runtimeWithoutConnectionInfo],
       });
 
-      it('does nothing when there are no stored servers', async () => {
+      await assignmentManager.reconcileAssignedServers();
+
+      await expect(assignmentManager.getServers('extension')).to.eventually.be
+        .empty;
+      sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+        added: [],
+        removed: [{ server: defaultServer, userInitiated: false }],
+        changed: [],
+      });
+      sinon.assert.calledOnceWithMatch(
+        vsCodeStub.window.showInformationMessage,
+        sinon.match(/notebooks Colab GPU A100 was/),
+      );
+    });
+
+    describe('with multiple servers', () => {
+      let servers: [ColabAssignedServer, ColabAssignedServer];
+      let liveRuntimes: [Runtime, Runtime];
+      const secondRuntimeId = `r-${randomUUID()}`;
+
+      beforeEach(() => {
+        servers = [
+          defaultServer,
+          {
+            ...defaultServer,
+            label: 'Second Server',
+            id: secondRuntimeId,
+            endpoint: 'm-s-bar',
+            connectionInformation: {
+              ...defaultServer.connectionInformation,
+              baseUrl: vsCodeStub.Uri.parse('https://example2.com'),
+            },
+          },
+        ];
+        liveRuntimes = [
+          defaultRuntime,
+          {
+            ...defaultRuntime,
+            name: `runtimes/${secondRuntimeId}`,
+            connectionInfo: {
+              ...defaultRuntime.connectionInfo,
+              endpoint: servers[1].endpoint,
+            },
+          },
+        ];
+      });
+
+      it('reconciles a single assigned server when there are others', async () => {
+        await serverStorage.store(servers);
+        listRuntimesStub.resolves({ runtimes: [liveRuntimes[0]] });
+
         await assignmentManager.reconcileAssignedServers();
 
-        sinon.assert.notCalled(vsCodeStub.commands.executeCommand);
-        sinon.assert.notCalled(assignmentChangeListener);
-        sinon.assert.notCalled(vsCodeStub.window.showInformationMessage);
+        const serversAfter = await assignmentManager.getServers('extension');
+        expect(stripNetworkOverrides(serversAfter)).to.deep.equal([servers[0]]);
+        sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+          added: [],
+          removed: [{ server: servers[1], userInitiated: false }],
+          changed: [],
+        });
+        sinon.assert.calledOnceWithMatch(
+          vsCodeStub.window.showInformationMessage,
+          sinon.match(/notebooks Second Server was/),
+        );
       });
 
-      it('does nothing when no servers need reconciling', async () => {
-        await serverStorage.store([defaultServerV2]);
-        stubLive(enablePublicApi, defaultLiveFixtures);
-
-        await assignmentManager.reconcileAssignedServers();
-
-        sinon.assert.notCalled(vsCodeStub.commands.executeCommand);
-        sinon.assert.notCalled(assignmentChangeListener);
-        sinon.assert.notCalled(vsCodeStub.window.showInformationMessage);
-      });
-
-      it('reconciles a single assigned server when it is the only one', async () => {
-        await serverStorage.store([defaultServerV2]);
-        stubLive(enablePublicApi);
+      it('reconciles multiple assigned servers when all need reconciling', async () => {
+        const thirdServer: ColabAssignedServer = {
+          ...defaultServer,
+          id: `r-${randomUUID()}`,
+          label: 'Third Server',
+          endpoint: 'm-s-baz',
+          connectionInformation: {
+            ...defaultServer.connectionInformation,
+            baseUrl: vsCodeStub.Uri.parse('https://example3.com'),
+          },
+        };
+        const threeServers = [...servers, thirdServer];
+        await serverStorage.store(threeServers);
+        listRuntimesStub.resolves({ runtimes: [] });
 
         await assignmentManager.reconcileAssignedServers();
 
@@ -488,174 +442,59 @@ describe('AssignmentManager', () => {
           .empty;
         sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
           added: [],
-          removed: [{ server: defaultServerV2, userInitiated: false }],
+          removed: threeServers.map((s) => ({
+            server: s,
+            userInitiated: false,
+          })),
           changed: [],
         });
         sinon.assert.calledOnceWithMatch(
           vsCodeStub.window.showInformationMessage,
-          sinon.match(/notebooks Colab GPU A100 was/),
+          sinon.match(
+            /notebooks Colab GPU A100, Second Server and Third Server were/,
+          ),
         );
       });
 
-      if (enablePublicApi) {
-        it('prunes server without connection info', async () => {
-          await serverStorage.store([defaultServerV2]);
-          listRuntimesStub.resolves({
-            runtimes: [runtimeWithoutConnectionInfo],
-          });
+      it('reconciles multiple assigned servers when some need reconciling', async () => {
+        const thirdServer: ColabAssignedServer = {
+          ...defaultServer,
+          label: 'Third Server',
+          id: `r-${randomUUID()}`,
+          endpoint: 'm-s-baz',
+          connectionInformation: {
+            ...defaultServer.connectionInformation,
+            baseUrl: vsCodeStub.Uri.parse('https://example3.com'),
+          },
+        };
+        const twoServers = servers;
+        const threeServers = [...twoServers, thirdServer];
+        await serverStorage.store(threeServers);
+        listRuntimesStub.resolves({ runtimes: liveRuntimes });
 
-          await assignmentManager.reconcileAssignedServers();
+        await assignmentManager.reconcileAssignedServers();
 
-          await expect(assignmentManager.getServers('extension')).to.eventually
-            .be.empty;
-          sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
-            added: [],
-            removed: [{ server: defaultServerV2, userInitiated: false }],
-            changed: [],
-          });
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.window.showInformationMessage,
-            sinon.match(/notebooks Colab GPU A100 was/),
-          );
+        const serversAfter = await assignmentManager.getServers('extension');
+        expect(stripNetworkOverrides(serversAfter)).to.deep.equal([
+          servers[0],
+          servers[1],
+        ]);
+        sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+          added: [],
+          removed: [{ server: thirdServer, userInitiated: false }],
+          changed: [],
         });
-      }
+        sinon.assert.calledOnceWithMatch(
+          vsCodeStub.window.showInformationMessage,
+          sinon.match(/notebooks Third Server was/),
+        );
+      });
 
-      describe('with multiple servers', () => {
-        let servers: [ColabAssignedServer, ColabAssignedServer];
-        let liveFixtures: [LiveFixture, LiveFixture];
-        const secondRuntimeId = `r-${randomUUID()}`;
-
-        beforeEach(() => {
-          servers = [
-            defaultServerV2,
+      it('reconciles ignoring assignments originating out of VS Code', async () => {
+        await serverStorage.store(servers);
+        listRuntimesStub.resolves({
+          runtimes: [
             {
-              ...defaultServerV2,
-              label: 'Second Server',
-              id: secondRuntimeId,
-              endpoint: 'm-s-bar',
-              connectionInformation: {
-                ...defaultServerV2.connectionInformation,
-                baseUrl: vsCodeStub.Uri.parse('https://example2.com'),
-              },
-            },
-          ];
-          liveFixtures = [
-            defaultLiveFixtures,
-            {
-              runtime: {
-                ...defaultRuntime,
-                name: `runtimes/${secondRuntimeId}`,
-                connectionInfo: {
-                  ...defaultRuntime.connectionInfo,
-                  endpoint: servers[1].endpoint,
-                },
-              },
-              assignment: {
-                ...defaultAssignment,
-                endpoint: 'm-s-bar',
-                runtimeProxyInfo: {
-                  ...defaultAssignment.runtimeProxyInfo,
-                  url: servers[1].connectionInformation.baseUrl.toString(),
-                },
-              },
-            },
-          ];
-        });
-
-        it('reconciles a single assigned server when there are others', async () => {
-          await serverStorage.store(servers);
-          stubLive(enablePublicApi, liveFixtures[0]);
-
-          await assignmentManager.reconcileAssignedServers();
-
-          const serversAfter = await assignmentManager.getServers('extension');
-          expect(stripNetworkOverrides(serversAfter)).to.deep.equal([
-            servers[0],
-          ]);
-          sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
-            added: [],
-            removed: [{ server: servers[1], userInitiated: false }],
-            changed: [],
-          });
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.window.showInformationMessage,
-            sinon.match(/notebooks Second Server was/),
-          );
-        });
-
-        it('reconciles multiple assigned servers when all need reconciling', async () => {
-          const thirdServer: ColabAssignedServer = {
-            ...defaultServerV2,
-            id: `r-${randomUUID()}`,
-            label: 'Third Server',
-            endpoint: 'm-s-baz',
-            connectionInformation: {
-              ...defaultServerV2.connectionInformation,
-              baseUrl: vsCodeStub.Uri.parse('https://example3.com'),
-            },
-          };
-          const threeServers = [...servers, thirdServer];
-          await serverStorage.store(threeServers);
-          stubLive(enablePublicApi);
-
-          await assignmentManager.reconcileAssignedServers();
-
-          await expect(assignmentManager.getServers('extension')).to.eventually
-            .be.empty;
-          sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
-            added: [],
-            removed: threeServers.map((s) => ({
-              server: s,
-              userInitiated: false,
-            })),
-            changed: [],
-          });
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.window.showInformationMessage,
-            sinon.match(
-              /notebooks Colab GPU A100, Second Server and Third Server were/,
-            ),
-          );
-        });
-
-        it('reconciles multiple assigned servers when some need reconciling', async () => {
-          const thirdServer: ColabAssignedServer = {
-            ...defaultServerV2,
-            label: 'Third Server',
-            id: `r-${randomUUID()}`,
-            endpoint: 'm-s-baz',
-            connectionInformation: {
-              ...defaultServerV2.connectionInformation,
-              baseUrl: vsCodeStub.Uri.parse('https://example3.com'),
-            },
-          };
-          const twoServers = servers;
-          const threeServers = [...twoServers, thirdServer];
-          await serverStorage.store(threeServers);
-          stubLive(enablePublicApi, ...liveFixtures);
-
-          await assignmentManager.reconcileAssignedServers();
-
-          const serversAfter = await assignmentManager.getServers('extension');
-          expect(stripNetworkOverrides(serversAfter)).to.deep.equal([
-            servers[0],
-            servers[1],
-          ]);
-          sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
-            added: [],
-            removed: [{ server: thirdServer, userInitiated: false }],
-            changed: [],
-          });
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.window.showInformationMessage,
-            sinon.match(/notebooks Third Server was/),
-          );
-        });
-
-        it('reconciles ignoring assignments originating out of VS Code', async () => {
-          await serverStorage.store(servers);
-          stubLive(enablePublicApi, {
-            runtime: {
               ...defaultRuntime,
               name: `runtimes/r-${randomUUID()}`,
               connectionInfo: {
@@ -664,70 +503,58 @@ describe('AssignmentManager', () => {
                 endpoint: 'm-s-baz',
               },
             },
-            assignment: {
-              ...defaultAssignment,
-              endpoint: 'm-s-baz',
-              runtimeProxyInfo: {
-                ...defaultAssignment.runtimeProxyInfo,
-                url: 'https://not-from-vs-code.com',
-              },
-            },
-          });
-
-          await assignmentManager.reconcileAssignedServers();
-
-          await expect(assignmentManager.getServers('extension')).to.eventually
-            .be.empty;
-          sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
-            added: [],
-            removed: servers.map((s) => ({
-              server: s,
-              userInitiated: false,
-            })),
-            changed: [],
-          });
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.window.showInformationMessage,
-            sinon.match(/notebooks Colab GPU A100 and Second Server were/),
-          );
+          ],
         });
+
+        await assignmentManager.reconcileAssignedServers();
+
+        await expect(assignmentManager.getServers('extension')).to.eventually.be
+          .empty;
+        sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+          added: [],
+          removed: servers.map((s) => ({
+            server: s,
+            userInitiated: false,
+          })),
+          changed: [],
+        });
+        sinon.assert.calledOnceWithMatch(
+          vsCodeStub.window.showInformationMessage,
+          sinon.match(/notebooks Colab GPU A100 and Second Server were/),
+        );
       });
     });
   });
 
   describe('hasAssignedServers', () => {
-    forEachPublicApiFlag((enablePublicApi) => {
-      it('throws after being disposed', async () => {
-        assignmentManager.dispose();
+    it('throws after being disposed', async () => {
+      assignmentManager.dispose();
 
-        await expect(assignmentManager.hasAssignedServer()).to.be.rejectedWith(
-          /disposed/,
-        );
-      });
+      await expect(assignmentManager.hasAssignedServer()).to.be.rejectedWith(
+        /disposed/,
+      );
+    });
 
-      it('returns false when no servers are assigned', async () => {
-        stubLive(enablePublicApi);
+    it('returns false when no servers are assigned', async () => {
+      listRuntimesStub.resolves({ runtimes: [] });
 
-        await expect(assignmentManager.hasAssignedServer()).to.eventually.be
-          .false;
-      });
+      await expect(assignmentManager.hasAssignedServer()).to.eventually.be
+        .false;
+    });
 
-      it('returns true when at least one server is assigned', async () => {
-        if (enablePublicApi) {
-          await setupRuntimes([defaultAssignmentDescriptor]);
-        } else {
-          await setupAssignments([defaultAssignmentDescriptor]);
-        }
+    it('returns true when at least one server is assigned', async () => {
+      await setupRuntimes([defaultServerDescriptor]);
 
-        await expect(assignmentManager.hasAssignedServer()).to.eventually.be
-          .true;
-      });
+      await expect(assignmentManager.hasAssignedServer()).to.eventually.be.true;
+    });
 
-      it('returns true when multiple servers are assigned', async () => {
-        const secondEndpoint = 'm-s-foo-2';
-        const secondRuntimeId = `r-${randomUUID()}`;
-        stubLive(enablePublicApi, defaultLiveFixtures, {
-          runtime: {
+    it('returns true when multiple servers are assigned', async () => {
+      const secondEndpoint = 'm-s-foo-2';
+      const secondRuntimeId = `r-${randomUUID()}`;
+      listRuntimesStub.resolves({
+        runtimes: [
+          defaultRuntime,
+          {
             ...defaultRuntime,
             name: `runtimes/${secondRuntimeId}`,
             connectionInfo: {
@@ -735,73 +562,24 @@ describe('AssignmentManager', () => {
               endpoint: secondEndpoint,
             },
           },
-          assignment: { ...defaultAssignment, endpoint: secondEndpoint },
-        });
-        await serverStorage.store([
-          defaultServerV2,
-          {
-            ...defaultServerV2,
-            id: secondRuntimeId,
-            endpoint: secondEndpoint,
-          },
-        ]);
-
-        await expect(assignmentManager.hasAssignedServer()).to.eventually.be
-          .true;
+        ],
       });
+      await serverStorage.store([
+        defaultServer,
+        {
+          ...defaultServer,
+          id: secondRuntimeId,
+          endpoint: secondEndpoint,
+        },
+      ]);
+
+      await expect(assignmentManager.hasAssignedServer()).to.eventually.be.true;
     });
   });
 
   describe('getServers', () => {
     const TEST_SESSION_NAME = 'test-session-name';
     const UNKNOWN_REMOTE_SERVER_NAME = 'Untitled';
-
-    const assignmentWithName = {
-      ...defaultAssignment,
-      endpoint: 'test-endpoint-with-session-name',
-      notebookIdHash: 'test-notebook-id-hash-with-session-name',
-      runtimeProxyInfo: {
-        ...defaultAssignment.runtimeProxyInfo,
-        url: 'https://test.url.with.session.name',
-      },
-    };
-    const assignmentWithoutName = {
-      ...defaultAssignment,
-      endpoint: 'test-endpoint-without-session-name',
-      notebookIdHash: 'test-notebook-id-hash-without-session-name',
-      runtimeProxyInfo: {
-        ...defaultAssignment.runtimeProxyInfo,
-        url: 'https://test.url.without.session.name',
-      },
-    };
-    const assignmentWithoutSession = {
-      ...defaultAssignment,
-      endpoint: 'test-endpoint-without-session',
-      notebookIdHash: 'test-notebook-id-hash-without-session',
-      runtimeProxyInfo: {
-        ...defaultAssignment.runtimeProxyInfo,
-        url: 'https://test.url.without.session',
-      },
-    };
-
-    const serverV1WithName = {
-      ...defaultAssignmentDescriptor,
-      label: TEST_SESSION_NAME,
-      id: assignmentWithName.notebookIdHash,
-      endpoint: assignmentWithName.endpoint,
-    } satisfies UnownedServer;
-    const serverV1WithoutName = {
-      ...defaultAssignmentDescriptor,
-      label: UNKNOWN_REMOTE_SERVER_NAME,
-      id: assignmentWithoutName.notebookIdHash,
-      endpoint: assignmentWithoutName.endpoint,
-    } satisfies UnownedServer;
-    const serverV1WithoutSession = {
-      ...defaultAssignmentDescriptor,
-      label: UNKNOWN_REMOTE_SERVER_NAME,
-      id: assignmentWithoutSession.notebookIdHash,
-      endpoint: assignmentWithoutSession.endpoint,
-    } satisfies UnownedServer;
 
     const runtimeWithSessionName = {
       ...defaultRuntime,
@@ -832,19 +610,19 @@ describe('AssignmentManager', () => {
     } satisfies Runtime;
 
     const serverV2WithName = {
-      ...defaultAssignmentDescriptor,
+      ...defaultServerDescriptor,
       label: TEST_SESSION_NAME,
       id: trimPrefix(runtimeWithSessionName.name, 'runtimes/'),
       endpoint: runtimeWithSessionName.connectionInfo.endpoint,
     } satisfies UnownedServer;
     const serverV2WithoutName = {
-      ...defaultAssignmentDescriptor,
+      ...defaultServerDescriptor,
       label: UNKNOWN_REMOTE_SERVER_NAME,
       id: trimPrefix(runtimeWithoutSessionName.name, 'runtimes/'),
       endpoint: runtimeWithoutSessionName.connectionInfo.endpoint,
     } satisfies UnownedServer;
     const serverV2WithoutSession = {
-      ...defaultAssignmentDescriptor,
+      ...defaultServerDescriptor,
       label: UNKNOWN_REMOTE_SERVER_NAME,
       id: trimPrefix(runtimeWithoutSession.name, 'runtimes/'),
       endpoint: runtimeWithoutSession.connectionInfo.endpoint,
@@ -861,19 +639,6 @@ describe('AssignmentManager', () => {
         name: '',
         connections: 1,
       },
-    };
-
-    const fixturesWithName: LiveFixture = {
-      runtime: runtimeWithSessionName,
-      assignment: assignmentWithName,
-    };
-    const fixturesWithoutName: LiveFixture = {
-      runtime: runtimeWithoutSessionName,
-      assignment: assignmentWithoutName,
-    };
-    const fixturesWithoutSession: LiveFixture = {
-      runtime: runtimeWithoutSession,
-      assignment: assignmentWithoutSession,
     };
 
     let jupyterStubWithSessionName: JupyterClientStub;
@@ -919,487 +684,432 @@ describe('AssignmentManager', () => {
       jupyterStubWithoutSession.sessions.list.resolves([]);
     });
 
-    forEachPublicApiFlag((enablePublicApi) => {
-      it('throws after being disposed', async () => {
-        assignmentManager.dispose();
+    it('throws after being disposed', async () => {
+      assignmentManager.dispose();
 
-        await expect(assignmentManager.getServers('all')).to.be.rejectedWith(
-          /disposed/,
-        );
+      await expect(assignmentManager.getServers('all')).to.be.rejectedWith(
+        /disposed/,
+      );
+    });
+
+    describe('from extension', () => {
+      it('returns an empty list when no servers are assigned', async () => {
+        const servers = await assignmentManager.getServers('extension');
+
+        expect(servers).to.deep.equal([]);
       });
 
-      describe('from extension', () => {
-        it('returns an empty list when no servers are assigned', async () => {
-          const servers = await assignmentManager.getServers('extension');
-
-          expect(servers).to.deep.equal([]);
+      describe('when a server is assigned', () => {
+        beforeEach(async () => {
+          listRuntimesStub.resolves({ runtimes: [defaultRuntime] });
+          await serverStorage.store([defaultServer]);
         });
 
-        describe('when a server is assigned', () => {
-          beforeEach(async () => {
-            stubLive(enablePublicApi, defaultLiveFixtures);
-            await serverStorage.store([defaultServerV2]);
+        it('returns the assigned server when there is one', async () => {
+          const servers = await assignmentManager.getServers('extension');
+
+          expect(stripNetworkOverrides(servers)).to.deep.equal([defaultServer]);
+        });
+
+        it('returns multiple assigned servers when there are some', async () => {
+          const storedServers = [
+            { ...defaultServer, id: `r-${randomUUID()}` },
+            { ...defaultServer, id: `r-${randomUUID()}` },
+          ];
+          await serverStorage.store(storedServers);
+
+          const servers = await assignmentManager.getServers('extension');
+
+          expect(stripNetworkOverrides(servers)).to.deep.equal(storedServers);
+        });
+
+        it('reconciles assigned servers before returning', async () => {
+          listRuntimesStub.resolves({ runtimes: [defaultRuntime] });
+          const noLongerAssignedServer = {
+            ...defaultServer,
+            endpoint: 'no-longer-assigned',
+          };
+          await serverStorage.store([defaultServer, noLongerAssignedServer]);
+
+          const results = await assignmentManager.getServers('extension');
+
+          expect(stripNetworkOverrides(results)).to.deep.equal([defaultServer]);
+        });
+
+        it('includes a fetch implementation that attaches Colab connection info', async () => {
+          const servers = await assignmentManager.getServers('extension');
+          assert.lengthOf(servers, 1);
+          const server = servers[0];
+          assert.isDefined(server.connectionInformation.fetch);
+          const fetchStub = sinon.stub(fetch, 'default');
+
+          await server.connectionInformation.fetch('https://example.com');
+
+          sinon.assert.calledOnceWithMatch(fetchStub, 'https://example.com', {
+            headers: new Headers({
+              [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
+                server.connectionInformation.token,
+              [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
+            }),
+          });
+        });
+
+        it('preserves request headers when wrapping a Request object', async () => {
+          const servers = await assignmentManager.getServers('extension');
+          assert.lengthOf(servers, 1);
+          const server = servers[0];
+          assert.isDefined(server.connectionInformation.fetch);
+          const fetchStub = sinon.stub(fetch, 'default');
+          const request = new Request('https://example.com', {
+            headers: {
+              Accept: 'application/json',
+              'X-Test': 'existing-value',
+            },
           });
 
-          it('returns the assigned server when there is one', async () => {
-            const servers = await assignmentManager.getServers('extension');
+          await server.connectionInformation.fetch(request);
 
-            expect(stripNetworkOverrides(servers)).to.deep.equal([
-              defaultServerV2,
-            ]);
+          sinon.assert.calledOnceWithMatch(
+            fetchStub,
+            sinon.match.instanceOf(Request),
+            {
+              headers: new Headers({
+                Accept: 'application/json',
+                'X-Test': 'existing-value',
+                [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
+                  server.connectionInformation.token,
+                [COLAB_CLIENT_AGENT_HEADER.key]:
+                  COLAB_CLIENT_AGENT_HEADER.value,
+              }),
+            },
+          );
+        });
+
+        it('allows init headers to override request headers', async () => {
+          const servers = await assignmentManager.getServers('extension');
+          assert.lengthOf(servers, 1);
+          const server = servers[0];
+          assert.isDefined(server.connectionInformation.fetch);
+          const fetchStub = sinon.stub(fetch, 'default');
+          const request = new Request('https://example.com', {
+            headers: {
+              Accept: 'text/plain',
+              'X-Test': 'request-value',
+            },
           });
 
-          it('returns multiple assigned servers when there are some', async () => {
-            const storedServers = [
-              { ...defaultServer, id: randomUUID() },
-              { ...defaultServerV2, id: `r-${randomUUID()}` },
-            ];
-            await serverStorage.store(storedServers);
-
-            const servers = await assignmentManager.getServers('extension');
-
-            expect(stripNetworkOverrides(servers)).to.deep.equal(storedServers);
+          await server.connectionInformation.fetch(request, {
+            headers: {
+              Accept: 'application/json',
+              'X-Test': 'init-value',
+            },
           });
 
-          it('reconciles assigned servers before returning', async () => {
-            stubLive(enablePublicApi, defaultLiveFixtures);
-            const noLongerAssignedServer = {
-              ...defaultServerV2,
-              endpoint: 'no-longer-assigned',
-            };
-            await serverStorage.store([
-              defaultServerV2,
-              noLongerAssignedServer,
-            ]);
+          sinon.assert.calledOnceWithMatch(
+            fetchStub,
+            sinon.match.instanceOf(Request),
+            {
+              headers: new Headers({
+                Accept: 'application/json',
+                'X-Test': 'init-value',
+                [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
+                  server.connectionInformation.token,
+                [COLAB_CLIENT_AGENT_HEADER.key]:
+                  COLAB_CLIENT_AGENT_HEADER.value,
+              }),
+            },
+          );
+        });
 
-            const results = await assignmentManager.getServers('extension');
-
-            expect(stripNetworkOverrides(results)).to.deep.equal([
-              defaultServerV2,
-            ]);
+        it('overrides caller-supplied Colab proxy headers', async () => {
+          const servers = await assignmentManager.getServers('extension');
+          assert.lengthOf(servers, 1);
+          const server = servers[0];
+          assert.isDefined(server.connectionInformation.fetch);
+          const fetchStub = sinon.stub(fetch, 'default');
+          const request = new Request('https://example.com', {
+            headers: {
+              [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: 'spoofed-request-token',
+              [COLAB_CLIENT_AGENT_HEADER.key]: 'spoofed-request-agent',
+            },
           });
 
-          it('includes a fetch implementation that attaches Colab connection info', async () => {
-            const servers = await assignmentManager.getServers('extension');
-            assert.lengthOf(servers, 1);
-            const server = servers[0];
-            assert.isDefined(server.connectionInformation.fetch);
-            const fetchStub = sinon.stub(fetch, 'default');
+          await server.connectionInformation.fetch(request, {
+            headers: {
+              [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: 'spoofed-init-token',
+              [COLAB_CLIENT_AGENT_HEADER.key]: 'spoofed-init-agent',
+            },
+          });
 
-            await server.connectionInformation.fetch('https://example.com');
-
-            sinon.assert.calledOnceWithMatch(fetchStub, 'https://example.com', {
+          sinon.assert.calledOnceWithMatch(
+            fetchStub,
+            sinon.match.instanceOf(Request),
+            {
               headers: new Headers({
                 [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
                   server.connectionInformation.token,
                 [COLAB_CLIENT_AGENT_HEADER.key]:
                   COLAB_CLIENT_AGENT_HEADER.value,
               }),
-            });
-          });
-
-          it('preserves request headers when wrapping a Request object', async () => {
-            const servers = await assignmentManager.getServers('extension');
-            assert.lengthOf(servers, 1);
-            const server = servers[0];
-            assert.isDefined(server.connectionInformation.fetch);
-            const fetchStub = sinon.stub(fetch, 'default');
-            const request = new Request('https://example.com', {
-              headers: {
-                Accept: 'application/json',
-                'X-Test': 'existing-value',
-              },
-            });
-
-            await server.connectionInformation.fetch(request);
-
-            sinon.assert.calledOnceWithMatch(
-              fetchStub,
-              sinon.match.instanceOf(Request),
-              {
-                headers: new Headers({
-                  Accept: 'application/json',
-                  'X-Test': 'existing-value',
-                  [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
-                    server.connectionInformation.token,
-                  [COLAB_CLIENT_AGENT_HEADER.key]:
-                    COLAB_CLIENT_AGENT_HEADER.value,
-                }),
-              },
-            );
-          });
-
-          it('allows init headers to override request headers', async () => {
-            const servers = await assignmentManager.getServers('extension');
-            assert.lengthOf(servers, 1);
-            const server = servers[0];
-            assert.isDefined(server.connectionInformation.fetch);
-            const fetchStub = sinon.stub(fetch, 'default');
-            const request = new Request('https://example.com', {
-              headers: {
-                Accept: 'text/plain',
-                'X-Test': 'request-value',
-              },
-            });
-
-            await server.connectionInformation.fetch(request, {
-              headers: {
-                Accept: 'application/json',
-                'X-Test': 'init-value',
-              },
-            });
-
-            sinon.assert.calledOnceWithMatch(
-              fetchStub,
-              sinon.match.instanceOf(Request),
-              {
-                headers: new Headers({
-                  Accept: 'application/json',
-                  'X-Test': 'init-value',
-                  [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
-                    server.connectionInformation.token,
-                  [COLAB_CLIENT_AGENT_HEADER.key]:
-                    COLAB_CLIENT_AGENT_HEADER.value,
-                }),
-              },
-            );
-          });
-
-          it('overrides caller-supplied Colab proxy headers', async () => {
-            const servers = await assignmentManager.getServers('extension');
-            assert.lengthOf(servers, 1);
-            const server = servers[0];
-            assert.isDefined(server.connectionInformation.fetch);
-            const fetchStub = sinon.stub(fetch, 'default');
-            const request = new Request('https://example.com', {
-              headers: {
-                [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: 'spoofed-request-token',
-                [COLAB_CLIENT_AGENT_HEADER.key]: 'spoofed-request-agent',
-              },
-            });
-
-            await server.connectionInformation.fetch(request, {
-              headers: {
-                [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: 'spoofed-init-token',
-                [COLAB_CLIENT_AGENT_HEADER.key]: 'spoofed-init-agent',
-              },
-            });
-
-            sinon.assert.calledOnceWithMatch(
-              fetchStub,
-              sinon.match.instanceOf(Request),
-              {
-                headers: new Headers({
-                  [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
-                    server.connectionInformation.token,
-                  [COLAB_CLIENT_AGENT_HEADER.key]:
-                    COLAB_CLIENT_AGENT_HEADER.value,
-                }),
-              },
-            );
-          });
-
-          it('includes a custom WebSocket implementation', async () => {
-            const servers = await assignmentManager.getServers('extension');
-            assert.lengthOf(servers, 1);
-            const server = servers[0];
-            assert.isDefined(server.connectionInformation.WebSocket);
-          });
+            },
+          );
         });
 
-        if (enablePublicApi) {
-          it('filters out server without name or connection info', async () => {
-            listRuntimesStub.resolves({
-              runtimes: [
-                runtimeWithoutName,
-                runtimeWithoutConnectionInfo,
-                defaultRuntime,
-              ],
-            });
-            await serverStorage.store([defaultServerV2]);
-
-            const results = await assignmentManager.getServers('extension');
-
-            expect(stripNetworkOverrides(results)).to.deep.equal([
-              defaultServerV2,
-            ]);
-          });
-        }
+        it('includes a custom WebSocket implementation', async () => {
+          const servers = await assignmentManager.getServers('extension');
+          assert.lengthOf(servers, 1);
+          const server = servers[0];
+          assert.isDefined(server.connectionInformation.WebSocket);
+        });
       });
 
-      describe('from external', () => {
-        it('returns unowned servers', async () => {
-          // Given 3 total assignments
-          stubLive(
-            enablePublicApi,
-            fixturesWithName,
-            fixturesWithoutName,
-            fixturesWithoutSession,
-          );
-          // One of the assignments was assigned within VS Code extension
-          const assignedServer = {
-            ...defaultServerV2,
-            endpoint: runtimeWithoutSessionName.connectionInfo.endpoint,
-          };
-          await serverStorage.store([assignedServer]);
-
-          // When we get servers from external
-          const results = await assignmentManager.getServers('external');
-
-          // Then only 2 unowned external servers are returned
-          if (enablePublicApi) {
-            expect(results).to.deep.equal([
-              serverV2WithName,
-              serverV2WithoutSession,
-            ]);
-          } else {
-            expect(results).to.deep.equal([
-              serverV1WithName,
-              serverV1WithoutSession,
-            ]);
-          }
+      it('filters out server without name or connection info', async () => {
+        listRuntimesStub.resolves({
+          runtimes: [
+            runtimeWithoutName,
+            runtimeWithoutConnectionInfo,
+            defaultRuntime,
+          ],
         });
+        await serverStorage.store([defaultServer]);
 
-        it('drops orphan unowned servers whose Jupyter client throws a FetchError', async () => {
-          // Simulates a race where the orphan assignment is deleted (e.g. via
-          // Colab web or another VS Code instance sharing the account)
-          // between listing assignments and listing its sessions.
-          stubLive(enablePublicApi, fixturesWithName, fixturesWithoutSession);
-          jupyterStubWithoutSession.sessions.list.rejects(
-            new JupyterFetchError(new Error('network error')),
-          );
+        const results = await assignmentManager.getServers('extension');
 
-          const results = await assignmentManager.getServers('external');
+        expect(stripNetworkOverrides(results)).to.deep.equal([defaultServer]);
+      });
+    });
 
-          if (enablePublicApi) {
-            expect(results).to.deep.equal([serverV2WithName]);
-          } else {
-            expect(results).to.deep.equal([serverV1WithName]);
-          }
+    describe('from external', () => {
+      it('returns unowned servers', async () => {
+        // Given 3 total assignments
+        listRuntimesStub.resolves({
+          runtimes: [
+            runtimeWithSessionName,
+            runtimeWithoutSessionName,
+            runtimeWithoutSession,
+          ],
         });
+        // One of the assignments was assigned within VS Code extension
+        const assignedServer = {
+          ...defaultServer,
+          endpoint: runtimeWithoutSessionName.connectionInfo.endpoint,
+        };
+        await serverStorage.store([assignedServer]);
 
-        it('falls back to placeholder label when sessions.list throws a non-FetchError', async () => {
-          stubLive(enablePublicApi, fixturesWithName, fixturesWithoutSession);
-          jupyterStubWithoutSession.sessions.list.rejects(
-            new JupyterResponseError(new Response(undefined, { status: 500 })),
-          );
+        // When we get servers from external
+        const results = await assignmentManager.getServers('external');
 
-          const results = await assignmentManager.getServers('external');
-
-          if (enablePublicApi) {
-            expect(results).to.deep.equal([
-              serverV2WithName,
-              serverV2WithoutSession,
-            ]);
-          } else {
-            expect(results).to.deep.equal([
-              serverV1WithName,
-              serverV1WithoutSession,
-            ]);
-          }
-        });
-
-        if (enablePublicApi) {
-          it('filters out server without name or connection info', async () => {
-            listRuntimesStub.resolves({
-              runtimes: [
-                runtimeWithoutName,
-                runtimeWithoutConnectionInfo,
-                defaultRuntime,
-              ],
-            });
-
-            await expect(
-              assignmentManager.getServers('external'),
-            ).to.eventually.deep.equal([
-              {
-                ...defaultAssignmentDescriptor,
-                id: trimPrefix(defaultRuntime.name, 'runtimes/'),
-                label: UNKNOWN_REMOTE_SERVER_NAME,
-                endpoint: defaultRuntime.connectionInfo.endpoint,
-              },
-            ]);
-          });
-        }
+        // Then only 2 unowned external servers are returned
+        expect(results).to.deep.equal([
+          serverV2WithName,
+          serverV2WithoutSession,
+        ]);
       });
 
-      it('falls back to placeholder label when sessions.list times out', async () => {
-        stubLive(enablePublicApi, fixturesWithName);
-        jupyterStubWithSessionName.sessions.list.callsFake(async () => {
-          // Block listSessions to trigger the timeout.
-          await new Promise((resolve) =>
-            setTimeout(resolve, LIST_UNOWNED_SESSIONS_TIMEOUT_MS + 100),
-          );
-          return [
-            {
-              ...defaultSession,
-              name: 'test-session-name-that-does-not-matter',
-            },
-          ];
+      it('drops orphan unowned servers whose Jupyter client throws a FetchError', async () => {
+        // Simulates a race where the orphan assignment is deleted (e.g. via
+        // Colab web or another VS Code instance sharing the account)
+        // between listing assignments and listing its sessions.
+        listRuntimesStub.resolves({
+          runtimes: [runtimeWithSessionName, runtimeWithoutSession],
         });
+        jupyterStubWithoutSession.sessions.list.rejects(
+          new JupyterFetchError(new Error('network error')),
+        );
 
-        const resultsPromise = assignmentManager.getServers('external');
-        await fakeClock.tickAsync(LIST_UNOWNED_SESSIONS_TIMEOUT_MS);
+        const results = await assignmentManager.getServers('external');
 
-        if (enablePublicApi) {
-          await expect(resultsPromise).to.eventually.deep.equal([
-            {
-              ...serverV2WithName,
-              label: UNKNOWN_REMOTE_SERVER_NAME,
-            },
-          ]);
-        } else {
-          await expect(resultsPromise).to.eventually.deep.equal([
-            {
-              ...serverV1WithName,
-              label: UNKNOWN_REMOTE_SERVER_NAME,
-            },
-          ]);
-        }
+        expect(results).to.deep.equal([serverV2WithName]);
       });
 
-      describe('from all', () => {
-        it('returns both assigned and unowned servers', async () => {
-          // Given 3 total assignments
-          stubLive(
-            enablePublicApi,
-            fixturesWithName,
-            fixturesWithoutName,
-            fixturesWithoutSession,
-          );
-          // One of the assignments was assigned within VS Code extension
-          const assignedServer = {
-            ...defaultServerV2,
-            endpoint: runtimeWithoutSessionName.connectionInfo.endpoint,
-          };
-          await serverStorage.store([assignedServer]);
+      it('falls back to placeholder label when sessions.list throws a non-FetchError', async () => {
+        listRuntimesStub.resolves({
+          runtimes: [runtimeWithSessionName, runtimeWithoutSession],
+        });
+        jupyterStubWithoutSession.sessions.list.rejects(
+          new JupyterResponseError(new Response(undefined, { status: 500 })),
+        );
 
-          // When we get servers from all
-          const results = await assignmentManager.getServers('all');
+        const results = await assignmentManager.getServers('external');
 
-          // Then 1 assigned server and 2 unowned servers are returned
-          expect(stripNetworkOverrides([...results.assigned])).to.deep.equal([
-            assignedServer,
-          ]);
+        expect(results).to.deep.equal([
+          serverV2WithName,
+          serverV2WithoutSession,
+        ]);
+      });
 
-          if (enablePublicApi) {
-            expect(results.unowned).to.deep.equal([
-              serverV2WithName,
-              serverV2WithoutSession,
-            ]);
-          } else {
-            expect(results.unowned).to.deep.equal([
-              serverV1WithName,
-              serverV1WithoutSession,
-            ]);
-          }
+      it('filters out server without name or connection info', async () => {
+        listRuntimesStub.resolves({
+          runtimes: [
+            runtimeWithoutName,
+            runtimeWithoutConnectionInfo,
+            defaultRuntime,
+          ],
         });
 
-        it('returns only unowned servers when no server is assigned in VS Code', async () => {
-          stubLive(
-            enablePublicApi,
-            fixturesWithName,
-            fixturesWithoutName,
-            fixturesWithoutSession,
-          );
-          await serverStorage.store([]);
+        await expect(
+          assignmentManager.getServers('external'),
+        ).to.eventually.deep.equal([
+          {
+            ...defaultServerDescriptor,
+            id: trimPrefix(defaultRuntime.name, 'runtimes/'),
+            label: UNKNOWN_REMOTE_SERVER_NAME,
+            endpoint: defaultRuntime.connectionInfo.endpoint,
+          },
+        ]);
+      });
+    });
 
-          const results = await assignmentManager.getServers('all');
+    it('falls back to placeholder label when sessions.list times out', async () => {
+      listRuntimesStub.resolves({ runtimes: [runtimeWithSessionName] });
+      jupyterStubWithSessionName.sessions.list.callsFake(async () => {
+        // Block listSessions to trigger the timeout.
+        await new Promise((resolve) =>
+          setTimeout(resolve, LIST_UNOWNED_SESSIONS_TIMEOUT_MS + 100),
+        );
+        return [
+          {
+            ...defaultSession,
+            name: 'test-session-name-that-does-not-matter',
+          },
+        ];
+      });
 
-          if (enablePublicApi) {
-            expect(results).to.deep.equal({
-              assigned: [],
-              unowned: [
-                serverV2WithName,
-                serverV2WithoutName,
-                serverV2WithoutSession,
-              ],
-            });
-          } else {
-            expect(results).to.deep.equal({
-              assigned: [],
-              unowned: [
-                serverV1WithName,
-                serverV1WithoutName,
-                serverV1WithoutSession,
-              ],
-            });
-          }
+      const resultsPromise = assignmentManager.getServers('external');
+      await fakeClock.tickAsync(LIST_UNOWNED_SESSIONS_TIMEOUT_MS);
+
+      await expect(resultsPromise).to.eventually.deep.equal([
+        {
+          ...serverV2WithName,
+          label: UNKNOWN_REMOTE_SERVER_NAME,
+        },
+      ]);
+    });
+
+    describe('from all', () => {
+      it('returns both assigned and unowned servers', async () => {
+        // Given 3 total assignments
+        listRuntimesStub.resolves({
+          runtimes: [
+            runtimeWithSessionName,
+            runtimeWithoutSessionName,
+            runtimeWithoutSession,
+          ],
         });
+        // One of the assignments was assigned within VS Code extension
+        const assignedServer = {
+          ...defaultServer,
+          endpoint: runtimeWithoutSessionName.connectionInfo.endpoint,
+        };
+        await serverStorage.store([assignedServer]);
 
-        it('returns only assigned servers when no server is unowned', async () => {
-          stubLive(
-            enablePublicApi,
-            fixturesWithName,
-            fixturesWithoutName,
-            fixturesWithoutSession,
-          );
-          const assignedServer1 = {
-            ...defaultServerV2,
-            endpoint: runtimeWithSessionName.connectionInfo.endpoint,
-          };
-          const assignedServer2 = {
-            ...defaultServerV2,
-            endpoint: runtimeWithoutSessionName.connectionInfo.endpoint,
-          };
-          const assignedServer3 = {
-            ...defaultServerV2,
-            endpoint: runtimeWithoutSession.connectionInfo.endpoint,
-          };
-          await serverStorage.store([
-            assignedServer1,
-            assignedServer2,
-            assignedServer3,
-          ]);
+        // When we get servers from all
+        const results = await assignmentManager.getServers('all');
 
-          const results = await assignmentManager.getServers('all');
+        // Then 1 assigned server and 2 unowned servers are returned
+        expect(stripNetworkOverrides([...results.assigned])).to.deep.equal([
+          assignedServer,
+        ]);
 
-          expect(stripNetworkOverrides([...results.assigned])).to.deep.equal([
-            assignedServer1,
-            assignedServer2,
-            assignedServer3,
-          ]);
-          expect(results.unowned).to.be.empty;
+        expect(results.unowned).to.deep.equal([
+          serverV2WithName,
+          serverV2WithoutSession,
+        ]);
+      });
+
+      it('returns only unowned servers when no server is assigned in VS Code', async () => {
+        listRuntimesStub.resolves({
+          runtimes: [
+            runtimeWithSessionName,
+            runtimeWithoutSessionName,
+            runtimeWithoutSession,
+          ],
         });
+        await serverStorage.store([]);
 
-        it('reconciles assigned servers before returning', async () => {
-          stubLive(enablePublicApi, fixturesWithName);
-          const assignedServer = {
-            ...defaultServerV2,
-            endpoint: runtimeWithSessionName.connectionInfo.endpoint,
-          };
-          const noLongerAssignedServer = {
-            ...defaultServerV2,
-            endpoint: 'no-longer-assigned',
-          };
-          await serverStorage.store([assignedServer, noLongerAssignedServer]);
+        const results = await assignmentManager.getServers('all');
 
-          const results = await assignmentManager.getServers('all');
-
-          expect(stripNetworkOverrides([...results.assigned])).to.deep.equal([
-            assignedServer,
-          ]);
+        expect(results).to.deep.equal({
+          assigned: [],
+          unowned: [
+            serverV2WithName,
+            serverV2WithoutName,
+            serverV2WithoutSession,
+          ],
         });
+      });
 
-        if (enablePublicApi) {
-          it('filters out server without name or connection info', async () => {
-            listRuntimesStub.resolves({
-              runtimes: [
-                runtimeWithoutName,
-                runtimeWithoutConnectionInfo,
-                defaultRuntime,
-              ],
-            });
-            await serverStorage.store([defaultServerV2]);
+      it('returns only assigned servers when no server is unowned', async () => {
+        listRuntimesStub.resolves({
+          runtimes: [
+            runtimeWithSessionName,
+            runtimeWithoutSessionName,
+            runtimeWithoutSession,
+          ],
+        });
+        const assignedServer1 = {
+          ...defaultServer,
+          endpoint: runtimeWithSessionName.connectionInfo.endpoint,
+        };
+        const assignedServer2 = {
+          ...defaultServer,
+          endpoint: runtimeWithoutSessionName.connectionInfo.endpoint,
+        };
+        const assignedServer3 = {
+          ...defaultServer,
+          endpoint: runtimeWithoutSession.connectionInfo.endpoint,
+        };
+        await serverStorage.store([
+          assignedServer1,
+          assignedServer2,
+          assignedServer3,
+        ]);
 
-            const results = await assignmentManager.getServers('all');
+        const results = await assignmentManager.getServers('all');
 
-            expect(stripNetworkOverrides([...results.assigned])).to.deep.equal([
-              defaultServerV2,
-            ]);
-            expect(results.unowned).to.be.empty;
-          });
-        }
+        expect(stripNetworkOverrides([...results.assigned])).to.deep.equal([
+          assignedServer1,
+          assignedServer2,
+          assignedServer3,
+        ]);
+        expect(results.unowned).to.be.empty;
+      });
+
+      it('reconciles assigned servers before returning', async () => {
+        listRuntimesStub.resolves({ runtimes: [runtimeWithSessionName] });
+        const assignedServer = {
+          ...defaultServer,
+          endpoint: runtimeWithSessionName.connectionInfo.endpoint,
+        };
+        const noLongerAssignedServer = {
+          ...defaultServer,
+          endpoint: 'no-longer-assigned',
+        };
+        await serverStorage.store([assignedServer, noLongerAssignedServer]);
+
+        const results = await assignmentManager.getServers('all');
+
+        expect(stripNetworkOverrides([...results.assigned])).to.deep.equal([
+          assignedServer,
+        ]);
+      });
+
+      it('filters out server without name or connection info', async () => {
+        listRuntimesStub.resolves({
+          runtimes: [
+            runtimeWithoutName,
+            runtimeWithoutConnectionInfo,
+            defaultRuntime,
+          ],
+        });
+        await serverStorage.store([defaultServer]);
+
+        const results = await assignmentManager.getServers('all');
+
+        expect(stripNetworkOverrides([...results.assigned])).to.deep.equal([
+          defaultServer,
+        ]);
+        expect(results.unowned).to.be.empty;
       });
     });
   });
@@ -1421,8 +1131,8 @@ describe('AssignmentManager', () => {
 
     it('returns all stored servers with connection info omitted', async () => {
       const storedServers = [
-        { ...defaultServer, id: randomUUID() },
-        { ...defaultServer, id: randomUUID() },
+        { ...defaultServer, id: `r-${randomUUID()}` },
+        { ...defaultServer, id: `r-${randomUUID()}` },
       ];
       await serverStorage.store(storedServers);
 
@@ -1454,527 +1164,80 @@ describe('AssignmentManager', () => {
   });
 
   describe('assignServer', () => {
-    describe('with Public API disabled', () => {
-      beforeEach(() => {
-        EXPERIMENT_TEST.setFlagForTest(ExperimentFlag.EnablePublicApi, false);
-      });
+    it('throws after being disposed', async () => {
+      assignmentManager.dispose();
 
-      afterEach(() => {
-        sinon.assert.notCalled(createRuntimeStub);
-        sinon.assert.notCalled(listRuntimesStub);
-      });
-
-      it('throws after being disposed', async () => {
-        assignmentManager.dispose();
-
-        await expect(
-          assignmentManager.assignServer(defaultAssignmentDescriptor),
-        ).to.be.rejectedWith(/disposed/);
-      });
-
-      it('throws an error when the assignment does not include a URL to connect to', () => {
-        colabClientStub.assign
-          .withArgs(sinon.match(isUUID), {
-            variant: defaultAssignment.variant,
-            accelerator: defaultAssignment.accelerator,
-          })
-          .resolves({
-            assignment: {
-              ...defaultAssignment,
-              runtimeProxyInfo: {
-                ...defaultAssignment.runtimeProxyInfo,
-                url: '',
-              },
-            },
-            isNew: false,
-          });
-
-        expect(
-          assignmentManager.assignServer(defaultAssignmentDescriptor),
-        ).to.be.rejectedWith(/connection info/);
-      });
-
-      it('throws an error when the assignment does not include a token to connect with', () => {
-        colabClientStub.assign
-          .withArgs(sinon.match(isUUID), {
-            variant: defaultAssignment.variant,
-            accelerator: defaultAssignment.accelerator,
-          })
-          .resolves({
-            assignment: {
-              ...defaultAssignment,
-              runtimeProxyInfo: {
-                ...defaultAssignment.runtimeProxyInfo,
-                token: '',
-              },
-            },
-            isNew: false,
-          });
-
-        expect(
-          assignmentManager.assignServer(defaultAssignmentDescriptor),
-        ).to.be.rejectedWith(/connection info/);
-      });
-
-      describe('when a server is assigned', () => {
-        let assignedServer: ColabAssignedServer;
-
-        beforeEach(async () => {
-          colabClientStub.assign
-            .withArgs(sinon.match(isUUID), {
-              variant: defaultServer.variant,
-              accelerator: defaultServer.accelerator,
-              shape: defaultServer.shape,
-              version: defaultServer.version,
-            })
-            .resolves({ assignment: defaultAssignment, isNew: false });
-          colabClientStub.listAssignments.resolves([defaultAssignment]);
-          await serverStorage.store([defaultServer]);
-
-          assignedServer = await assignmentManager.assignServer(
-            defaultAssignmentDescriptor,
-          );
-        });
-
-        it('stores and returns the server', () => {
-          const { id: assignedId, ...got } =
-            stripNetworkOverride(assignedServer);
-          const { id: defaultId, ...want } = defaultServer;
-          expect(got).to.deep.equal(want);
-          expect(assignedId).to.satisfy(isUUID);
-        });
-
-        it('emits an assignment change event', () => {
-          const { id: defaultId, ...want } = defaultServer;
-          sinon.assert.calledOnceWithMatch(assignmentChangeListener, {
-            added: [sinon.match(want)],
-            removed: [],
-            changed: [],
-          });
-        });
-
-        it('includes a fetch implementation that attaches Colab connection info', async () => {
-          assert.isDefined(assignedServer.connectionInformation.fetch);
-          const fetchStub = sinon.stub(fetch, 'default');
-
-          await assignedServer.connectionInformation.fetch(
-            'https://example.com',
-          );
-
-          sinon.assert.calledOnceWithMatch(fetchStub, 'https://example.com', {
-            headers: new Headers({
-              [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
-                assignedServer.connectionInformation.token,
-              [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
-            }),
-          });
-        });
-
-        it('includes a custom WebSocket implementation', () => {
-          assert.isDefined(assignedServer.connectionInformation.WebSocket);
-        });
-      });
-
-      describe('with too many assigned servers', () => {
-        beforeEach(() => {
-          colabClientStub.assign.rejects(new TooManyAssignmentsError());
-        });
-
-        it('notifies the user', async () => {
-          await expect(
-            assignmentManager.assignServer(defaultAssignmentDescriptor),
-          ).to.eventually.be.rejectedWith(TooManyAssignmentsError);
-
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.window.showErrorMessage as sinon.SinonStub,
-            /too many/,
-          );
-        });
-
-        it('presents an action to remove servers', async () => {
-          (vsCodeStub.window.showErrorMessage as sinon.SinonStub).resolves(
-            'Remove Server',
-          );
-
-          await expect(
-            assignmentManager.assignServer(defaultAssignmentDescriptor),
-          ).to.eventually.be.rejectedWith(TooManyAssignmentsError);
-
-          sinon.assert.calledOnceWithExactly(
-            vsCodeStub.commands.executeCommand,
-            REMOVE_SERVER.id,
-            CommandSource.COMMAND_SOURCE_NOTIFICATION,
-          );
-        });
-      });
-
-      describe('with insufficient quota', () => {
-        beforeEach(() => {
-          colabClientStub.assign.rejects(new InsufficientQuotaError('💰🐖'));
-        });
-
-        it('notifies the user', async () => {
-          await expect(
-            assignmentManager.assignServer(defaultAssignmentDescriptor),
-          ).to.eventually.be.rejectedWith(InsufficientQuotaError);
-
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.window.showErrorMessage as sinon.SinonStub,
-            /Unable to assign .* 💰🐖/,
-          );
-        });
-
-        it('presents an action to learn more', async () => {
-          sinon.stub(assignmentManager, 'hasAssignedServer').resolves(false);
-          (vsCodeStub.window.showErrorMessage as sinon.SinonStub).resolves(
-            'Learn More',
-          );
-
-          await expect(
-            assignmentManager.assignServer(defaultAssignmentDescriptor),
-          ).to.eventually.be.rejectedWith(InsufficientQuotaError);
-
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.env.openExternal,
-            sinon.match(function (url: Uri) {
-              return (
-                url.toString() ===
-                'https://research.google.com/colaboratory/faq.html#resource-limits'
-              );
-            }),
-          );
-        });
-      });
-
-      describe('when the user is banned', () => {
-        beforeEach(() => {
-          colabClientStub.assign.rejects(new DenylistedError('👨‍⚖️'));
-        });
-
-        it('notifies the user', async () => {
-          await expect(
-            assignmentManager.assignServer(defaultAssignmentDescriptor),
-          ).to.eventually.be.rejectedWith(DenylistedError);
-
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.window.showErrorMessage as sinon.SinonStub,
-            /Unable to assign .* 👨‍⚖️/,
-          );
-        });
-      });
-
-      describe('with an accelerator that is unavailable', () => {
-        beforeEach(() => {
-          colabClientStub.getUserInfo.resolves({
-            subscriptionTier: SubscriptionTier.PRO,
-            paidComputeUnitsBalance: 1,
-            eligibleAccelerators: [
-              {
-                variant: Variant.GPU,
-                models: ['T4', 'V100', 'A100', 'H100'],
-              },
-            ],
-            ineligibleAccelerators: [],
-          });
-
-          colabClientStub.assign
-            .withArgs(sinon.match(isUUID), {
-              variant: Variant.GPU,
-              accelerator: 'A100',
-              shape: undefined,
-              version: undefined,
-            })
-            .rejects(new AcceleratorUnavailableError('A100'));
-        });
-
-        it('falls back to the next available accelerator', async () => {
-          colabClientStub.assign
-            .withArgs(sinon.match(isUUID), {
-              variant: Variant.GPU,
-              accelerator: 'T4',
-              shape: undefined,
-              version: undefined,
-            })
-            .resolves({
-              assignment: { ...defaultAssignment, accelerator: 'T4' },
-              isNew: false,
-            });
-
-          const result = await assignmentManager.assignServer({
-            label: 'Colab GPU A100',
-            variant: Variant.GPU,
-            accelerator: 'A100',
-          });
-
-          expect(result.accelerator).to.equal('T4');
-          sinon.assert.calledWithMatch(
-            vsCodeStub.window.showInformationMessage as sinon.SinonStub,
-            /Requested accelerator "A100" is unavailable, assigned "T4"/,
-          );
-        });
-
-        it('falls back multiple times to the next available accelerator', async () => {
-          colabClientStub.assign
-            .withArgs(
-              sinon.match(isUUID),
-              sinon.match({
-                accelerator: sinon.match.in(['A100', 'T4', 'V100']),
-              }),
-            )
-            .rejects(new AcceleratorUnavailableError('A100'))
-            .withArgs(sinon.match(isUUID), sinon.match({ accelerator: 'H100' }))
-            .resolves({
-              assignment: { ...defaultAssignment, accelerator: 'H100' },
-              isNew: false,
-            });
-
-          const result = await assignmentManager.assignServer({
-            label: 'Colab GPU A100',
-            variant: Variant.GPU,
-            accelerator: 'A100',
-          });
-
-          expect(result.accelerator).to.equal('H100');
-          sinon.assert.calledWithMatch(
-            vsCodeStub.window.showInformationMessage as sinon.SinonStub,
-            /Requested accelerator "A100" is unavailable, assigned "H100"/,
-          );
-        });
-
-        it('throws an error if all fallbacks fail', async () => {
-          colabClientStub.assign.rejects(
-            new AcceleratorUnavailableError('any'),
-          );
-
-          await expect(
-            assignmentManager.assignServer({
-              label: 'Colab GPU A100',
-              variant: Variant.GPU,
-              accelerator: 'A100',
-            }),
-          ).to.be.rejectedWith(
-            /All GPU accelerators are unavailable: A100, T4, V100/,
-          );
-
-          sinon.assert.calledWithMatch(
-            vsCodeStub.window.showErrorMessage as sinon.SinonStub,
-            /Unable to assign server. All GPU accelerators are unavailable: A100, T4, V100/,
-          );
-        });
-      });
-
-      describe('telemetry', () => {
-        let logStub: SinonStubbedFunction<typeof telemetry.logAssignServer>;
-
-        beforeEach(() => {
-          logStub = sinon.stub(telemetry, 'logAssignServer');
-        });
-
-        afterEach(() => {
-          logStub.restore();
-        });
-
-        it('logs OUTCOME_SUCCEEDED with the requested configuration', async () => {
-          colabClientStub.assign.resolves({
-            assignment: defaultAssignment,
-            isNew: false,
-          });
-
-          await assignmentManager.assignServer(defaultAssignmentDescriptor);
-
-          sinon.assert.calledOnceWithExactly(
-            logStub,
-            AssignmentOutcome.ASSIGNMENT_OUTCOME_SUCCEEDED,
-            {
-              variant: defaultAssignmentDescriptor.variant,
-              accelerator: defaultAssignmentDescriptor.accelerator ?? '',
-              shape: 'STANDARD',
-              version: defaultAssignmentDescriptor.version ?? '',
-              hadFallback: false,
-            },
-          );
-        });
-
-        it('logs hadFallback=true when a fallback succeeds', async () => {
-          colabClientStub.getUserInfo.resolves({
-            subscriptionTier: SubscriptionTier.PRO,
-            paidComputeUnitsBalance: 1,
-            eligibleAccelerators: [
-              { variant: Variant.GPU, models: ['T4', 'A100'] },
-            ],
-            ineligibleAccelerators: [],
-          });
-          colabClientStub.assign
-            .withArgs(sinon.match(isUUID), {
-              variant: defaultAssignmentDescriptor.variant,
-              accelerator: 'A100',
-              shape: defaultAssignmentDescriptor.shape,
-              version: defaultAssignmentDescriptor.version,
-            })
-            .rejects(new AcceleratorUnavailableError('A100'))
-            .withArgs(sinon.match(isUUID), {
-              variant: defaultAssignmentDescriptor.variant,
-              accelerator: 'T4',
-              shape: defaultAssignmentDescriptor.shape,
-              version: defaultAssignmentDescriptor.version,
-            })
-            .resolves({
-              assignment: { ...defaultAssignment, accelerator: 'T4' },
-              isNew: false,
-            });
-
-          await assignmentManager.assignServer(defaultAssignmentDescriptor);
-
-          sinon.assert.calledOnceWithExactly(
-            logStub,
-            AssignmentOutcome.ASSIGNMENT_OUTCOME_SUCCEEDED,
-            {
-              variant: defaultAssignmentDescriptor.variant,
-              accelerator: defaultAssignmentDescriptor.accelerator ?? '',
-              shape: 'STANDARD',
-              version: defaultAssignmentDescriptor.version ?? '',
-              hadFallback: true,
-            },
-          );
-        });
-
-        it('logs OUTCOME_ALL_ACCELERATORS_UNAVAILABLE when fallbacks are exhausted', async () => {
-          colabClientStub.getUserInfo.resolves({
-            subscriptionTier: SubscriptionTier.PRO,
-            paidComputeUnitsBalance: 1,
-            eligibleAccelerators: [
-              { variant: Variant.GPU, models: ['T4', 'A100'] },
-            ],
-            ineligibleAccelerators: [],
-          });
-          colabClientStub.assign.rejects(
-            new AcceleratorUnavailableError('any'),
-          );
-
-          await expect(
-            assignmentManager.assignServer(defaultAssignmentDescriptor),
-          ).to.be.rejected;
-
-          sinon.assert.calledOnceWithExactly(
-            logStub,
-            AssignmentOutcome.ASSIGNMENT_OUTCOME_ALL_ACCELERATORS_UNAVAILABLE,
-            {
-              variant: defaultAssignmentDescriptor.variant,
-              accelerator: defaultAssignmentDescriptor.accelerator ?? '',
-              shape: 'STANDARD',
-              version: defaultAssignmentDescriptor.version ?? '',
-              hadFallback: true,
-            },
-          );
-        });
-
-        const errorOutcomeCases = [
-          {
-            label: 'OUTCOME_TOO_MANY_ASSIGNMENTS',
-            error: new TooManyAssignmentsError(),
-            outcome: AssignmentOutcome.ASSIGNMENT_OUTCOME_TOO_MANY_ASSIGNMENTS,
-          },
-          {
-            label: 'OUTCOME_INSUFFICIENT_QUOTA',
-            error: new InsufficientQuotaError('💰🐖'),
-            outcome: AssignmentOutcome.ASSIGNMENT_OUTCOME_INSUFFICIENT_QUOTA,
-          },
-          {
-            label: 'OUTCOME_DENYLISTED',
-            error: new DenylistedError('👨‍⚖️'),
-            outcome: AssignmentOutcome.ASSIGNMENT_OUTCOME_DENYLISTED,
-          },
-          {
-            label: 'OUTCOME_OTHER_FAILURE for unexpected errors',
-            error: new Error('boom'),
-            outcome: AssignmentOutcome.ASSIGNMENT_OUTCOME_OTHER_FAILURE,
-          },
-        ];
-        for (const { label, error, outcome } of errorOutcomeCases) {
-          it(`logs ${label}`, async () => {
-            colabClientStub.assign.rejects(error);
-
-            await expect(
-              assignmentManager.assignServer(defaultAssignmentDescriptor),
-            ).to.be.rejected;
-
-            sinon.assert.calledOnceWithExactly(logStub, outcome, {
-              variant: defaultAssignmentDescriptor.variant,
-              accelerator: defaultAssignmentDescriptor.accelerator ?? '',
-              shape: 'STANDARD',
-              version: defaultAssignmentDescriptor.version ?? '',
-              hadFallback: false,
-            });
-          });
-        }
-
-        it('logs the requested shape and version when present', async () => {
-          colabClientStub.assign.resolves({
-            assignment: defaultAssignment,
-            isNew: false,
-          });
-
-          await assignmentManager.assignServer({
-            ...defaultAssignmentDescriptor,
-            shape: Shape.HIGHMEM,
-            version: 'v1',
-          });
-
-          sinon.assert.calledOnceWithExactly(
-            logStub,
-            AssignmentOutcome.ASSIGNMENT_OUTCOME_SUCCEEDED,
-            {
-              variant: defaultAssignmentDescriptor.variant,
-              accelerator: defaultAssignmentDescriptor.accelerator ?? '',
-              shape: 'HIGHMEM',
-              version: 'v1',
-              hadFallback: false,
-            },
-          );
-        });
-
-        it('logs an empty accelerator for the default CPU descriptor', async () => {
-          colabClientStub.assign.resolves({
-            assignment: { ...defaultAssignment, accelerator: 'NONE' },
-            isNew: false,
-          });
-
-          await assignmentManager.assignServer(DEFAULT_CPU_SERVER);
-
-          sinon.assert.calledOnceWithExactly(
-            logStub,
-            AssignmentOutcome.ASSIGNMENT_OUTCOME_SUCCEEDED,
-            {
-              variant: Variant.DEFAULT,
-              accelerator: '',
-              shape: '',
-              version: '',
-              hadFallback: false,
-            },
-          );
-        });
-      });
+      await expect(
+        assignmentManager.assignServer(defaultServerDescriptor),
+      ).to.be.rejectedWith(/disposed/);
     });
 
-    describe('with Public API enabled', () => {
-      beforeEach(() => {
-        EXPERIMENT_TEST.setFlagForTest(ExperimentFlag.EnablePublicApi, true);
-      });
+    it('throws an error when the assignment does not include a URL to connect to', () => {
+      createRuntimeStub
+        .withArgs(
+          sinon.match((req: CreateRuntimeRequest) => {
+            const spec = req.runtime?.runtimeSpec;
+            return (
+              req.requestId &&
+              isUUID(req.requestId) &&
+              spec?.variant === defaultRuntime.runtimeSpec.variant &&
+              spec.shape === defaultRuntime.runtimeSpec.shape &&
+              spec.accelerator === defaultRuntime.runtimeSpec.accelerator &&
+              req.runtime?.version === defaultRuntime.version
+            );
+          }),
+        )
+        .resolves({
+          done: true,
+          response: {
+            ...defaultRuntime,
+            connectionInfo: {
+              ...defaultRuntime.connectionInfo,
+              url: '',
+            },
+          },
+        });
 
-      afterEach(() => {
-        sinon.assert.notCalled(colabClientStub.assign);
-        sinon.assert.notCalled(colabClientStub.listAssignments);
-      });
+      expect(
+        assignmentManager.assignServer(defaultServerDescriptor),
+      ).to.be.rejectedWith(/connection info/);
+    });
 
-      it('throws after being disposed', async () => {
-        assignmentManager.dispose();
+    it('throws an error when the assignment does not include a token to connect with', () => {
+      createRuntimeStub
+        .withArgs(
+          sinon.match((req: CreateRuntimeRequest) => {
+            const spec = req.runtime?.runtimeSpec;
+            return (
+              req.requestId &&
+              isUUID(req.requestId) &&
+              spec?.variant === defaultRuntime.runtimeSpec.variant &&
+              spec.shape === defaultRuntime.runtimeSpec.shape &&
+              spec.accelerator === defaultRuntime.runtimeSpec.accelerator &&
+              req.runtime?.version === defaultRuntime.version
+            );
+          }),
+        )
+        .resolves({
+          done: true,
+          response: {
+            ...defaultRuntime,
+            connectionInfo: {
+              ...defaultRuntime.connectionInfo,
+              token: '',
+            },
+          },
+        });
 
-        await expect(
-          assignmentManager.assignServer(defaultAssignmentDescriptor),
-        ).to.be.rejectedWith(/disposed/);
-      });
+      expect(
+        assignmentManager.assignServer(defaultServerDescriptor),
+      ).to.be.rejectedWith(/connection info/);
+    });
 
-      it('throws an error when the assignment does not include a URL to connect to', () => {
+    describe('when a server is assigned', () => {
+      let assignedServer: ColabAssignedServer;
+
+      beforeEach(async () => {
         createRuntimeStub
           .withArgs(
             sinon.match((req: CreateRuntimeRequest) => {
@@ -1990,1357 +1253,1123 @@ describe('AssignmentManager', () => {
             }),
           )
           .resolves({
-            done: true,
-            response: {
-              ...defaultRuntime,
-              connectionInfo: {
-                ...defaultRuntime.connectionInfo,
-                url: '',
-              },
-            },
-          });
-
-        expect(
-          assignmentManager.assignServer(defaultAssignmentDescriptor),
-        ).to.be.rejectedWith(/connection info/);
-      });
-
-      it('throws an error when the assignment does not include a token to connect with', () => {
-        createRuntimeStub
-          .withArgs(
-            sinon.match((req: CreateRuntimeRequest) => {
-              const spec = req.runtime?.runtimeSpec;
-              return (
-                req.requestId &&
-                isUUID(req.requestId) &&
-                spec?.variant === defaultRuntime.runtimeSpec.variant &&
-                spec.shape === defaultRuntime.runtimeSpec.shape &&
-                spec.accelerator === defaultRuntime.runtimeSpec.accelerator &&
-                req.runtime?.version === defaultRuntime.version
-              );
-            }),
-          )
-          .resolves({
-            done: true,
-            response: {
-              ...defaultRuntime,
-              connectionInfo: {
-                ...defaultRuntime.connectionInfo,
-                token: '',
-              },
-            },
-          });
-
-        expect(
-          assignmentManager.assignServer(defaultAssignmentDescriptor),
-        ).to.be.rejectedWith(/connection info/);
-      });
-
-      describe('when a server is assigned', () => {
-        let assignedServer: ColabAssignedServer;
-
-        beforeEach(async () => {
-          createRuntimeStub
-            .withArgs(
-              sinon.match((req: CreateRuntimeRequest) => {
-                const spec = req.runtime?.runtimeSpec;
-                return (
-                  req.requestId &&
-                  isUUID(req.requestId) &&
-                  spec?.variant === defaultRuntime.runtimeSpec.variant &&
-                  spec.shape === defaultRuntime.runtimeSpec.shape &&
-                  spec.accelerator === defaultRuntime.runtimeSpec.accelerator &&
-                  req.runtime?.version === defaultRuntime.version
-                );
-              }),
-            )
-            .resolves({
-              done: true,
-              response: defaultRuntime,
-            });
-          colabClientStub.listAssignments.resolves([defaultAssignment]);
-          await serverStorage.store([defaultServerV2]);
-
-          assignedServer = await assignmentManager.assignServer(
-            defaultAssignmentDescriptor,
-          );
-        });
-
-        it('stores and returns the server', () => {
-          expect(stripNetworkOverride(assignedServer)).to.deep.equal(
-            defaultServerV2,
-          );
-        });
-
-        it('emits an assignment change event', () => {
-          sinon.assert.calledOnceWithMatch(assignmentChangeListener, {
-            added: [sinon.match(defaultServerV2)],
-            removed: [],
-            changed: [],
-          });
-        });
-
-        it('includes a fetch implementation that attaches Colab connection info', async () => {
-          assert.isDefined(assignedServer.connectionInformation.fetch);
-          const fetchStub = sinon.stub(fetch, 'default');
-
-          await assignedServer.connectionInformation.fetch(
-            'https://example.com',
-          );
-
-          sinon.assert.calledOnceWithMatch(fetchStub, 'https://example.com', {
-            headers: new Headers({
-              [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
-                assignedServer.connectionInformation.token,
-              [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
-            }),
-          });
-        });
-
-        it('includes a custom WebSocket implementation', () => {
-          assert.isDefined(assignedServer.connectionInformation.WebSocket);
-        });
-      });
-
-      describe('when a server is assigned in a long-running operation', () => {
-        const OPERATION_ID = randomUUID();
-        const WAIT_OPERATION_TIMEOUT = '200s';
-
-        beforeEach(() => {
-          createRuntimeStub
-            .withArgs(
-              sinon.match((req: CreateRuntimeRequest) => {
-                const spec = req.runtime?.runtimeSpec;
-                return (
-                  req.requestId &&
-                  isUUID(req.requestId) &&
-                  spec?.variant === defaultRuntime.runtimeSpec.variant &&
-                  spec.shape === defaultRuntime.runtimeSpec.shape &&
-                  spec.accelerator === defaultRuntime.runtimeSpec.accelerator &&
-                  req.runtime?.version === defaultRuntime.version
-                );
-              }),
-            )
-            .resolves({
-              name: `operations/${OPERATION_ID}`,
-              done: false,
-            });
-
-          vsCodeStub.window.withProgress
-            .withArgs(
-              sinon.match({
-                location: vsCodeStub.ProgressLocation.Notification,
-                title: 'Assigning server...',
-                cancellable: false,
-              }),
-              sinon.match.any,
-            )
-            .callsFake((_, task) => {
-              const tokenSource = new vsCodeStub.CancellationTokenSource();
-              return task({ report: sinon.stub() }, tokenSource.token);
-            });
-        });
-
-        it('stores and returns the server with progress', async () => {
-          waitOperationStub
-            .withArgs(
-              sinon.match({
-                operationsId: OPERATION_ID,
-                timeout: WAIT_OPERATION_TIMEOUT,
-              }),
-            )
-            .resolves({
-              name: `operations/${OPERATION_ID}`,
-              done: true,
-              response: defaultRawRuntime,
-            });
-
-          const assignedServer = await assignmentManager.assignServer(
-            defaultAssignmentDescriptor,
-          );
-
-          expect(stripNetworkOverride(assignedServer)).to.deep.equal(
-            defaultServerV2,
-          );
-          sinon.assert.calledOnce(vsCodeStub.window.withProgress);
-        });
-
-        it('throws WaitOperationTimeoutError if the operation is still not done after wait', async () => {
-          waitOperationStub
-            .withArgs(
-              sinon.match({
-                operationsId: OPERATION_ID,
-                timeout: WAIT_OPERATION_TIMEOUT,
-              }),
-            )
-            .resolves({
-              name: `operations/${OPERATION_ID}`,
-              done: false,
-            });
-
-          const promise = assignmentManager.assignServer(
-            defaultAssignmentDescriptor,
-          );
-
-          await expect(promise).to.eventually.be.rejectedWith(
-            WaitOperationTimeoutError,
-          );
-          sinon.assert.calledOnce(vsCodeStub.window.withProgress);
-        });
-      });
-
-      describe('with too many assigned servers', () => {
-        beforeEach(() => {
-          createRuntimeStub.resolves({
-            done: true,
-            error: {
-              code: 9,
-              details: [{ reason: 'TOO_MANY_ACTIVE_RUNTIMES' }],
-            },
-          });
-        });
-
-        it('notifies the user', async () => {
-          await expect(
-            assignmentManager.assignServer(defaultAssignmentDescriptor),
-          ).to.eventually.be.rejectedWith(TooManyAssignmentsError);
-
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.window.showErrorMessage as sinon.SinonStub,
-            /too many/,
-          );
-        });
-
-        it('presents an action to remove servers', async () => {
-          (vsCodeStub.window.showErrorMessage as sinon.SinonStub).resolves(
-            'Remove Server',
-          );
-
-          await expect(
-            assignmentManager.assignServer(defaultAssignmentDescriptor),
-          ).to.eventually.be.rejectedWith(TooManyAssignmentsError);
-
-          sinon.assert.calledOnceWithExactly(
-            vsCodeStub.commands.executeCommand,
-            REMOVE_SERVER.id,
-            CommandSource.COMMAND_SOURCE_NOTIFICATION,
-          );
-        });
-      });
-
-      describe('with insufficient quota', () => {
-        beforeEach(() => {
-          createRuntimeStub.resolves({
-            done: true,
-            error: {
-              code: 9,
-              details: [{ reason: 'QUOTA_EXCEEDED_USAGE_TIME' }],
-            },
-          });
-        });
-
-        it('notifies the user', async () => {
-          await expect(
-            assignmentManager.assignServer(defaultAssignmentDescriptor),
-          ).to.eventually.be.rejectedWith(InsufficientQuotaError);
-
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.window.showErrorMessage as sinon.SinonStub,
-            /Unable to assign/,
-          );
-        });
-
-        it('presents an action to learn more', async () => {
-          sinon.stub(assignmentManager, 'hasAssignedServer').resolves(false);
-          (vsCodeStub.window.showErrorMessage as sinon.SinonStub).resolves(
-            'Learn More',
-          );
-
-          await expect(
-            assignmentManager.assignServer(defaultAssignmentDescriptor),
-          ).to.eventually.be.rejectedWith(InsufficientQuotaError);
-
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.env.openExternal,
-            sinon.match(function (url: Uri) {
-              return (
-                url.toString() ===
-                'https://research.google.com/colaboratory/faq.html#resource-limits'
-              );
-            }),
-          );
-        });
-      });
-
-      describe('when the user is banned', () => {
-        beforeEach(() => {
-          createRuntimeStub.resolves({
-            done: true,
-            error: {
-              code: 9,
-              details: [{ reason: 'DENYLISTED' }],
-            },
-          });
-        });
-
-        it('notifies the user', async () => {
-          await expect(
-            assignmentManager.assignServer(defaultAssignmentDescriptor),
-          ).to.eventually.be.rejectedWith(DenylistedError);
-
-          sinon.assert.calledOnceWithMatch(
-            vsCodeStub.window.showErrorMessage as sinon.SinonStub,
-            /Unable to assign/,
-          );
-        });
-      });
-
-      describe('with an accelerator that is unavailable', () => {
-        beforeEach(() => {
-          listRuntimeSpecsStub.resolves({
-            runtimeSpecs: [
-              {
-                key: {
-                  variant: 'VARIANT_GPU',
-                  accelerator: 'A100',
-                  shape: 'SHAPE_STANDARD',
-                },
-                eligible: true,
-              },
-              {
-                key: {
-                  variant: 'VARIANT_GPU',
-                  accelerator: 'T4',
-                  shape: 'SHAPE_STANDARD',
-                },
-                eligible: true,
-              },
-              // Intentionally include a second T4 spec of high-mem shape to
-              // ensure accelerator fallbacks are de-dupped.
-              {
-                key: {
-                  variant: 'VARIANT_GPU',
-                  accelerator: 'T4',
-                  shape: 'SHAPE_HIGHMEM',
-                },
-                eligible: true,
-              },
-              {
-                key: {
-                  variant: 'VARIANT_GPU',
-                  accelerator: 'V100',
-                  shape: 'SHAPE_STANDARD',
-                },
-                eligible: true,
-              },
-              {
-                key: {
-                  variant: 'VARIANT_GPU',
-                  accelerator: 'H100',
-                  shape: 'SHAPE_STANDARD',
-                },
-                eligible: true,
-              },
-            ],
-          });
-          createRuntimeStub
-            .withArgs(
-              sinon.match((req: CreateRuntimeRequest) => {
-                const spec = req.runtime?.runtimeSpec;
-                return (
-                  spec?.variant === 'VARIANT_GPU' && spec.accelerator === 'A100'
-                );
-              }),
-            )
-            .resolves({
-              done: true,
-              error: {
-                code: 9,
-                details: [{ reason: 'NO_RUNTIMES' }],
-              },
-            });
-        });
-
-        it('falls back to the next available accelerator', async () => {
-          createRuntimeStub
-            .withArgs(
-              sinon.match((req: CreateRuntimeRequest) => {
-                const spec = req.runtime?.runtimeSpec;
-                return (
-                  spec?.variant === 'VARIANT_GPU' && spec.accelerator === 'T4'
-                );
-              }),
-            )
-            .resolves({
-              done: true,
-              response: {
-                ...defaultRuntime,
-                runtimeSpec: {
-                  ...defaultRuntime.runtimeSpec,
-                  accelerator: 'T4',
-                },
-              },
-            });
-
-          const result = await assignmentManager.assignServer({
-            label: 'Colab GPU A100',
-            variant: Variant.GPU,
-            accelerator: 'A100',
-          });
-
-          expect(result.accelerator).to.equal('T4');
-          sinon.assert.calledWithMatch(
-            vsCodeStub.window.showInformationMessage as sinon.SinonStub,
-            /Requested accelerator "A100" is unavailable, assigned "T4"/,
-          );
-        });
-
-        it('falls back multiple times to the next available accelerator', async () => {
-          createRuntimeStub
-            .withArgs(
-              sinon.match((req: CreateRuntimeRequest) => {
-                const spec = req.runtime?.runtimeSpec;
-                return (
-                  spec?.variant === 'VARIANT_GPU' &&
-                  ['A100', 'T4', 'V100'].includes(spec.accelerator)
-                );
-              }),
-            )
-            .resolves({
-              done: true,
-              error: {
-                code: 9,
-                details: [{ reason: 'NO_RUNTIMES' }],
-              },
-            })
-            .withArgs(
-              sinon.match((req: CreateRuntimeRequest) => {
-                const spec = req.runtime?.runtimeSpec;
-                return (
-                  spec?.variant === 'VARIANT_GPU' && spec.accelerator === 'H100'
-                );
-              }),
-            )
-            .resolves({
-              done: true,
-              response: {
-                ...defaultRuntime,
-                runtimeSpec: {
-                  ...defaultRuntime.runtimeSpec,
-                  accelerator: 'H100',
-                },
-              },
-            });
-
-          const result = await assignmentManager.assignServer({
-            label: 'Colab GPU A100',
-            variant: Variant.GPU,
-            accelerator: 'A100',
-          });
-
-          expect(result.accelerator).to.equal('H100');
-          sinon.assert.calledWithMatch(
-            vsCodeStub.window.showInformationMessage as sinon.SinonStub,
-            /Requested accelerator "A100" is unavailable, assigned "H100"/,
-          );
-        });
-
-        it('throws an error if all fallbacks fail', async () => {
-          createRuntimeStub.resolves({
-            done: true,
-            error: {
-              code: 9,
-              details: [{ reason: 'NO_RUNTIMES' }],
-            },
-          });
-
-          await expect(
-            assignmentManager.assignServer({
-              label: 'Colab GPU A100',
-              variant: Variant.GPU,
-              accelerator: 'A100',
-            }),
-          ).to.be.rejectedWith(
-            /All GPU accelerators are unavailable: A100, T4, V100/,
-          );
-
-          sinon.assert.calledWithMatch(
-            vsCodeStub.window.showErrorMessage as sinon.SinonStub,
-            /Unable to assign server. All GPU accelerators are unavailable: A100, T4, V100/,
-          );
-        });
-      });
-
-      describe('telemetry', () => {
-        let logStub: SinonStubbedFunction<typeof telemetry.logAssignServer>;
-
-        beforeEach(() => {
-          logStub = sinon.stub(telemetry, 'logAssignServer');
-        });
-
-        afterEach(() => {
-          logStub.restore();
-        });
-
-        it('logs OUTCOME_SUCCEEDED with the requested configuration', async () => {
-          createRuntimeStub.resolves({
             done: true,
             response: defaultRuntime,
           });
+        listRuntimesStub.resolves({ runtimes: [defaultRuntime] });
+        await serverStorage.store([defaultServer]);
 
-          await assignmentManager.assignServer(defaultAssignmentDescriptor);
+        assignedServer = await assignmentManager.assignServer(
+          defaultServerDescriptor,
+        );
+      });
 
-          sinon.assert.calledOnceWithExactly(
-            logStub,
-            AssignmentOutcome.ASSIGNMENT_OUTCOME_SUCCEEDED,
-            {
-              variant: defaultAssignmentDescriptor.variant,
-              accelerator: defaultAssignmentDescriptor.accelerator ?? '',
-              shape: 'STANDARD',
-              version: defaultAssignmentDescriptor.version ?? '',
-              hadFallback: false,
-            },
-          );
+      it('stores and returns the server', () => {
+        expect(stripNetworkOverride(assignedServer)).to.deep.equal(
+          defaultServer,
+        );
+      });
+
+      it('emits an assignment change event', () => {
+        sinon.assert.calledOnceWithMatch(assignmentChangeListener, {
+          added: [sinon.match(defaultServer)],
+          removed: [],
+          changed: [],
         });
+      });
 
-        it('logs hadFallback=true when a fallback succeeds', async () => {
-          listRuntimeSpecsStub.resolves({
-            runtimeSpecs: [
-              {
-                key: {
-                  variant: 'VARIANT_GPU',
-                  accelerator: 'A100',
-                  shape: 'SHAPE_STANDARD',
-                },
-                eligible: true,
-              },
-              {
-                key: {
-                  variant: 'VARIANT_GPU',
-                  accelerator: 'T4',
-                  shape: 'SHAPE_STANDARD',
-                },
-                eligible: true,
-              },
-            ],
-          });
-          createRuntimeStub
-            .withArgs(
-              sinon.match((req: CreateRuntimeRequest) => {
-                const spec = req.runtime?.runtimeSpec;
-                return (
-                  spec?.variant === 'VARIANT_GPU' && spec.accelerator === 'A100'
-                );
-              }),
-            )
-            .resolves({
-              done: true,
-              error: {
-                code: 9,
-                details: [{ reason: 'NO_RUNTIMES' }],
-              },
-            })
-            .withArgs(
-              sinon.match((req: CreateRuntimeRequest) => {
-                const spec = req.runtime?.runtimeSpec;
-                return (
-                  spec?.variant === 'VARIANT_GPU' && spec.accelerator === 'T4'
-                );
-              }),
-            )
-            .resolves({
-              done: true,
-              response: {
-                ...defaultRuntime,
-                runtimeSpec: {
-                  ...defaultRuntime.runtimeSpec,
-                  accelerator: 'T4',
-                },
-              },
-            });
+      it('includes a fetch implementation that attaches Colab connection info', async () => {
+        assert.isDefined(assignedServer.connectionInformation.fetch);
+        const fetchStub = sinon.stub(fetch, 'default');
 
-          await assignmentManager.assignServer(defaultAssignmentDescriptor);
+        await assignedServer.connectionInformation.fetch('https://example.com');
 
-          sinon.assert.calledOnceWithExactly(
-            logStub,
-            AssignmentOutcome.ASSIGNMENT_OUTCOME_SUCCEEDED,
-            {
-              variant: defaultAssignmentDescriptor.variant,
-              accelerator: defaultAssignmentDescriptor.accelerator ?? '',
-              shape: 'STANDARD',
-              version: defaultAssignmentDescriptor.version ?? '',
-              hadFallback: true,
-            },
-          );
+        sinon.assert.calledOnceWithMatch(fetchStub, 'https://example.com', {
+          headers: new Headers({
+            [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
+              assignedServer.connectionInformation.token,
+            [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
+          }),
         });
+      });
 
-        it('logs OUTCOME_ALL_ACCELERATORS_UNAVAILABLE when fallbacks are exhausted', async () => {
-          listRuntimeSpecsStub.resolves({
-            runtimeSpecs: [
-              {
-                key: {
-                  variant: 'VARIANT_GPU',
-                  accelerator: 'A100',
-                  shape: 'SHAPE_STANDARD',
-                },
-                eligible: true,
-              },
-              {
-                key: {
-                  variant: 'VARIANT_GPU',
-                  accelerator: 'T4',
-                  shape: 'SHAPE_STANDARD',
-                },
-                eligible: true,
-              },
-            ],
+      it('includes a custom WebSocket implementation', () => {
+        assert.isDefined(assignedServer.connectionInformation.WebSocket);
+      });
+    });
+
+    describe('when a server is assigned in a long-running operation', () => {
+      const OPERATION_ID = randomUUID();
+      const WAIT_OPERATION_TIMEOUT = '200s';
+
+      beforeEach(() => {
+        createRuntimeStub
+          .withArgs(
+            sinon.match((req: CreateRuntimeRequest) => {
+              const spec = req.runtime?.runtimeSpec;
+              return (
+                req.requestId &&
+                isUUID(req.requestId) &&
+                spec?.variant === defaultRuntime.runtimeSpec.variant &&
+                spec.shape === defaultRuntime.runtimeSpec.shape &&
+                spec.accelerator === defaultRuntime.runtimeSpec.accelerator &&
+                req.runtime?.version === defaultRuntime.version
+              );
+            }),
+          )
+          .resolves({
+            name: `operations/${OPERATION_ID}`,
+            done: false,
           });
-          createRuntimeStub.resolves({
+
+        vsCodeStub.window.withProgress
+          .withArgs(
+            sinon.match({
+              location: vsCodeStub.ProgressLocation.Notification,
+              title: 'Assigning server...',
+              cancellable: false,
+            }),
+            sinon.match.any,
+          )
+          .callsFake((_, task) => {
+            const tokenSource = new vsCodeStub.CancellationTokenSource();
+            return task({ report: sinon.stub() }, tokenSource.token);
+          });
+      });
+
+      it('stores and returns the server with progress', async () => {
+        waitOperationStub
+          .withArgs(
+            sinon.match({
+              operationsId: OPERATION_ID,
+              timeout: WAIT_OPERATION_TIMEOUT,
+            }),
+          )
+          .resolves({
+            name: `operations/${OPERATION_ID}`,
+            done: true,
+            response: defaultRawRuntime,
+          });
+
+        const assignedServer = await assignmentManager.assignServer(
+          defaultServerDescriptor,
+        );
+
+        expect(stripNetworkOverride(assignedServer)).to.deep.equal(
+          defaultServer,
+        );
+        sinon.assert.calledOnce(vsCodeStub.window.withProgress);
+      });
+
+      it('throws WaitOperationTimeoutError if the operation is still not done after wait', async () => {
+        waitOperationStub
+          .withArgs(
+            sinon.match({
+              operationsId: OPERATION_ID,
+              timeout: WAIT_OPERATION_TIMEOUT,
+            }),
+          )
+          .resolves({
+            name: `operations/${OPERATION_ID}`,
+            done: false,
+          });
+
+        const promise = assignmentManager.assignServer(defaultServerDescriptor);
+
+        await expect(promise).to.eventually.be.rejectedWith(
+          WaitOperationTimeoutError,
+        );
+        sinon.assert.calledOnce(vsCodeStub.window.withProgress);
+      });
+    });
+
+    describe('with too many assigned servers', () => {
+      beforeEach(() => {
+        createRuntimeStub.resolves({
+          done: true,
+          error: {
+            code: 9,
+            details: [{ reason: 'TOO_MANY_ACTIVE_RUNTIMES' }],
+          },
+        });
+      });
+
+      it('notifies the user', async () => {
+        await expect(
+          assignmentManager.assignServer(defaultServerDescriptor),
+        ).to.eventually.be.rejectedWith(TooManyAssignmentsError);
+
+        sinon.assert.calledOnceWithMatch(
+          vsCodeStub.window.showErrorMessage as sinon.SinonStub,
+          /too many/,
+        );
+      });
+
+      it('presents an action to remove servers', async () => {
+        (vsCodeStub.window.showErrorMessage as sinon.SinonStub).resolves(
+          'Remove Server',
+        );
+
+        await expect(
+          assignmentManager.assignServer(defaultServerDescriptor),
+        ).to.eventually.be.rejectedWith(TooManyAssignmentsError);
+
+        sinon.assert.calledOnceWithExactly(
+          vsCodeStub.commands.executeCommand,
+          REMOVE_SERVER.id,
+          CommandSource.COMMAND_SOURCE_NOTIFICATION,
+        );
+      });
+    });
+
+    describe('with insufficient quota', () => {
+      beforeEach(() => {
+        createRuntimeStub.resolves({
+          done: true,
+          error: {
+            code: 9,
+            details: [{ reason: 'QUOTA_EXCEEDED_USAGE_TIME' }],
+          },
+        });
+      });
+
+      it('notifies the user', async () => {
+        await expect(
+          assignmentManager.assignServer(defaultServerDescriptor),
+        ).to.eventually.be.rejectedWith(InsufficientQuotaError);
+
+        sinon.assert.calledOnceWithMatch(
+          vsCodeStub.window.showErrorMessage as sinon.SinonStub,
+          /Unable to assign/,
+        );
+      });
+
+      it('presents an action to learn more', async () => {
+        sinon.stub(assignmentManager, 'hasAssignedServer').resolves(false);
+        (vsCodeStub.window.showErrorMessage as sinon.SinonStub).resolves(
+          'Learn More',
+        );
+
+        await expect(
+          assignmentManager.assignServer(defaultServerDescriptor),
+        ).to.eventually.be.rejectedWith(InsufficientQuotaError);
+
+        sinon.assert.calledOnceWithMatch(
+          vsCodeStub.env.openExternal,
+          sinon.match(function (url: Uri) {
+            return (
+              url.toString() ===
+              'https://research.google.com/colaboratory/faq.html#resource-limits'
+            );
+          }),
+        );
+      });
+    });
+
+    describe('when the user is banned', () => {
+      beforeEach(() => {
+        createRuntimeStub.resolves({
+          done: true,
+          error: {
+            code: 9,
+            details: [{ reason: 'DENYLISTED' }],
+          },
+        });
+      });
+
+      it('notifies the user', async () => {
+        await expect(
+          assignmentManager.assignServer(defaultServerDescriptor),
+        ).to.eventually.be.rejectedWith(DenylistedError);
+
+        sinon.assert.calledOnceWithMatch(
+          vsCodeStub.window.showErrorMessage as sinon.SinonStub,
+          /Unable to assign/,
+        );
+      });
+    });
+
+    describe('with an accelerator that is unavailable', () => {
+      beforeEach(() => {
+        listRuntimeSpecsStub.resolves({
+          runtimeSpecs: [
+            {
+              key: {
+                variant: 'VARIANT_GPU',
+                accelerator: 'A100',
+                shape: 'SHAPE_STANDARD',
+              },
+              eligible: true,
+            },
+            {
+              key: {
+                variant: 'VARIANT_GPU',
+                accelerator: 'T4',
+                shape: 'SHAPE_STANDARD',
+              },
+              eligible: true,
+            },
+            // Intentionally include a second T4 spec of high-mem shape to
+            // ensure accelerator fallbacks are de-dupped.
+            {
+              key: {
+                variant: 'VARIANT_GPU',
+                accelerator: 'T4',
+                shape: 'SHAPE_HIGHMEM',
+              },
+              eligible: true,
+            },
+            {
+              key: {
+                variant: 'VARIANT_GPU',
+                accelerator: 'V100',
+                shape: 'SHAPE_STANDARD',
+              },
+              eligible: true,
+            },
+            {
+              key: {
+                variant: 'VARIANT_GPU',
+                accelerator: 'H100',
+                shape: 'SHAPE_STANDARD',
+              },
+              eligible: true,
+            },
+          ],
+        });
+        createRuntimeStub
+          .withArgs(
+            sinon.match((req: CreateRuntimeRequest) => {
+              const spec = req.runtime?.runtimeSpec;
+              return (
+                spec?.variant === 'VARIANT_GPU' && spec.accelerator === 'A100'
+              );
+            }),
+          )
+          .resolves({
             done: true,
             error: {
               code: 9,
               details: [{ reason: 'NO_RUNTIMES' }],
             },
           });
+      });
 
-          await expect(
-            assignmentManager.assignServer(defaultAssignmentDescriptor),
-          ).to.be.rejected;
-
-          sinon.assert.calledOnceWithExactly(
-            logStub,
-            AssignmentOutcome.ASSIGNMENT_OUTCOME_ALL_ACCELERATORS_UNAVAILABLE,
-            {
-              variant: defaultAssignmentDescriptor.variant,
-              accelerator: defaultAssignmentDescriptor.accelerator ?? '',
-              shape: 'STANDARD',
-              version: defaultAssignmentDescriptor.version ?? '',
-              hadFallback: true,
-            },
-          );
-        });
-
-        const errorOutcomeCases = [
-          {
-            label: 'OUTCOME_TOO_MANY_ASSIGNMENTS',
-            code: 9,
-            reason: 'TOO_MANY_ACTIVE_RUNTIMES',
-            outcome: AssignmentOutcome.ASSIGNMENT_OUTCOME_TOO_MANY_ASSIGNMENTS,
-          },
-          {
-            label: 'OUTCOME_INSUFFICIENT_QUOTA',
-            code: 9,
-            reason: 'QUOTA_EXCEEDED_USAGE_TIME',
-            outcome: AssignmentOutcome.ASSIGNMENT_OUTCOME_INSUFFICIENT_QUOTA,
-          },
-          {
-            label: 'OUTCOME_DENYLISTED',
-            code: 9,
-            reason: 'DENYLISTED',
-            outcome: AssignmentOutcome.ASSIGNMENT_OUTCOME_DENYLISTED,
-          },
-          {
-            label: 'OUTCOME_OTHER_FAILURE for unexpected errors',
-            code: 6,
-            reason: 'ALREADY_EXISTS',
-            outcome: AssignmentOutcome.ASSIGNMENT_OUTCOME_OTHER_FAILURE,
-          },
-        ];
-        for (const { label, code, reason, outcome } of errorOutcomeCases) {
-          it(`logs ${label}`, async () => {
-            createRuntimeStub.resolves({
-              done: true,
-              error: {
-                code,
-                details: [{ reason }],
-              },
-            });
-
-            await expect(
-              assignmentManager.assignServer(defaultAssignmentDescriptor),
-            ).to.be.rejected;
-
-            sinon.assert.calledOnceWithExactly(logStub, outcome, {
-              variant: defaultAssignmentDescriptor.variant,
-              accelerator: defaultAssignmentDescriptor.accelerator ?? '',
-              shape: 'STANDARD',
-              version: defaultAssignmentDescriptor.version ?? '',
-              hadFallback: false,
-            });
-          });
-        }
-
-        it('logs an empty accelerator for the default CPU descriptor', async () => {
-          createRuntimeStub.resolves({
+      it('falls back to the next available accelerator', async () => {
+        createRuntimeStub
+          .withArgs(
+            sinon.match((req: CreateRuntimeRequest) => {
+              const spec = req.runtime?.runtimeSpec;
+              return (
+                spec?.variant === 'VARIANT_GPU' && spec.accelerator === 'T4'
+              );
+            }),
+          )
+          .resolves({
             done: true,
             response: {
               ...defaultRuntime,
               runtimeSpec: {
                 ...defaultRuntime.runtimeSpec,
-                accelerator: 'NONE',
+                accelerator: 'T4',
               },
             },
           });
 
-          await assignmentManager.assignServer(DEFAULT_CPU_SERVER);
-
-          sinon.assert.calledOnceWithExactly(
-            logStub,
-            AssignmentOutcome.ASSIGNMENT_OUTCOME_SUCCEEDED,
-            {
-              variant: DEFAULT_CPU_SERVER.variant,
-              accelerator: '',
-              shape: '',
-              version: '',
-              hadFallback: false,
-            },
-          );
+        const result = await assignmentManager.assignServer({
+          label: 'Colab GPU A100',
+          variant: Variant.GPU,
+          accelerator: 'A100',
         });
+
+        expect(result.accelerator).to.equal('T4');
+        sinon.assert.calledWithMatch(
+          vsCodeStub.window.showInformationMessage as sinon.SinonStub,
+          /Requested accelerator "A100" is unavailable, assigned "T4"/,
+        );
+      });
+
+      it('falls back multiple times to the next available accelerator', async () => {
+        createRuntimeStub
+          .withArgs(
+            sinon.match((req: CreateRuntimeRequest) => {
+              const spec = req.runtime?.runtimeSpec;
+              return (
+                spec?.variant === 'VARIANT_GPU' &&
+                ['A100', 'T4', 'V100'].includes(spec.accelerator)
+              );
+            }),
+          )
+          .resolves({
+            done: true,
+            error: {
+              code: 9,
+              details: [{ reason: 'NO_RUNTIMES' }],
+            },
+          })
+          .withArgs(
+            sinon.match((req: CreateRuntimeRequest) => {
+              const spec = req.runtime?.runtimeSpec;
+              return (
+                spec?.variant === 'VARIANT_GPU' && spec.accelerator === 'H100'
+              );
+            }),
+          )
+          .resolves({
+            done: true,
+            response: {
+              ...defaultRuntime,
+              runtimeSpec: {
+                ...defaultRuntime.runtimeSpec,
+                accelerator: 'H100',
+              },
+            },
+          });
+
+        const result = await assignmentManager.assignServer({
+          label: 'Colab GPU A100',
+          variant: Variant.GPU,
+          accelerator: 'A100',
+        });
+
+        expect(result.accelerator).to.equal('H100');
+        sinon.assert.calledWithMatch(
+          vsCodeStub.window.showInformationMessage as sinon.SinonStub,
+          /Requested accelerator "A100" is unavailable, assigned "H100"/,
+        );
+      });
+
+      it('throws an error if all fallbacks fail', async () => {
+        createRuntimeStub.resolves({
+          done: true,
+          error: {
+            code: 9,
+            details: [{ reason: 'NO_RUNTIMES' }],
+          },
+        });
+
+        await expect(
+          assignmentManager.assignServer({
+            label: 'Colab GPU A100',
+            variant: Variant.GPU,
+            accelerator: 'A100',
+          }),
+        ).to.be.rejectedWith(
+          /All GPU accelerators are unavailable: A100, T4, V100/,
+        );
+
+        sinon.assert.calledWithMatch(
+          vsCodeStub.window.showErrorMessage as sinon.SinonStub,
+          /Unable to assign server. All GPU accelerators are unavailable: A100, T4, V100/,
+        );
+      });
+    });
+
+    describe('telemetry', () => {
+      let logStub: SinonStubbedFunction<typeof telemetry.logAssignServer>;
+
+      beforeEach(() => {
+        logStub = sinon.stub(telemetry, 'logAssignServer');
+      });
+
+      afterEach(() => {
+        logStub.restore();
+      });
+
+      it('logs OUTCOME_SUCCEEDED with the requested configuration', async () => {
+        createRuntimeStub.resolves({
+          done: true,
+          response: defaultRuntime,
+        });
+
+        await assignmentManager.assignServer(defaultServerDescriptor);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          AssignmentOutcome.ASSIGNMENT_OUTCOME_SUCCEEDED,
+          {
+            variant: defaultServerDescriptor.variant,
+            accelerator: defaultServerDescriptor.accelerator ?? '',
+            shape: 'STANDARD',
+            version: defaultServerDescriptor.version ?? '',
+            hadFallback: false,
+          },
+        );
+      });
+
+      it('logs hadFallback=true when a fallback succeeds', async () => {
+        listRuntimeSpecsStub.resolves({
+          runtimeSpecs: [
+            {
+              key: {
+                variant: 'VARIANT_GPU',
+                accelerator: 'A100',
+                shape: 'SHAPE_STANDARD',
+              },
+              eligible: true,
+            },
+            {
+              key: {
+                variant: 'VARIANT_GPU',
+                accelerator: 'T4',
+                shape: 'SHAPE_STANDARD',
+              },
+              eligible: true,
+            },
+          ],
+        });
+        createRuntimeStub
+          .withArgs(
+            sinon.match((req: CreateRuntimeRequest) => {
+              const spec = req.runtime?.runtimeSpec;
+              return (
+                spec?.variant === 'VARIANT_GPU' && spec.accelerator === 'A100'
+              );
+            }),
+          )
+          .resolves({
+            done: true,
+            error: {
+              code: 9,
+              details: [{ reason: 'NO_RUNTIMES' }],
+            },
+          })
+          .withArgs(
+            sinon.match((req: CreateRuntimeRequest) => {
+              const spec = req.runtime?.runtimeSpec;
+              return (
+                spec?.variant === 'VARIANT_GPU' && spec.accelerator === 'T4'
+              );
+            }),
+          )
+          .resolves({
+            done: true,
+            response: {
+              ...defaultRuntime,
+              runtimeSpec: {
+                ...defaultRuntime.runtimeSpec,
+                accelerator: 'T4',
+              },
+            },
+          });
+
+        await assignmentManager.assignServer(defaultServerDescriptor);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          AssignmentOutcome.ASSIGNMENT_OUTCOME_SUCCEEDED,
+          {
+            variant: defaultServerDescriptor.variant,
+            accelerator: defaultServerDescriptor.accelerator ?? '',
+            shape: 'STANDARD',
+            version: defaultServerDescriptor.version ?? '',
+            hadFallback: true,
+          },
+        );
+      });
+
+      it('logs OUTCOME_ALL_ACCELERATORS_UNAVAILABLE when fallbacks are exhausted', async () => {
+        listRuntimeSpecsStub.resolves({
+          runtimeSpecs: [
+            {
+              key: {
+                variant: 'VARIANT_GPU',
+                accelerator: 'A100',
+                shape: 'SHAPE_STANDARD',
+              },
+              eligible: true,
+            },
+            {
+              key: {
+                variant: 'VARIANT_GPU',
+                accelerator: 'T4',
+                shape: 'SHAPE_STANDARD',
+              },
+              eligible: true,
+            },
+          ],
+        });
+        createRuntimeStub.resolves({
+          done: true,
+          error: {
+            code: 9,
+            details: [{ reason: 'NO_RUNTIMES' }],
+          },
+        });
+
+        await expect(assignmentManager.assignServer(defaultServerDescriptor)).to
+          .be.rejected;
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          AssignmentOutcome.ASSIGNMENT_OUTCOME_ALL_ACCELERATORS_UNAVAILABLE,
+          {
+            variant: defaultServerDescriptor.variant,
+            accelerator: defaultServerDescriptor.accelerator ?? '',
+            shape: 'STANDARD',
+            version: defaultServerDescriptor.version ?? '',
+            hadFallback: true,
+          },
+        );
+      });
+
+      const errorOutcomeCases = [
+        {
+          label: 'OUTCOME_TOO_MANY_ASSIGNMENTS',
+          code: 9,
+          reason: 'TOO_MANY_ACTIVE_RUNTIMES',
+          outcome: AssignmentOutcome.ASSIGNMENT_OUTCOME_TOO_MANY_ASSIGNMENTS,
+        },
+        {
+          label: 'OUTCOME_INSUFFICIENT_QUOTA',
+          code: 9,
+          reason: 'QUOTA_EXCEEDED_USAGE_TIME',
+          outcome: AssignmentOutcome.ASSIGNMENT_OUTCOME_INSUFFICIENT_QUOTA,
+        },
+        {
+          label: 'OUTCOME_DENYLISTED',
+          code: 9,
+          reason: 'DENYLISTED',
+          outcome: AssignmentOutcome.ASSIGNMENT_OUTCOME_DENYLISTED,
+        },
+        {
+          label: 'OUTCOME_OTHER_FAILURE for unexpected errors',
+          code: 6,
+          reason: 'ALREADY_EXISTS',
+          outcome: AssignmentOutcome.ASSIGNMENT_OUTCOME_OTHER_FAILURE,
+        },
+      ];
+      for (const { label, code, reason, outcome } of errorOutcomeCases) {
+        it(`logs ${label}`, async () => {
+          createRuntimeStub.resolves({
+            done: true,
+            error: {
+              code,
+              details: [{ reason }],
+            },
+          });
+
+          await expect(assignmentManager.assignServer(defaultServerDescriptor))
+            .to.be.rejected;
+
+          sinon.assert.calledOnceWithExactly(logStub, outcome, {
+            variant: defaultServerDescriptor.variant,
+            accelerator: defaultServerDescriptor.accelerator ?? '',
+            shape: 'STANDARD',
+            version: defaultServerDescriptor.version ?? '',
+            hadFallback: false,
+          });
+        });
+      }
+
+      it('logs an empty accelerator for the default CPU descriptor', async () => {
+        createRuntimeStub.resolves({
+          done: true,
+          response: {
+            ...defaultRuntime,
+            runtimeSpec: {
+              ...defaultRuntime.runtimeSpec,
+              accelerator: 'NONE',
+            },
+          },
+        });
+
+        await assignmentManager.assignServer(DEFAULT_CPU_SERVER);
+
+        sinon.assert.calledOnceWithExactly(
+          logStub,
+          AssignmentOutcome.ASSIGNMENT_OUTCOME_SUCCEEDED,
+          {
+            variant: DEFAULT_CPU_SERVER.variant,
+            accelerator: '',
+            shape: '',
+            version: '',
+            hadFallback: false,
+          },
+        );
       });
     });
   });
 
   describe('unassignServer', () => {
-    forEachPublicApiFlag((enablePublicApi) => {
-      it('throws after being disposed', async () => {
-        assignmentManager.dispose();
+    it('throws after being disposed', async () => {
+      assignmentManager.dispose();
+
+      await expect(
+        assignmentManager.unassignServer(defaultServer),
+      ).to.be.rejectedWith(/disposed/);
+    });
+
+    it('does nothing when the server does not exist', async () => {
+      await assignmentManager.unassignServer(defaultServer);
+
+      sinon.assert.notCalled(deleteRuntimeStub);
+      sinon.assert.notCalled(vsCodeStub.commands.executeCommand);
+      sinon.assert.notCalled(assignmentChangeListener);
+    });
+
+    describe(`when a server created in VS Code exists`, () => {
+      let jupyterStub: JupyterClientStub;
+
+      beforeEach(async () => {
+        await serverStorage.store([defaultServer]);
+        jupyterStub = createJupyterClientStub();
+        jupyterStaticConnectionStub
+          .withArgs(
+            defaultServer.connectionInformation.baseUrl,
+            defaultServer.connectionInformation.token,
+          )
+          .returns(jupyterStub);
+      });
+
+      it('deletes sessions', async () => {
+        const session1 = {
+          id: 'mock-session-id-1',
+          kernel: {
+            id: 'mock-kernel-id',
+            name: 'mock-kernel-name',
+            lastActivity: new Date().toISOString(),
+            executionState: 'idle',
+            connections: 1,
+          },
+          name: 'mock-session-name',
+          path: 'mock-path',
+          type: 'notebook',
+        };
+        const session2 = {
+          ...session1,
+          id: 'mock-session-id-2',
+        };
+        jupyterStub.sessions.list.resolves([session1, session2]);
+
+        await assignmentManager.unassignServer(defaultServer);
+
+        sinon.assert.calledTwice(jupyterStub.sessions.delete);
+        sinon.assert.calledWith(jupyterStub.sessions.delete, {
+          session: session1.id,
+        });
+        sinon.assert.calledWith(jupyterStub.sessions.delete, {
+          session: session2.id,
+        });
+      });
+
+      it('does not delete sessions when there are none', async () => {
+        jupyterStub.sessions.list.resolves([]);
+
+        await assignmentManager.unassignServer(defaultServer);
+
+        sinon.assert.notCalled(jupyterStub.sessions.delete);
+      });
+
+      it('unassigns the server', async () => {
+        jupyterStub.sessions.list.resolves([]);
+
+        await assignmentManager.unassignServer(defaultServer);
+
+        const serversAfter = await assignmentManager.getServers('extension');
+        expect(serversAfter).to.be.empty;
+        sinon.assert.alwaysCalledWithMatch(
+          deleteRuntimeStub,
+          sinon.match({ runtime: defaultServer.id }),
+          sinon.match.any,
+        );
+        sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+          added: [],
+          removed: [{ server: defaultServer, userInitiated: true }],
+          changed: [],
+        });
+        sinon.assert.calledOnceWithMatch(
+          vsCodeStub.window.showInformationMessage,
+          sinon.match(/notebooks Colab GPU A100 was/),
+        );
+      });
+
+      it('unassigns the server even if listing session fails', async () => {
+        jupyterStub.sessions.list.rejects(new Error('list failed'));
+
+        await assignmentManager.unassignServer(defaultServer);
+
+        const serversAfter = await assignmentManager.getServers('extension');
+        expect(serversAfter).to.be.empty;
+        sinon.assert.alwaysCalledWithMatch(
+          deleteRuntimeStub,
+          sinon.match({ runtime: defaultServer.id }),
+          sinon.match.any,
+        );
+        sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+          added: [],
+          removed: [{ server: defaultServer, userInitiated: true }],
+          changed: [],
+        });
+        sinon.assert.calledOnceWithMatch(
+          vsCodeStub.window.showInformationMessage,
+          sinon.match(/notebooks Colab GPU A100 was/),
+        );
+      });
+
+      it('unassigns the server even if deleting session fails', async () => {
+        const session = {
+          id: 'mock-session-id-1',
+          kernel: {
+            id: 'mock-kernel-id',
+            name: 'mock-kernel-name',
+            lastActivity: new Date().toISOString(),
+            executionState: 'idle',
+            connections: 1,
+          },
+          name: 'mock-session-name',
+          path: 'mock-path',
+          type: 'notebook',
+        };
+        jupyterStub.sessions.list.resolves([session]);
+        jupyterStub.sessions.delete.rejects(new Error('delete failed'));
+
+        await assignmentManager.unassignServer(defaultServer);
+
+        const serversAfter = await assignmentManager.getServers('extension');
+        expect(serversAfter).to.be.empty;
+        sinon.assert.alwaysCalledWithMatch(
+          deleteRuntimeStub,
+          sinon.match({ runtime: defaultServer.id }),
+          sinon.match.any,
+        );
+        sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+          added: [],
+          removed: [{ server: defaultServer, userInitiated: true }],
+          changed: [],
+        });
+        sinon.assert.calledOnceWithMatch(
+          vsCodeStub.window.showInformationMessage,
+          sinon.match(/notebooks Colab GPU A100 was/),
+        );
+      });
+
+      it('keeps the server tracked if remote unassign fails', async () => {
+        jupyterStub.sessions.list.resolves([]);
+        deleteRuntimeStub.rejects(new Error('unassign failed'));
 
         await expect(
           assignmentManager.unassignServer(defaultServer),
-        ).to.be.rejectedWith(/disposed/);
-      });
+        ).to.be.rejectedWith('unassign failed');
 
-      it('does nothing when the server does not exist', async () => {
-        await assignmentManager.unassignServer(defaultServer);
-
-        sinon.assert.notCalled(deleteRuntimeStub);
-        sinon.assert.notCalled(colabClientStub.unassign);
-        sinon.assert.notCalled(vsCodeStub.commands.executeCommand);
+        const serversAfter =
+          await assignmentManager.getLastKnownAssignedServers();
+        expect(serversAfter).to.deep.equal([
+          {
+            id: defaultServer.id,
+            label: defaultServer.label,
+            variant: defaultServer.variant,
+            accelerator: defaultServer.accelerator,
+            shape: defaultServer.shape,
+            version: defaultServer.version,
+            endpoint: defaultServer.endpoint,
+            dateAssigned: defaultServer.dateAssigned,
+          },
+        ]);
+        sinon.assert.alwaysCalledWithMatch(
+          deleteRuntimeStub,
+          sinon.match({ runtime: defaultServer.id }),
+          sinon.match.any,
+        );
         sinon.assert.notCalled(assignmentChangeListener);
       });
 
-      const tests = [
-        { server: defaultServer, isV1Server: true },
-        { server: defaultServerV2, isV1Server: false },
-      ];
-      tests.forEach(({ server, isV1Server }) => {
-        describe(`when a ${isV1Server ? 'v1' : 'v2'} server created in VS Code exists`, () => {
-          let jupyterStub: JupyterClientStub;
+      it('stops tracking the server when the runtime is already gone', async () => {
+        jupyterStub.sessions.list.resolves([]);
+        deleteRuntimeStub.rejects(
+          new ResponseError(new Response(null, { status: 404 })),
+        );
 
-          beforeEach(async () => {
-            await serverStorage.store([server]);
-            jupyterStub = createJupyterClientStub();
-            jupyterStaticConnectionStub
-              .withArgs(
-                server.connectionInformation.baseUrl,
-                server.connectionInformation.token,
-              )
-              .returns(jupyterStub);
-          });
+        await assignmentManager.unassignServer(defaultServer);
 
-          afterEach(() => {
-            if (isV1Server) {
-              sinon.assert.notCalled(deleteRuntimeStub);
-            } else {
-              sinon.assert.notCalled(colabClientStub.unassign);
-            }
-          });
-
-          it('deletes sessions', async () => {
-            const session1 = {
-              id: 'mock-session-id-1',
-              kernel: {
-                id: 'mock-kernel-id',
-                name: 'mock-kernel-name',
-                lastActivity: new Date().toISOString(),
-                executionState: 'idle',
-                connections: 1,
-              },
-              name: 'mock-session-name',
-              path: 'mock-path',
-              type: 'notebook',
-            };
-            const session2 = {
-              ...session1,
-              id: 'mock-session-id-2',
-            };
-            jupyterStub.sessions.list.resolves([session1, session2]);
-
-            await assignmentManager.unassignServer(server);
-
-            sinon.assert.calledTwice(jupyterStub.sessions.delete);
-            sinon.assert.calledWith(jupyterStub.sessions.delete, {
-              session: session1.id,
-            });
-            sinon.assert.calledWith(jupyterStub.sessions.delete, {
-              session: session2.id,
-            });
-          });
-
-          it('does not delete sessions when there are none', async () => {
-            jupyterStub.sessions.list.resolves([]);
-
-            await assignmentManager.unassignServer(server);
-
-            sinon.assert.notCalled(jupyterStub.sessions.delete);
-          });
-
-          it('unassigns the server', async () => {
-            jupyterStub.sessions.list.resolves([]);
-
-            await assignmentManager.unassignServer(server);
-
-            const serversAfter =
-              await assignmentManager.getServers('extension');
-            expect(serversAfter).to.be.empty;
-            if (isV1Server) {
-              sinon.assert.calledOnceWithMatch(
-                colabClientStub.unassign,
-                server.endpoint,
-              );
-            } else {
-              sinon.assert.alwaysCalledWithMatch(
-                deleteRuntimeStub,
-                sinon.match({ runtime: server.id }),
-                sinon.match.any,
-              );
-            }
-            sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
-              added: [],
-              removed: [{ server, userInitiated: true }],
-              changed: [],
-            });
-            sinon.assert.calledOnceWithMatch(
-              vsCodeStub.window.showInformationMessage,
-              sinon.match(/notebooks Colab GPU A100 was/),
-            );
-          });
-
-          it('unassigns the server even if listing session fails', async () => {
-            jupyterStub.sessions.list.rejects(new Error('list failed'));
-
-            await assignmentManager.unassignServer(server);
-
-            const serversAfter =
-              await assignmentManager.getServers('extension');
-            expect(serversAfter).to.be.empty;
-            if (isV1Server) {
-              sinon.assert.calledOnceWithMatch(
-                colabClientStub.unassign,
-                server.endpoint,
-              );
-            } else {
-              sinon.assert.alwaysCalledWithMatch(
-                deleteRuntimeStub,
-                sinon.match({ runtime: server.id }),
-                sinon.match.any,
-              );
-            }
-            sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
-              added: [],
-              removed: [{ server, userInitiated: true }],
-              changed: [],
-            });
-            sinon.assert.calledOnceWithMatch(
-              vsCodeStub.window.showInformationMessage,
-              sinon.match(/notebooks Colab GPU A100 was/),
-            );
-          });
-
-          it('unassigns the server even if deleting session fails', async () => {
-            const session = {
-              id: 'mock-session-id-1',
-              kernel: {
-                id: 'mock-kernel-id',
-                name: 'mock-kernel-name',
-                lastActivity: new Date().toISOString(),
-                executionState: 'idle',
-                connections: 1,
-              },
-              name: 'mock-session-name',
-              path: 'mock-path',
-              type: 'notebook',
-            };
-            jupyterStub.sessions.list.resolves([session]);
-            jupyterStub.sessions.delete.rejects(new Error('delete failed'));
-
-            await assignmentManager.unassignServer(server);
-
-            const serversAfter =
-              await assignmentManager.getServers('extension');
-            expect(serversAfter).to.be.empty;
-            if (isV1Server) {
-              sinon.assert.calledOnceWithMatch(
-                colabClientStub.unassign,
-                server.endpoint,
-              );
-            } else {
-              sinon.assert.alwaysCalledWithMatch(
-                deleteRuntimeStub,
-                sinon.match({ runtime: server.id }),
-                sinon.match.any,
-              );
-            }
-            sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
-              added: [],
-              removed: [{ server, userInitiated: true }],
-              changed: [],
-            });
-            sinon.assert.calledOnceWithMatch(
-              vsCodeStub.window.showInformationMessage,
-              sinon.match(/notebooks Colab GPU A100 was/),
-            );
-          });
-
-          it('keeps the server tracked if remote unassign fails', async () => {
-            jupyterStub.sessions.list.resolves([]);
-            if (isV1Server) {
-              colabClientStub.unassign.rejects(new Error('unassign failed'));
-            } else {
-              deleteRuntimeStub.rejects(new Error('unassign failed'));
-            }
-
-            await expect(
-              assignmentManager.unassignServer(server),
-            ).to.be.rejectedWith('unassign failed');
-
-            const serversAfter =
-              await assignmentManager.getLastKnownAssignedServers();
-            expect(serversAfter).to.deep.equal([
-              {
-                id: server.id,
-                label: server.label,
-                variant: server.variant,
-                accelerator: server.accelerator,
-                shape: server.shape,
-                version: server.version,
-                endpoint: server.endpoint,
-                dateAssigned: server.dateAssigned,
-              },
-            ]);
-            if (isV1Server) {
-              sinon.assert.calledOnceWithMatch(
-                colabClientStub.unassign,
-                server.endpoint,
-              );
-            } else {
-              sinon.assert.alwaysCalledWithMatch(
-                deleteRuntimeStub,
-                sinon.match({ runtime: server.id }),
-                sinon.match.any,
-              );
-            }
-            sinon.assert.notCalled(assignmentChangeListener);
-          });
-
-          if (!isV1Server) {
-            it('stops tracking the server when the runtime is already gone', async () => {
-              jupyterStub.sessions.list.resolves([]);
-              deleteRuntimeStub.rejects(
-                new ResponseError(new Response(null, { status: 404 })),
-              );
-
-              await assignmentManager.unassignServer(server);
-
-              const serversAfter =
-                await assignmentManager.getLastKnownAssignedServers();
-              expect(serversAfter).to.be.empty;
-              sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
-                added: [],
-                removed: [{ server, userInitiated: true }],
-                changed: [],
-              });
-            });
-
-            it('keeps the server tracked on a non-404 response error', async () => {
-              jupyterStub.sessions.list.resolves([]);
-              deleteRuntimeStub.rejects(
-                new ResponseError(new Response(null, { status: 500 }), '☢️'),
-              );
-
-              await expect(
-                assignmentManager.unassignServer(server),
-              ).to.be.rejectedWith('☢️');
-
-              const serversAfter =
-                await assignmentManager.getLastKnownAssignedServers();
-              expect(serversAfter).to.have.lengthOf(1);
-              sinon.assert.notCalled(assignmentChangeListener);
-            });
-          }
+        const serversAfter =
+          await assignmentManager.getLastKnownAssignedServers();
+        expect(serversAfter).to.be.empty;
+        sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+          added: [],
+          removed: [{ server: defaultServer, userInitiated: true }],
+          changed: [],
         });
       });
 
-      describe('when an unowned server exists', () => {
-        it('unassigns the server', async () => {
-          const remoteServer = {
-            id: 'test-id',
-            endpoint: 'test-endpoint',
-            label: 'name',
-            variant: Variant.DEFAULT,
-          };
+      it('keeps the server tracked on a non-404 response error', async () => {
+        jupyterStub.sessions.list.resolves([]);
+        deleteRuntimeStub.rejects(
+          new ResponseError(new Response(null, { status: 500 }), '☢️'),
+        );
 
-          await assignmentManager.unassignServer(remoteServer);
+        await expect(
+          assignmentManager.unassignServer(defaultServer),
+        ).to.be.rejectedWith('☢️');
 
-          if (enablePublicApi) {
-            sinon.assert.calledOnceWithMatch(
-              deleteRuntimeStub,
-              sinon.match({ runtime: remoteServer.id }),
-              sinon.match.any,
-            );
-            sinon.assert.notCalled(colabClientStub.unassign);
-          } else {
-            sinon.assert.calledOnceWithMatch(
-              colabClientStub.unassign,
-              remoteServer.endpoint,
-            );
-            sinon.assert.notCalled(deleteRuntimeStub);
-          }
-        });
+        const serversAfter =
+          await assignmentManager.getLastKnownAssignedServers();
+        expect(serversAfter).to.have.lengthOf(1);
+        sinon.assert.notCalled(assignmentChangeListener);
+      });
+    });
 
-        if (enablePublicApi) {
-          it('ignores a 404 from deleteRuntime', async () => {
-            const remoteServer = {
-              id: 'test-id',
-              endpoint: 'test-endpoint',
-              label: 'name',
-              variant: Variant.DEFAULT,
-            };
-            deleteRuntimeStub.rejects(
-              new ResponseError(new Response(null, { status: 404 })),
-            );
+    describe('when an unowned server exists', () => {
+      it('unassigns the server', async () => {
+        const remoteServer = {
+          id: 'test-id',
+          endpoint: 'test-endpoint',
+          label: 'name',
+          variant: Variant.DEFAULT,
+        };
 
-            await assignmentManager.unassignServer(remoteServer);
+        await assignmentManager.unassignServer(remoteServer);
 
-            sinon.assert.calledOnceWithMatch(
-              deleteRuntimeStub,
-              sinon.match({ runtime: remoteServer.id }),
-              sinon.match.any,
-            );
-          });
+        sinon.assert.calledOnceWithMatch(
+          deleteRuntimeStub,
+          sinon.match({ runtime: remoteServer.id }),
+          sinon.match.any,
+        );
+      });
 
-          it('rethrows non-404 errors from deleteRuntime', async () => {
-            const remoteServer = {
-              id: 'test-id',
-              endpoint: 'test-endpoint',
-              label: 'name',
-              variant: Variant.DEFAULT,
-            };
-            deleteRuntimeStub.rejects(
-              new ResponseError(new Response(null, { status: 500 }), '☢️'),
-            );
+      it('ignores a 404 from deleteRuntime', async () => {
+        const remoteServer = {
+          id: 'test-id',
+          endpoint: 'test-endpoint',
+          label: 'name',
+          variant: Variant.DEFAULT,
+        };
+        deleteRuntimeStub.rejects(
+          new ResponseError(new Response(null, { status: 404 })),
+        );
 
-            await expect(
-              assignmentManager.unassignServer(remoteServer),
-            ).to.be.rejectedWith('☢️');
-          });
+        await assignmentManager.unassignServer(remoteServer);
 
-          it('rethrows non-response errors from deleteRuntime', async () => {
-            const remoteServer = {
-              id: 'test-id',
-              endpoint: 'test-endpoint',
-              label: 'name',
-              variant: Variant.DEFAULT,
-            };
-            deleteRuntimeStub.rejects(new Error('💩'));
+        sinon.assert.calledOnceWithMatch(
+          deleteRuntimeStub,
+          sinon.match({ runtime: remoteServer.id }),
+          sinon.match.any,
+        );
+      });
 
-            await expect(
-              assignmentManager.unassignServer(remoteServer),
-            ).to.be.rejectedWith('💩');
-          });
-        }
+      it('rethrows non-404 errors from deleteRuntime', async () => {
+        const remoteServer = {
+          id: 'test-id',
+          endpoint: 'test-endpoint',
+          label: 'name',
+          variant: Variant.DEFAULT,
+        };
+        deleteRuntimeStub.rejects(
+          new ResponseError(new Response(null, { status: 500 }), '☢️'),
+        );
+
+        await expect(
+          assignmentManager.unassignServer(remoteServer),
+        ).to.be.rejectedWith('☢️');
+      });
+
+      it('rethrows non-response errors from deleteRuntime', async () => {
+        const remoteServer = {
+          id: 'test-id',
+          endpoint: 'test-endpoint',
+          label: 'name',
+          variant: Variant.DEFAULT,
+        };
+        deleteRuntimeStub.rejects(new Error('💩'));
+
+        await expect(
+          assignmentManager.unassignServer(remoteServer),
+        ).to.be.rejectedWith('💩');
       });
     });
   });
 
   describe('latestOrAutoAssignServer', () => {
-    forEachPublicApiFlag((enablePublicApi) => {
-      it('throws after being disposed', async () => {
-        assignmentManager.dispose();
+    it('throws after being disposed', async () => {
+      assignmentManager.dispose();
 
-        await expect(
-          assignmentManager.latestOrAutoAssignServer(),
-        ).to.be.rejectedWith(/disposed/);
-      });
+      await expect(
+        assignmentManager.latestOrAutoAssignServer(),
+      ).to.be.rejectedWith(/disposed/);
+    });
 
-      it('assigns a new default server when none have been assigned', async () => {
-        if (enablePublicApi) {
-          listRuntimesStub.resolves({ runtimes: [] });
-          const defaultCpuRuntime: Runtime = {
-            ...defaultRuntime,
-            runtimeSpec: {
-              ...defaultRuntime.runtimeSpec,
-              variant: ApiVariant.VariantCpu,
-              accelerator: 'NONE',
-            },
-            version: undefined,
-          };
-          createRuntimeStub.resolves({
-            done: true,
-            response: defaultCpuRuntime,
-          });
-        } else {
-          colabClientStub.listAssignments.resolves([]);
-          const defaultCpuAssignment = {
-            ...defaultAssignment,
-            variant: Variant.DEFAULT,
-            accelerator: 'NONE',
-          };
-          colabClientStub.assign
-            .withArgs(sinon.match(isUUID), {
-              variant: Variant.DEFAULT,
-              accelerator: undefined,
-              shape: undefined,
-              version: undefined,
-            })
-            .resolves({ assignment: defaultCpuAssignment, isNew: true });
-        }
-
-        const server = await assignmentManager.latestOrAutoAssignServer();
-
-        const defaultCpuServer = {
-          ...(enablePublicApi ? defaultServerV2 : defaultServer),
-          variant: Variant.DEFAULT,
+    it('assigns a new default server when none have been assigned', async () => {
+      listRuntimesStub.resolves({ runtimes: [] });
+      const defaultCpuRuntime: Runtime = {
+        ...defaultRuntime,
+        runtimeSpec: {
+          ...defaultRuntime.runtimeSpec,
+          variant: ApiVariant.VariantCpu,
           accelerator: 'NONE',
-          label: 'Colab CPU',
-          version: undefined,
-        };
-        const { id: gotId, ...got } = stripNetworkOverride(server);
-        const { id: wantId, ...want } = defaultCpuServer;
-        expect(got).to.deep.equal(want);
-        if (enablePublicApi) {
-          expect(gotId).to.equal(wantId);
-        }
+        },
+        version: undefined,
+      };
+      createRuntimeStub.resolves({
+        done: true,
+        response: defaultCpuRuntime,
       });
 
-      it('reconciles servers before resolving', async () => {
-        const deadServer = defaultServerV2;
-        const olderActiveServer: ColabAssignedServer = {
-          ...defaultServerV2,
-          id: randomUUID(),
-          endpoint: 'm-s-bar',
-          label: 'Older server',
-          dateAssigned: new Date(NOW.getTime() - 10000),
-        };
-        const olderActiveFixtures = {
-          runtime: {
-            ...defaultRuntime,
-            connectionInfo: {
-              ...defaultRuntime.connectionInfo,
-              endpoint: olderActiveServer.endpoint,
-            },
-          },
-          assignment: {
-            ...defaultAssignment,
-            endpoint: olderActiveServer.endpoint,
-          },
-        };
-        stubLive(enablePublicApi, olderActiveFixtures);
-        await serverStorage.store([deadServer, olderActiveServer]);
+      const server = await assignmentManager.latestOrAutoAssignServer();
 
-        const server = await assignmentManager.latestOrAutoAssignServer();
+      const defaultCpuServer = {
+        ...defaultServer,
+        variant: Variant.DEFAULT,
+        accelerator: 'NONE',
+        label: 'Colab CPU',
+        version: undefined,
+      };
+      const { id: gotId, ...got } = stripNetworkOverride(server);
+      const { id: wantId, ...want } = defaultCpuServer;
+      expect(got).to.deep.equal(want);
+      expect(gotId).to.equal(wantId);
+    });
 
-        expect(stripNetworkOverride(server)).to.deep.equal(olderActiveServer);
-      });
+    it('reconciles servers before resolving', async () => {
+      const deadServer = defaultServer;
+      const olderActiveServer: ColabAssignedServer = {
+        ...defaultServer,
+        id: randomUUID(),
+        endpoint: 'm-s-bar',
+        label: 'Older server',
+        dateAssigned: new Date(NOW.getTime() - 10000),
+      };
+      const olderActiveRuntime = {
+        ...defaultRuntime,
+        connectionInfo: {
+          ...defaultRuntime.connectionInfo,
+          endpoint: olderActiveServer.endpoint,
+        },
+      };
+      listRuntimesStub.resolves({ runtimes: [olderActiveRuntime] });
+      await serverStorage.store([deadServer, olderActiveServer]);
+
+      const server = await assignmentManager.latestOrAutoAssignServer();
+
+      expect(stripNetworkOverride(server)).to.deep.equal(olderActiveServer);
     });
   });
 
   describe('latestServer', () => {
-    forEachPublicApiFlag((enablePublicApi) => {
-      it('throws after being disposed', async () => {
-        assignmentManager.dispose();
+    it('throws after being disposed', async () => {
+      assignmentManager.dispose();
 
-        await expect(assignmentManager.latestServer()).to.be.rejectedWith(
-          /disposed/,
-        );
-      });
+      await expect(assignmentManager.latestServer()).to.be.rejectedWith(
+        /disposed/,
+      );
+    });
 
-      it('returns undefined when none have been assigned', async () => {
-        stubLive(enablePublicApi);
+    it('returns undefined when none have been assigned', async () => {
+      listRuntimesStub.resolves({ runtimes: [] });
 
-        const server = await assignmentManager.latestServer();
-        expect(server).to.equal(undefined);
-      });
+      const server = await assignmentManager.latestServer();
+      expect(server).to.equal(undefined);
+    });
 
-      it('reconciles servers before resolving', async () => {
-        const deadServer = defaultServerV2;
-        const olderActiveServer: ColabAssignedServer = {
-          ...defaultServerV2,
-          id: randomUUID(),
-          endpoint: 'm-s-bar',
-          label: 'Older server',
-          dateAssigned: new Date(NOW.getTime() - 10000),
-        };
-        const olderActiveFixtures = {
-          runtime: {
-            ...defaultRuntime,
-            connectionInfo: {
-              ...defaultRuntime.connectionInfo,
-              endpoint: olderActiveServer.endpoint,
-            },
-          },
-          assignment: {
-            ...defaultAssignment,
-            endpoint: olderActiveServer.endpoint,
-          },
-        };
-        stubLive(enablePublicApi, olderActiveFixtures);
-        await serverStorage.store([deadServer, olderActiveServer]);
+    it('reconciles servers before resolving', async () => {
+      const deadServer = defaultServer;
+      const olderActiveServer: ColabAssignedServer = {
+        ...defaultServer,
+        id: randomUUID(),
+        endpoint: 'm-s-bar',
+        label: 'Older server',
+        dateAssigned: new Date(NOW.getTime() - 10000),
+      };
+      const olderActiveRuntime = {
+        ...defaultRuntime,
+        connectionInfo: {
+          ...defaultRuntime.connectionInfo,
+          endpoint: olderActiveServer.endpoint,
+        },
+      };
+      listRuntimesStub.resolves({ runtimes: [olderActiveRuntime] });
+      await serverStorage.store([deadServer, olderActiveServer]);
 
-        const server = await assignmentManager.latestServer();
+      const server = await assignmentManager.latestServer();
 
-        expect(server ? stripNetworkOverride(server) : null).to.deep.equal(
-          olderActiveServer,
-        );
-      });
+      expect(server ? stripNetworkOverride(server) : null).to.deep.equal(
+        olderActiveServer,
+      );
     });
   });
 
   describe('refreshConnection', () => {
-    const tests = [
-      {
-        name: 'with Public API disabled and v1 server',
-        enablePublicApi: false,
-        isV1Server: true,
-        server: defaultServer,
-      },
-      {
-        name: 'with Public API disabled but v2 server',
-        enablePublicApi: false,
-        isV1Server: false,
-        server: defaultServerV2,
-      },
-      {
-        name: 'with Public API enabled but v1 server',
-        enablePublicApi: true,
-        isV1Server: true,
-        server: defaultServer,
-      },
-      {
-        name: 'with Public API enabled and v2 server',
-        enablePublicApi: true,
-        isV1Server: false,
-        server: defaultServerV2,
-      },
-    ];
-    tests.forEach(({ name, enablePublicApi, isV1Server, server }) => {
-      describe(name, () => {
-        beforeEach(() => {
-          EXPERIMENT_TEST.setFlagForTest(
-            ExperimentFlag.EnablePublicApi,
-            enablePublicApi,
-          );
+    it('throws after being disposed', async () => {
+      assignmentManager.dispose();
+
+      await expect(
+        assignmentManager.refreshConnection(defaultServer.id),
+      ).to.be.rejectedWith(/disposed/);
+    });
+
+    it("throws a not found error when refreshing a server that's not tracked", async () => {
+      await expect(
+        assignmentManager.refreshConnection(defaultServer.id),
+      ).to.eventually.be.rejectedWith(NotFoundError);
+    });
+
+    describe('with a refreshed connection', () => {
+      const newToken = 'new-token';
+      let refreshedServer: ColabAssignedServer;
+
+      beforeEach(async () => {
+        listRuntimesStub.resolves({ runtimes: [defaultRuntime] });
+        getRuntimeStub
+          .withArgs(sinon.match({ runtime: defaultServer.id }), sinon.match.any)
+          .resolves({
+            ...defaultRuntime,
+            connectionInfo: {
+              ...defaultRuntime.connectionInfo,
+              token: newToken,
+              expireTime: new Date(NOW.getTime() + TOKEN_EXPIRY_MS * 2),
+            },
+          });
+        await serverStorage.store([defaultServer]);
+
+        fakeClock.now = NOW.getTime() + TOKEN_EXPIRY_MS;
+        refreshedServer = await assignmentManager.refreshConnection(
+          defaultServer.id,
+        );
+      });
+
+      it('stores and returns the server with updated connection info', () => {
+        const expectedServer: ColabAssignedServer = {
+          ...defaultServer,
+          connectionInformation: {
+            ...defaultServer.connectionInformation,
+            headers: {
+              [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: newToken,
+              [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
+            },
+            token: newToken,
+            tokenExpiry: new Date(NOW.getTime() + TOKEN_EXPIRY_MS * 2),
+          },
+        };
+        expect(stripNetworkOverride(refreshedServer)).to.deep.equal(
+          expectedServer,
+        );
+      });
+
+      it('includes a fetch implementation that attaches Colab connection info', async () => {
+        assert.isDefined(refreshedServer.connectionInformation.fetch);
+        const fetchStub = sinon.stub(fetch, 'default');
+
+        await refreshedServer.connectionInformation.fetch(
+          'https://example.com',
+        );
+
+        sinon.assert.calledOnceWithMatch(fetchStub, 'https://example.com', {
+          headers: new Headers({
+            [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
+              refreshedServer.connectionInformation.token,
+            [COLAB_CLIENT_AGENT_HEADER.key]: COLAB_CLIENT_AGENT_HEADER.value,
+          }),
         });
+      });
 
-        afterEach(() => {
-          if (isV1Server) {
-            sinon.assert.notCalled(getRuntimeStub);
-          } else {
-            sinon.assert.notCalled(colabClientStub.refreshConnection);
-          }
+      it('includes a custom WebSocket implementation', () => {
+        assert.isDefined(refreshedServer.connectionInformation.WebSocket);
+      });
 
-          if (enablePublicApi) {
-            sinon.assert.notCalled(colabClientStub.listAssignments);
-          } else {
-            sinon.assert.notCalled(listRuntimesStub);
-          }
-        });
-
-        it('throws after being disposed', async () => {
-          assignmentManager.dispose();
-
-          await expect(
-            assignmentManager.refreshConnection(server.id),
-          ).to.be.rejectedWith(/disposed/);
-        });
-
-        it("throws a not found error when refreshing a server that's not tracked", async () => {
-          await expect(
-            assignmentManager.refreshConnection(server.id),
-          ).to.eventually.be.rejectedWith(NotFoundError);
-        });
-
-        describe('with a refreshed connection', () => {
-          const newToken = 'new-token';
-          let refreshedServer: ColabAssignedServer;
-
-          beforeEach(async () => {
-            stubLive(enablePublicApi, defaultLiveFixtures);
-            getRuntimeStub
-              .withArgs(
-                sinon.match({ runtime: defaultServerV2.id }),
-                sinon.match.any,
-              )
-              .resolves({
-                ...defaultRuntime,
-                connectionInfo: {
-                  ...defaultRuntime.connectionInfo,
-                  token: newToken,
-                  expireTime: new Date(NOW.getTime() + TOKEN_EXPIRY_MS * 2),
-                },
-              });
-            colabClientStub.refreshConnection
-              .withArgs(defaultServer.endpoint)
-              .resolves({
-                ...defaultAssignment.runtimeProxyInfo,
-                token: newToken,
-              });
-            await serverStorage.store([server]);
-
-            fakeClock.now = NOW.getTime() + TOKEN_EXPIRY_MS;
-            refreshedServer = await assignmentManager.refreshConnection(
-              server.id,
-            );
-          });
-
-          it('stores and returns the server with updated connection info', () => {
-            const expectedServer: ColabAssignedServer = {
-              ...server,
-              connectionInformation: {
-                ...server.connectionInformation,
-                headers: {
-                  [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]: newToken,
-                  [COLAB_CLIENT_AGENT_HEADER.key]:
-                    COLAB_CLIENT_AGENT_HEADER.value,
-                },
-                token: newToken,
-                tokenExpiry: new Date(NOW.getTime() + TOKEN_EXPIRY_MS * 2),
-              },
-            };
-            expect(stripNetworkOverride(refreshedServer)).to.deep.equal(
-              expectedServer,
-            );
-          });
-
-          it('includes a fetch implementation that attaches Colab connection info', async () => {
-            assert.isDefined(refreshedServer.connectionInformation.fetch);
-            const fetchStub = sinon.stub(fetch, 'default');
-
-            await refreshedServer.connectionInformation.fetch(
-              'https://example.com',
-            );
-
-            sinon.assert.calledOnceWithMatch(fetchStub, 'https://example.com', {
-              headers: new Headers({
-                [COLAB_RUNTIME_PROXY_TOKEN_HEADER.key]:
-                  refreshedServer.connectionInformation.token,
-                [COLAB_CLIENT_AGENT_HEADER.key]:
-                  COLAB_CLIENT_AGENT_HEADER.value,
-              }),
-            });
-          });
-
-          it('includes a custom WebSocket implementation', () => {
-            assert.isDefined(refreshedServer.connectionInformation.WebSocket);
-          });
-
-          it('emits an assignment change event', () => {
-            sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
-              added: [],
-              removed: [],
-              changed: [refreshedServer],
-            });
-          });
+      it('emits an assignment change event', () => {
+        sinon.assert.calledOnceWithExactly(assignmentChangeListener, {
+          added: [],
+          removed: [],
+          changed: [refreshedServer],
         });
       });
     });
@@ -3364,7 +2393,7 @@ describe('AssignmentManager', () => {
     it('returns a simple variant-accelerator pair when there are only custom aliased servers', async () => {
       const variant = Variant.GPU;
       const accelerator = 'A100';
-      await setupAssignments([{ variant, accelerator, label: 'foo' }]);
+      await setupRuntimes([{ variant, accelerator, label: 'foo' }]);
 
       await expect(
         assignmentManager.getDefaultLabel(variant, accelerator),
@@ -3374,9 +2403,7 @@ describe('AssignmentManager', () => {
     it('returns the next sequential label with one matching assigned server', async () => {
       const variant = Variant.GPU;
       const accelerator = 'A100';
-      await setupAssignments([
-        { variant, accelerator, label: 'Colab GPU A100' },
-      ]);
+      await setupRuntimes([{ variant, accelerator, label: 'Colab GPU A100' }]);
 
       await expect(
         assignmentManager.getDefaultLabel(variant, accelerator),
@@ -3386,7 +2413,7 @@ describe('AssignmentManager', () => {
     it('returns the next sequential label with multiple assigned servers', async () => {
       const variant = Variant.GPU;
       const accelerator = 'A100';
-      await setupAssignments([
+      await setupRuntimes([
         { variant, accelerator, label: 'Colab GPU A100' },
         { variant, accelerator, label: 'Colab GPU A100 (1)' },
       ]);
@@ -3397,7 +2424,7 @@ describe('AssignmentManager', () => {
     });
 
     it('only increments from matching variant-accelerator server pairs', async () => {
-      await setupAssignments([
+      await setupRuntimes([
         { variant: Variant.DEFAULT, label: 'Colab CPU' },
         {
           variant: Variant.GPU,
@@ -3415,7 +2442,7 @@ describe('AssignmentManager', () => {
     it('uses the next sequential label with many assigned servers', async () => {
       const variant = Variant.GPU;
       const accelerator = 'A100';
-      await setupAssignments(
+      await setupRuntimes(
         Array.from({ length: 10 }, (_, i) => i + 1)
           .map((i) => ({
             variant,
@@ -3433,7 +2460,7 @@ describe('AssignmentManager', () => {
     it('uses the simple variant-accelerator label when the initial assignment is missing', async () => {
       const variant = Variant.GPU;
       const accelerator = 'A100';
-      await setupAssignments([
+      await setupRuntimes([
         { variant, accelerator, label: 'Colab GPU A100 (2)' },
       ]);
 
@@ -3445,7 +2472,7 @@ describe('AssignmentManager', () => {
     it("uses the next sequential label when there's an assigned server gap", async () => {
       const variant = Variant.GPU;
       const accelerator = 'A100';
-      await setupAssignments([
+      await setupRuntimes([
         { variant, accelerator, label: 'Colab GPU A100 (2)' },
         { variant, accelerator, label: 'Colab GPU A100' },
       ]);
@@ -3456,7 +2483,7 @@ describe('AssignmentManager', () => {
     });
 
     it('reconciles servers before determining label', async () => {
-      colabClientStub.listAssignments.resolves([]);
+      listRuntimesStub.resolves({ runtimes: [] });
       await serverStorage.store([defaultServer]);
 
       await expect(
@@ -3516,47 +2543,7 @@ describe('AssignmentManager', () => {
       sinon.assert.notCalled(vsCodeStub.env.openExternal);
     });
   });
-
-  function forEachPublicApiFlag(body: (enablePublicApi: boolean) => void) {
-    for (const enablePublicApi of [true, false]) {
-      describe(`with Public API ${enablePublicApi ? 'enabled' : 'disabled'}`, () => {
-        beforeEach(() => {
-          EXPERIMENT_TEST.setFlagForTest(
-            ExperimentFlag.EnablePublicApi,
-            enablePublicApi,
-          );
-        });
-
-        afterEach(() => {
-          if (enablePublicApi) {
-            sinon.assert.notCalled(colabClientStub.listAssignments);
-            sinon.assert.notCalled(colabClientStub.assign);
-          } else {
-            sinon.assert.notCalled(listRuntimesStub);
-            sinon.assert.notCalled(createRuntimeStub);
-          }
-        });
-
-        body(enablePublicApi);
-      });
-    }
-  }
-
-  function stubLive(enablePublicApi: boolean, ...fixtures: LiveFixture[]) {
-    if (enablePublicApi) {
-      listRuntimesStub.resolves({ runtimes: fixtures.map((f) => f.runtime) });
-    } else {
-      colabClientStub.listAssignments.resolves(
-        fixtures.map((f) => f.assignment),
-      );
-    }
-  }
 });
-
-interface LiveFixture {
-  runtime: Runtime;
-  assignment: ListedAssignment;
-}
 
 function stripNetworkOverride(
   server: ColabAssignedServer,

--- a/src/jupyter/module.ts
+++ b/src/jupyter/module.ts
@@ -81,7 +81,6 @@ export function createJupyterModule(
     vs,
     authProvider.onDidChangeSessions,
     assignmentManager,
-    colabClient,
     colabApiClient,
     new ServerPicker(vs, assignmentManager),
     jupyter.exports,

--- a/src/jupyter/provider.ts
+++ b/src/jupyter/provider.ts
@@ -15,9 +15,8 @@ import {
 import { CancellationToken, Disposable, Event, ProviderResult } from 'vscode';
 import vscode from 'vscode';
 import { AuthChangeEvent } from '../auth/auth-provider';
-import { ColabClient } from '../colab/client/v1';
-import { ExperimentFlag } from '../colab/client/v1/api';
-import { ColabApiClient, normalizeSubscriptionTier } from '../colab/client/v2';
+import { ColabApiClient } from '../colab/client/v2';
+import { SubscriptionTier } from '../colab/client/v2/generated/colab';
 import {
   AUTO_CONNECT,
   Command,
@@ -29,9 +28,7 @@ import {
 import { openColabSignup, openColabWeb } from '../colab/commands/external';
 import { buildIconLabel, stripIconLabel } from '../colab/commands/utils';
 import { NotFoundError } from '../colab/errors';
-import { getFlag } from '../colab/experiment-state';
 import { ServerPicker } from '../colab/server-picker';
-import { SubscriptionTier } from '../colab/types';
 import { LatestCancelable } from '../common/async';
 import { traceMethod } from '../common/logging/decorators';
 import { InputFlowAction } from '../common/multi-step-quickpick';
@@ -69,7 +66,6 @@ export class ColabJupyterServerProvider
    * @param vs - The VS Code API instance.
    * @param authEvent - The authentication event emitter.
    * @param assignmentManager - The assignment manager instance.
-   * @param colabClient - The old Colab private API client instance.
    * @param colabApiClient - The new Colab public API client instance.
    * @param serverPicker - The Server picker.
    * @param jupyter - The Jupyter API provider.
@@ -78,7 +74,6 @@ export class ColabJupyterServerProvider
     private readonly vs: typeof vscode,
     authEvent: Event<AuthChangeEvent>,
     private readonly assignmentManager: AssignmentManager,
-    private readonly colabClient: ColabClient,
     private readonly colabApiClient: ColabApiClient,
     private readonly serverPicker: ServerPicker,
     jupyter: Jupyter,
@@ -188,15 +183,8 @@ export class ColabJupyterServerProvider
     commands.push(AUTO_CONNECT, NEW_SERVER, OPEN_COLAB_WEB);
     if (this.isAuthorized) {
       try {
-        const enablePublicApi = getFlag(ExperimentFlag.EnablePublicApi);
-        let tier: SubscriptionTier;
-        if (enablePublicApi) {
-          const subs = await this.colabApiClient.colab.getSubscription();
-          tier = normalizeSubscriptionTier(subs.tier);
-        } else {
-          tier = (await this.colabClient.getUserInfo()).subscriptionTier;
-        }
-        if (tier === SubscriptionTier.NONE) {
+        const subs = await this.colabApiClient.colab.getSubscription();
+        if (subs.tier === SubscriptionTier.SubscriptionTierFree) {
           commands.push(UPGRADE_TO_PRO);
         }
       } catch {

--- a/src/jupyter/provider.unit.test.ts
+++ b/src/jupyter/provider.unit.test.ts
@@ -16,8 +16,6 @@ import { SinonStubbedInstance } from 'sinon';
 import * as sinon from 'sinon';
 import { CancellationToken, CancellationTokenSource } from 'vscode';
 import { AuthChangeEvent } from '../auth/auth-provider';
-import { ColabClient } from '../colab/client/v1';
-import { ExperimentFlag } from '../colab/client/v1/api';
 import { ColabApiClient } from '../colab/client/v2';
 import { ColaboratoryApi } from '../colab/client/v2/generated/colab';
 import { ColaboratoryApi as OperationsApi } from '../colab/client/v2/generated/operations';
@@ -30,13 +28,12 @@ import {
 } from '../colab/commands/constants';
 import { buildIconLabel } from '../colab/commands/utils';
 import { NotFoundError } from '../colab/errors';
-import { TEST_ONLY as EXPERIMENT_TEST } from '../colab/experiment-state';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
 } from '../colab/headers';
 import { ServerPicker } from '../colab/server-picker';
-import { SubscriptionTier, Variant } from '../colab/types';
+import { Variant } from '../colab/types';
 import { InputFlowAction } from '../common/multi-step-quickpick';
 import { TestEventEmitter } from '../test/helpers/events';
 import { TestUri } from '../test/helpers/uri';
@@ -77,10 +74,10 @@ describe('ColabJupyterServerProvider', () => {
   let serverCollectionDisposeStub: sinon.SinonStub<[], void>;
   let authChangeEmitter: TestEventEmitter<AuthChangeEvent>;
   let assignmentStub: SinonStubbedInstance<AssignmentManager>;
-  let colabClientStub: SinonStubbedInstance<ColabClient>;
   let colabApiClientStub: SinonStubbedInstance<ColabApiClient>;
   let serverPickerStub: SinonStubbedInstance<ServerPicker>;
   let serverProvider: ColabJupyterServerProvider;
+  let getSubscriptionStub: sinon.SinonStub;
 
   // Resolves the value used when "setContext" is called for the
   // "colab.hasAssignedServer" key.
@@ -163,18 +160,18 @@ describe('ColabJupyterServerProvider', () => {
     Object.defineProperty(assignmentStub, 'onDidAssignmentsChange', {
       value: sinon.stub(),
     });
-    colabClientStub = sinon.createStubInstance(ColabClient);
     colabApiClientStub = {
       colab: sinon.createStubInstance(ColaboratoryApi),
       operations: sinon.createStubInstance(OperationsApi),
     };
+    getSubscriptionStub = colabApiClientStub.colab
+      .getSubscription as sinon.SinonStub;
     serverPickerStub = sinon.createStubInstance(ServerPicker);
 
     serverProvider = new ColabJupyterServerProvider(
       vsCodeStub.asVsCode(),
       authChangeEmitter.event,
       assignmentStub,
-      colabClientStub,
       colabApiClientStub,
       serverPickerStub,
       jupyterStub as Partial<Jupyter> as Jupyter,
@@ -183,7 +180,6 @@ describe('ColabJupyterServerProvider', () => {
   });
 
   afterEach(() => {
-    EXPERIMENT_TEST.resetExperimentsForTest();
     sinon.restore();
   });
 
@@ -320,116 +316,69 @@ describe('ColabJupyterServerProvider', () => {
           toggleAuth(AuthState.SIGNED_IN);
         });
 
-        const tests = [
-          { name: 'with Public API enabled', enablePublicApi: true },
-          { name: 'with Public API disabled', enablePublicApi: false },
-        ];
-        tests.forEach(({ name, enablePublicApi }) => {
-          describe(name, () => {
-            beforeEach(() => {
-              EXPERIMENT_TEST.setFlagForTest(
-                ExperimentFlag.EnablePublicApi,
-                enablePublicApi,
-              );
-            });
+        it('excludes upgrade to pro command when getting the subscription tier fails', async () => {
+          getSubscriptionStub.rejects(new Error('foo'));
 
-            it('excludes upgrade to pro command when getting the subscription tier fails', async () => {
-              if (enablePublicApi) {
-                (
-                  colabApiClientStub.colab.getSubscription as sinon.SinonStub
-                ).rejects(new Error('foo'));
-              } else {
-                colabClientStub.getUserInfo.rejects(new Error('foo'));
-              }
-              const commands = await serverProvider.provideCommands(
-                undefined,
-                cancellationToken,
-              );
+          const commands = await serverProvider.provideCommands(
+            undefined,
+            cancellationToken,
+          );
 
-              assert.isDefined(commands);
-              expect(commands.map((c) => c.label)).to.deep.equal([
-                buildIconLabel(AUTO_CONNECT),
-                buildIconLabel(NEW_SERVER),
-                buildIconLabel(OPEN_COLAB_WEB),
-              ]);
-            });
+          assert.isDefined(commands);
+          expect(commands.map((c) => c.label)).to.deep.equal([
+            buildIconLabel(AUTO_CONNECT),
+            buildIconLabel(NEW_SERVER),
+            buildIconLabel(OPEN_COLAB_WEB),
+          ]);
+        });
 
-            it('excludes upgrade to pro command for users with pro', async () => {
-              if (enablePublicApi) {
-                (
-                  colabApiClientStub.colab.getSubscription as sinon.SinonStub
-                ).resolves({ tier: 'SUBSCRIPTION_TIER_PRO' });
-              } else {
-                colabClientStub.getUserInfo.resolves({
-                  subscriptionTier: SubscriptionTier.PRO,
-                  eligibleAccelerators: [],
-                  ineligibleAccelerators: [],
-                });
-              }
-              const commands = await serverProvider.provideCommands(
-                undefined,
-                cancellationToken,
-              );
+        it('excludes upgrade to pro command for users with pro', async () => {
+          getSubscriptionStub.resolves({ tier: 'SUBSCRIPTION_TIER_PRO' });
 
-              assert.isDefined(commands);
-              expect(commands.map((c) => c.label)).to.deep.equal([
-                buildIconLabel(AUTO_CONNECT),
-                buildIconLabel(NEW_SERVER),
-                buildIconLabel(OPEN_COLAB_WEB),
-              ]);
-            });
+          const commands = await serverProvider.provideCommands(
+            undefined,
+            cancellationToken,
+          );
 
-            it('excludes upgrade to pro command for users with pro-plus', async () => {
-              if (enablePublicApi) {
-                (
-                  colabApiClientStub.colab.getSubscription as sinon.SinonStub
-                ).resolves({ tier: 'SUBSCRIPTION_TIER_PRO_PLUS' });
-              } else {
-                colabClientStub.getUserInfo.resolves({
-                  subscriptionTier: SubscriptionTier.PRO_PLUS,
-                  eligibleAccelerators: [],
-                  ineligibleAccelerators: [],
-                });
-              }
-              const commands = await serverProvider.provideCommands(
-                undefined,
-                cancellationToken,
-              );
+          assert.isDefined(commands);
+          expect(commands.map((c) => c.label)).to.deep.equal([
+            buildIconLabel(AUTO_CONNECT),
+            buildIconLabel(NEW_SERVER),
+            buildIconLabel(OPEN_COLAB_WEB),
+          ]);
+        });
 
-              assert.isDefined(commands);
-              expect(commands.map((c) => c.label)).to.deep.equal([
-                buildIconLabel(AUTO_CONNECT),
-                buildIconLabel(NEW_SERVER),
-                buildIconLabel(OPEN_COLAB_WEB),
-              ]);
-            });
+        it('excludes upgrade to pro command for users with pro-plus', async () => {
+          getSubscriptionStub.resolves({ tier: 'SUBSCRIPTION_TIER_PRO_PLUS' });
 
-            it('returns commands to auto-connect, create a server, open Colab web and upgrade to pro for free users', async () => {
-              if (enablePublicApi) {
-                (
-                  colabApiClientStub.colab.getSubscription as sinon.SinonStub
-                ).resolves({ tier: 'SUBSCRIPTION_TIER_FREE' });
-              } else {
-                colabClientStub.getUserInfo.resolves({
-                  subscriptionTier: SubscriptionTier.NONE,
-                  eligibleAccelerators: [],
-                  ineligibleAccelerators: [],
-                });
-              }
-              const commands = await serverProvider.provideCommands(
-                undefined,
-                cancellationToken,
-              );
+          const commands = await serverProvider.provideCommands(
+            undefined,
+            cancellationToken,
+          );
 
-              assert.isDefined(commands);
-              expect(commands.map((c) => c.label)).to.deep.equal([
-                buildIconLabel(AUTO_CONNECT),
-                buildIconLabel(NEW_SERVER),
-                buildIconLabel(OPEN_COLAB_WEB),
-                buildIconLabel(UPGRADE_TO_PRO),
-              ]);
-            });
-          });
+          assert.isDefined(commands);
+          expect(commands.map((c) => c.label)).to.deep.equal([
+            buildIconLabel(AUTO_CONNECT),
+            buildIconLabel(NEW_SERVER),
+            buildIconLabel(OPEN_COLAB_WEB),
+          ]);
+        });
+
+        it('returns commands to auto-connect, create a server, open Colab web and upgrade to pro for free users', async () => {
+          getSubscriptionStub.resolves({ tier: 'SUBSCRIPTION_TIER_FREE' });
+
+          const commands = await serverProvider.provideCommands(
+            undefined,
+            cancellationToken,
+          );
+
+          assert.isDefined(commands);
+          expect(commands.map((c) => c.label)).to.deep.equal([
+            buildIconLabel(AUTO_CONNECT),
+            buildIconLabel(NEW_SERVER),
+            buildIconLabel(OPEN_COLAB_WEB),
+            buildIconLabel(UPGRADE_TO_PRO),
+          ]);
         });
       });
 

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -18,16 +18,3 @@ export function isUUID(value: string): value is UUID {
     /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
   return uuidRegex.test(value);
 }
-
-/**
- * Converts a UUID string into a Colab-valid notebook (file ID) hash.
- *
- * The result conforms to Colab's NBH-Regex: `^[a-zA-Z0-9\\-_.]{44}$`.
- *
- * @param uuid - The UUID to convert.
- * @returns A 44-character padded string of the UUID.
- */
-export function uuidToWebSafeBase64(uuid: UUID): string {
-  // Ensure 44-character length by adding the necessary padding.
-  return uuid.replace(/-/g, '_') + '.'.repeat(44 - uuid.length);
-}


### PR DESCRIPTION
Post public API migration rollout, this PR cleans up the fully launched `EnablePublicApi` flag and unused code.

For a peace of mind, I went through each and every call site, and manually cleaned up without the help of agents.

---

**Validations**:
* ✅ All tests and pre-merge checks are green.
* ✅ GitHub Copilot agent review came back promising: https://paste.googleplex.com/4803984506880000.
* ✅ Sanity tested multiple scenarios locally with no issues.

---

Internal tracking bug: b/555768009