### PR TITLE
fix: redact and truncate request errors

### DIFF
--- a/src/colab/errors.ts
+++ b/src/colab/errors.ts
@@ -7,6 +7,36 @@
 import { Request, Response } from 'node-fetch';
 
 /**
+ * Cap on the response body carried in an error message.
+ *
+ * Bodies can be entire HTML error pages, and the message is reported verbatim
+ * to telemetry.
+ */
+const MAX_BODY_CHARS = 512;
+
+/**
+ * Drops the query string, which can carry notebook hashes and auth hints.
+ *
+ * @param url - The URL to redact.
+ * @returns The URL without its query string.
+ */
+function redactUrl(url: string): string {
+  return url.split(/[?#]/)[0];
+}
+
+/**
+ * Shortens a response body for inclusion in an error message.
+ *
+ * @param body - The response body.
+ * @returns The body, truncated if it exceeds {@link MAX_BODY_CHARS}.
+ */
+function truncate(body: string): string {
+  return body.length <= MAX_BODY_CHARS
+    ? body
+    : `${body.slice(0, MAX_BODY_CHARS)}... (${String(body.length)} chars total)`;
+}
+
+/**
  * Wrapper for errors thrown from issuing requests.
  */
 export class ColabRequestError extends Error {
@@ -25,8 +55,8 @@ export class ColabRequestError extends Error {
     readonly responseBody?: string,
   ) {
     super(
-      `Failed to issue request ${request.method} ${request.url}: ${response.statusText}` +
-        (responseBody ? `\nResponse body: ${responseBody}` : ''),
+      `Failed to issue request ${request.method} ${redactUrl(request.url)}: ${response.statusText}` +
+        (responseBody ? `\nResponse body: ${truncate(responseBody)}` : ''),
     );
   }
 }

--- a/src/colab/errors.ts
+++ b/src/colab/errors.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { URL } from 'url';
 import { Request, Response } from 'node-fetch';
 
 /**
@@ -15,13 +16,30 @@ import { Request, Response } from 'node-fetch';
 const MAX_BODY_CHARS = 512;
 
 /**
- * Drops the query string, which can carry notebook hashes and auth hints.
+ * Redacts the values of every search parameter in the URL.
+ *
+ * E.g. `https://example.com/path?foo=bar&baz=quux` becomes
+ * `https://example.com/path?foo=REDACTED&baz=REDACTED`.
+ *
+ * Given an invalid, unparsable URL, the URL without the query string or
+ * fragment is returned.
  *
  * @param url - The URL to redact.
- * @returns The URL without its query string.
+ * @returns The URL with all search parameter values redacted.
  */
 function redactUrl(url: string): string {
-  return url.split(/[?#]/)[0];
+  try {
+    const u = new URL(url);
+    for (const key of u.searchParams.keys()) {
+      u.searchParams.set(key, 'REDACTED');
+    }
+    if (u.hash) {
+      u.hash = 'REDACTED';
+    }
+    return u.toString();
+  } catch {
+    return url.split(/[?#]/)[0];
+  }
 }
 
 /**

--- a/src/colab/errors.unit.test.ts
+++ b/src/colab/errors.unit.test.ts
@@ -19,35 +19,102 @@ import {
   WaitOperationTimeoutError,
 } from './errors';
 
-describe('errors', () => {
-  const cases: [string, Error][] = [
-    [
-      'ColabRequestError',
-      new ColabRequestError(
-        new Request('https://example.test/v1/thing'),
-        new Response('nope', { status: 500 }),
-      ),
-    ],
-    ['TooManyAssignmentsError', new TooManyAssignmentsError()],
-    ['AcceleratorUnavailableError', new AcceleratorUnavailableError('T4')],
-    ['DenylistedError', new DenylistedError()],
-    ['InsufficientQuotaError', new InsufficientQuotaError()],
-    ['NotFoundError', new NotFoundError()],
-    ['LongRunningOperationError', new LongRunningOperationError()],
-    ['WaitOperationTimeoutError', new WaitOperationTimeoutError('op', '20s')],
-    ['InputFlowAction', InputFlowAction.back],
-    ['ServerNotFound', new ServerNotFound('https://example.test')],
-  ];
+describe('ColabRequestError', () => {
+  function buildBadRequestError(url: string, body?: string): ColabRequestError {
+    return new ColabRequestError(
+      new Request(url),
+      new Response(body, { status: 400, statusText: 'Bad Request' }),
+      body,
+    );
+  }
 
-  cases.forEach(([expected, error]) => {
-    it(`reports ${expected} as its own name`, () => {
-      expect(error.name).to.equal(expected);
-    });
+  it('keeps the method, path and status in the message', () => {
+    const error = buildBadRequestError('https://example.test/tun/m/assign');
+
+    expect(error.message).to.contain('GET');
+    expect(error.message).to.contain('https://example.test/tun/m/assign');
+    expect(error.message).to.contain('Bad Request');
   });
 
-  it('gives every error a distinct name', () => {
-    const names = cases.map(([, error]) => error.name);
+  it('drops the query string, which carries notebook hashes', () => {
+    const error = buildBadRequestError(
+      'https://example.test/tun/m/assign?nbh=secret&authuser=0',
+    );
 
-    expect(new Set(names).size).to.equal(names.length);
+    expect(error.message).to.not.contain('secret');
+    expect(error.message).to.not.contain('authuser');
   });
+
+  it('drops the query from a URL that does not parse', () => {
+    const error = buildBadRequestError('/tun/m/assign?nbh=secret&authuser=0');
+
+    expect(error.message).to.not.contain('secret');
+    expect(error.message).to.not.contain('authuser');
+  });
+
+  it('drops fragments', () => {
+    const error = buildBadRequestError(
+      'https://example.test/v1/thing#nbh=secret',
+    );
+
+    expect(error.message).to.not.contain('secret');
+  });
+
+  it('truncates an oversized response body', () => {
+    const body = 'x'.repeat(5000);
+
+    const error = buildBadRequestError('https://example.test/v1/thing', body);
+
+    expect(error.message.length).to.be.lessThan(1000);
+    expect(error.message).to.contain('5000 chars total');
+  });
+
+  it('leaves a small response body intact', () => {
+    const error = buildBadRequestError(
+      'https://example.test/v1/thing',
+      'not found',
+    );
+
+    expect(error.message).to.contain('not found');
+    expect(error.message).to.not.contain('chars total');
+  });
+
+  it('exposes the full body on the error', () => {
+    const body = 'x'.repeat(5000);
+
+    expect(
+      buildBadRequestError('https://example.test/v1/thing', body).responseBody,
+    ).to.equal(body);
+  });
+});
+
+const errors: [string, Error][] = [
+  [
+    'ColabRequestError',
+    new ColabRequestError(
+      new Request('https://example.test/v1/thing'),
+      new Response('nope', { status: 500 }),
+    ),
+  ],
+  ['TooManyAssignmentsError', new TooManyAssignmentsError()],
+  ['AcceleratorUnavailableError', new AcceleratorUnavailableError('T4')],
+  ['DenylistedError', new DenylistedError()],
+  ['InsufficientQuotaError', new InsufficientQuotaError()],
+  ['NotFoundError', new NotFoundError()],
+  ['LongRunningOperationError', new LongRunningOperationError()],
+  ['WaitOperationTimeoutError', new WaitOperationTimeoutError('op', '20s')],
+  ['InputFlowAction', InputFlowAction.back],
+  ['ServerNotFound', new ServerNotFound('https://example.test')],
+];
+
+errors.forEach(([expected, error]) => {
+  it(`reports ${expected} as its own name`, () => {
+    expect(error.name).to.equal(expected);
+  });
+});
+
+it('gives every error a distinct name', () => {
+  const names = errors.map(([, error]) => error.name);
+
+  expect(new Set(names).size).to.equal(names.length);
 });

--- a/src/colab/errors.unit.test.ts
+++ b/src/colab/errors.unit.test.ts
@@ -36,13 +36,15 @@ describe('ColabRequestError', () => {
     expect(error.message).to.contain('Bad Request');
   });
 
-  it('drops the query string, which carries notebook hashes', () => {
+  it('redacts values in the query string', () => {
     const error = buildBadRequestError(
-      'https://example.test/tun/m/assign?nbh=secret&authuser=0',
+      'https://example.test/tun/m/assign?nbh=secret',
     );
 
     expect(error.message).to.not.contain('secret');
-    expect(error.message).to.not.contain('authuser');
+    expect(error.message).to.contain(
+      'https://example.test/tun/m/assign?nbh=REDACTED',
+    );
   });
 
   it('drops the query from a URL that does not parse', () => {
@@ -52,12 +54,13 @@ describe('ColabRequestError', () => {
     expect(error.message).to.not.contain('authuser');
   });
 
-  it('drops fragments', () => {
+  it('redacts URL fragment', () => {
     const error = buildBadRequestError(
       'https://example.test/v1/thing#nbh=secret',
     );
 
     expect(error.message).to.not.contain('secret');
+    expect(error.message).to.contain('https://example.test/v1/thing#REDACTED');
   });
 
   it('truncates an oversized response body', () => {


### PR DESCRIPTION
Error messages embedded the full request URL and the entire response body, so telemetry received query param values and whole HTML error pages (some quite large).