### PR TITLE
fix: give each error class its own name

### DIFF
--- a/src/colab/errors.ts
+++ b/src/colab/errors.ts
@@ -10,6 +10,8 @@ import { Request, Response } from 'node-fetch';
  * Wrapper for errors thrown from issuing requests.
  */
 export class ColabRequestError extends Error {
+  override name = 'ColabRequestError' as const;
+
   /**
    * Initializes a new instance
    *
@@ -30,10 +32,14 @@ export class ColabRequestError extends Error {
 }
 
 /** Error thrown when the user has too many assignments. */
-export class TooManyAssignmentsError extends Error {}
+export class TooManyAssignmentsError extends Error {
+  override name = 'TooManyAssignmentsError' as const;
+}
 
 /** Error thrown when the requested machine accelerator is unavailable. */
 export class AcceleratorUnavailableError extends Error {
+  override name = 'AcceleratorUnavailableError' as const;
+
   /**
    * Initializes a new instance.
    *
@@ -45,16 +51,24 @@ export class AcceleratorUnavailableError extends Error {
 }
 
 /** Error thrown when the user has been denylisted. */
-export class DenylistedError extends Error {}
+export class DenylistedError extends Error {
+  override name = 'DenylistedError' as const;
+}
 
 /** Error thrown when the user has insufficient quota. */
-export class InsufficientQuotaError extends Error {}
+export class InsufficientQuotaError extends Error {
+  override name = 'InsufficientQuotaError' as const;
+}
 
 /** Error thrown when the request resource cannot be found. */
-export class NotFoundError extends Error {}
+export class NotFoundError extends Error {
+  override name = 'NotFoundError' as const;
+}
 
 /** Error thrown when a long-running operation fails. */
 export class LongRunningOperationError extends Error {
+  override name = 'LongRunningOperationError' as const;
+
   /**
    * Initializes a new instance.
    *
@@ -77,6 +91,8 @@ export class LongRunningOperationError extends Error {
 
 /** Error thrown when WaitOperation times out. */
 export class WaitOperationTimeoutError extends Error {
+  override name = 'WaitOperationTimeoutError' as const;
+
   /**
    * Initializes a new instance.
    *

--- a/src/colab/errors.unit.test.ts
+++ b/src/colab/errors.unit.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import { Request, Response } from 'node-fetch';
+import { InputFlowAction } from '../common/multi-step-quickpick';
+import { ServerNotFound } from '../jupyter/contents/sessions';
+import {
+  AcceleratorUnavailableError,
+  ColabRequestError,
+  DenylistedError,
+  InsufficientQuotaError,
+  LongRunningOperationError,
+  NotFoundError,
+  TooManyAssignmentsError,
+  WaitOperationTimeoutError,
+} from './errors';
+
+describe('errors', () => {
+  const cases: [string, Error][] = [
+    [
+      'ColabRequestError',
+      new ColabRequestError(
+        new Request('https://example.test/v1/thing'),
+        new Response('nope', { status: 500 }),
+      ),
+    ],
+    ['TooManyAssignmentsError', new TooManyAssignmentsError()],
+    ['AcceleratorUnavailableError', new AcceleratorUnavailableError('T4')],
+    ['DenylistedError', new DenylistedError()],
+    ['InsufficientQuotaError', new InsufficientQuotaError()],
+    ['NotFoundError', new NotFoundError()],
+    ['LongRunningOperationError', new LongRunningOperationError()],
+    ['WaitOperationTimeoutError', new WaitOperationTimeoutError('op', '20s')],
+    ['InputFlowAction', InputFlowAction.back],
+    ['ServerNotFound', new ServerNotFound('https://example.test')],
+  ];
+
+  cases.forEach(([expected, error]) => {
+    it(`reports ${expected} as its own name`, () => {
+      expect(error.name).to.equal(expected);
+    });
+  });
+
+  it('gives every error a distinct name', () => {
+    const names = cases.map(([, error]) => error.name);
+
+    expect(new Set(names).size).to.equal(names.length);
+  });
+});

--- a/src/common/multi-step-quickpick.ts
+++ b/src/common/multi-step-quickpick.ts
@@ -17,6 +17,8 @@ import vscode from 'vscode';
  * Represents an action that can be taken during an input flow.
  */
 export class InputFlowAction extends Error {
+  override name = 'InputFlowAction' as const;
+
   /** Navigate back in the input flow. */
   static back = new InputFlowAction('back');
   /** Cancel the input flow. */

--- a/src/jupyter/assignments.ts
+++ b/src/jupyter/assignments.ts
@@ -1155,6 +1155,8 @@ const MISSING_OPERATION_NAME_ERR_MSG = 'Name missing in operation';
 const MISSING_OPERATION_RESPONSE_ERR_MSG = 'Response missing in operation';
 
 class AllAcceleratorsUnavailableError extends Error {
+  override name = 'AllAcceleratorsUnavailableError' as const;
+
   constructor(
     variant: string,
     readonly attempted: string[],

--- a/src/jupyter/contents/sessions.ts
+++ b/src/jupyter/contents/sessions.ts
@@ -24,6 +24,8 @@ interface ServerConnection {
  * Error thrown when a server corresponding to a provided endpoint is not found.
  */
 export class ServerNotFound extends Error {
+  override name = 'ServerNotFound' as const;
+
   /**
    * Initializes the error with a message indicating the missing server
    * endpoint.


### PR DESCRIPTION
Every hand-written error subclass inherited `name: "Error"`, so telemetry bucketed unrelated failures together and had to disambiguate on message text alone.