### PR TITLE
fix: keep task names readable in minified builds

### DIFF
--- a/src/colab/connection-refresher.ts
+++ b/src/colab/connection-refresher.ts
@@ -152,7 +152,7 @@ export class ConnectionRefresher implements Disposable {
     }
     this.isDisposed = true;
     this.abortController.abort(
-      new Error(`${this.constructor.name} is being disposed`),
+      new Error('ConnectionRefresher is being disposed'),
     );
     for (const { timeout } of this.refreshes.values()) {
       clearTimeout(timeout);

--- a/src/colab/consumption/poller.ts
+++ b/src/colab/consumption/poller.ts
@@ -54,7 +54,7 @@ export class ConsumptionPoller implements Toggleable, Disposable {
         abandonGraceMs: 0,
       },
       {
-        name: ConsumptionPoller.name,
+        name: 'ConsumptionPoller',
         run: this.poll.bind(this),
       },
       OverrunPolicy.AbandonAndRun,

--- a/src/colab/experiment-state.ts
+++ b/src/colab/experiment-state.ts
@@ -62,7 +62,7 @@ export class ExperimentStateProvider implements Toggleable, Disposable {
         abandonGraceMs: 0,
       },
       {
-        name: ExperimentStateProvider.name,
+        name: 'ExperimentStateProvider',
         run: async (signal: AbortSignal) => {
           await this.getExperimentState(this.isAuthorized, signal);
         },

--- a/src/colab/keep-alive.ts
+++ b/src/colab/keep-alive.ts
@@ -86,7 +86,7 @@ export class ServerKeepAliveController implements Toggleable, Disposable {
         abandonGraceMs: 0,
       },
       {
-        name: ServerKeepAliveController.name,
+        name: 'ServerKeepAliveController',
         run: (signal) => this.keepServersAlive(signal),
       },
       OverrunPolicy.AllowToComplete,

--- a/src/colab/resource-monitor/resource-tree.ts
+++ b/src/colab/resource-monitor/resource-tree.ts
@@ -77,7 +77,7 @@ export class ResourceTreeProvider
           abandonGraceMs: 0, // Nothing to cleanup, abandon immediately.
         },
         {
-          name: ResourceTreeProvider.name,
+          name: 'ResourceTreeProvider',
           run: () => {
             this.refresh.call(this);
             return Promise.resolve();


### PR DESCRIPTION
Production builds minify class names, so `Foo.name` reached telemetry as identifiers like "Q2", making timeout and task-failure reports unattributable. Enabling esbuild `keepNames` would fix it too, but unecessarily keeps the names of dependencies we never introspect.