### PR TITLE
fix: don't resurrect a cleared session after a token refresh

### DIFF
--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -218,11 +218,15 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
   ): Promise<AuthenticationSession[]> {
     this.guardDisposed();
     this.assertReady();
+    // Snapshot the session rather than narrowing `this.session` directly:
+    // narrowing a field survives the `await` below in the type system, but not
+    // at runtime.
+    const current = this.session;
     if (
-      !this.session ||
+      !current ||
       !areScopesAllowed(scopes) ||
       // Checks if provided scopes are a subset of the current session's scopes
-      (scopes && !scopes.every((r) => this.session?.scopes.includes(r)))
+      (scopes && !scopes.every((r) => current.scopes.includes(r)))
     ) {
       return [];
     }
@@ -233,17 +237,21 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
         this.shouldClearSessionOnRefreshError(err);
       if (shouldClearSession) {
         log.warn(`${reason}. Clearing session.`, err);
-        if (this.session.id) {
-          await this.removeSession(this.session.id);
-        }
+        await this.removeSession(current.id);
         return [];
       }
       log.error('Unable to refresh access token', err);
     }
-    if (options.account && this.session.account != options.account) {
+    // Re-read the session: it may have been cleared or replaced while the
+    // refresh above was in flight.
+    const session = this.session;
+    if (!session) {
       return [];
     }
-    return [this.session];
+    if (options.account && session.account != options.account) {
+      return [];
+    }
+    return [session];
   }
 
   /**
@@ -415,7 +423,8 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
   }
 
   private async refreshSessionIfNeeded(): Promise<void> {
-    if (!this.session) {
+    const session = this.session;
+    if (!session) {
       return;
     }
     const expiryDateMs = this.oAuth2Client.credentials.expiry_date;
@@ -427,9 +436,16 @@ export class GoogleAuthProvider implements AuthenticationProvider, Disposable {
     if (!accessToken) {
       throw new Error('Failed to refresh Google OAuth token.');
     }
+    // The managed session may have been cleared (sign out) or replaced
+    // (re-authentication) while the refresh was in flight. Writing back here
+    // would resurrect the session we started with, and spreading a cleared
+    // session yields a partial object missing `scopes`, `id` and `account`.
+    if (this.session !== session) {
+      return;
+    }
 
     this.session = {
-      ...this.session,
+      ...session,
       accessToken,
     };
   }

--- a/src/auth/auth-provider.unit.test.ts
+++ b/src/auth/auth-provider.unit.test.ts
@@ -10,13 +10,14 @@ import { OAuth2Client } from 'google-auth-library';
 import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
 import { SinonStub, SinonStubbedInstance, SinonFakeTimers } from 'sinon';
 import * as sinon from 'sinon';
-import vscode from 'vscode';
+import { AuthenticationSession } from 'vscode';
 import {
   AUTHORIZATION_HEADER,
   CONTENT_TYPE_JSON_HEADER,
 } from '../colab/headers';
 import { Toggleable } from '../common/toggleable';
 import { PROVIDER_ID } from '../config/constants';
+import { Deferred } from '../test/helpers/async';
 import { newVsCodeStub, VsCodeStub } from '../test/helpers/vscode';
 import { AuthChangeEvent, GoogleAuthProvider } from './auth-provider';
 import { Credentials, LoginOptions } from './login';
@@ -44,7 +45,7 @@ const DEFAULT_CREDENTIALS = {
   id_token: 'eh',
   scope: SCOPES.join(' '),
 };
-const DEFAULT_AUTH_SESSION: vscode.AuthenticationSession = {
+const DEFAULT_AUTH_SESSION: AuthenticationSession = {
   id: DEFAULT_REFRESH_SESSION.id,
   accessToken: DEFAULT_ACCESS_TOKEN,
   account: DEFAULT_REFRESH_SESSION.account,
@@ -68,7 +69,7 @@ const UPGRADED_CREDENTIALS = {
   id_token: 'aw',
   scope: UPGRADED_SCOPES.join(' '),
 };
-const UPGRADED_AUTH_SESSION: vscode.AuthenticationSession = {
+const UPGRADED_AUTH_SESSION: AuthenticationSession = {
   id: UPGRADED_REFRESH_SESSION.id,
   accessToken: UPGRADED_ACCESS_TOKEN,
   account: UPGRADED_REFRESH_SESSION.account,
@@ -629,6 +630,58 @@ describe('GoogleAuthProvider', () => {
         const sessions = authProvider.getSessions(undefined, {});
 
         await expect(sessions).to.eventually.deep.equal([DEFAULT_AUTH_SESSION]);
+      });
+
+      describe('when the session is cleared while a refresh is in flight', () => {
+        let refreshStarted: Deferred<void>;
+        let finishRefresh: Deferred<void>;
+
+        beforeEach(() => {
+          refreshStarted = new Deferred<void>();
+          finishRefresh = new Deferred<void>();
+          // Cast necessary due to OAuth2Client.refreshAccessToken overload.
+          (refreshAccessTokenStub as SinonStub).callsFake(async () => {
+            refreshStarted.resolve();
+            await finishRefresh.promise;
+            oauth2Client.credentials = {
+              ...oauth2Client.credentials,
+              access_token: 'new',
+            };
+          });
+          sinon.stub(oauth2Client, 'revokeToken').resolves();
+          fakeClock.tick(HOUR_MS * 2);
+        });
+
+        /**
+         * Races a sign out against an in-flight token refresh.
+         *
+         * Suspends a `getSessions` call inside `refreshAccessToken`, signs out
+         * (which clears the managed session) and only then lets the refresh
+         * finish.
+         *
+         * @returns The sessions returned by the raced `getSessions` call.
+         */
+        async function signOutDuringRefresh(): Promise<
+          AuthenticationSession[]
+        > {
+          const inFlight = authProvider.getSessions(SCOPES, {});
+          await refreshStarted.promise;
+          await authProvider.signOut();
+          finishRefresh.resolve();
+          return inFlight;
+        }
+
+        it('does not resurrect the cleared session', async () => {
+          await expect(signOutDuringRefresh()).to.eventually.deep.equal([]);
+        });
+
+        it('does not leave a partial session behind for later lookups', async () => {
+          await signOutDuringRefresh();
+
+          await expect(
+            authProvider.getSessions(SCOPES, {}),
+          ).to.eventually.deep.equal([]);
+        });
       });
     });
 


### PR DESCRIPTION
`refreshSessionIfNeeded` guarded on `this.session` and then wrote back `{ ...this.session, accessToken }` on the far side of an `await`. If the session was cleared while the refresh was in flight (e.g. a sign out racing `getSessions`) the spread ran against `undefined`. Spreading `undefined` yields `{}`, so the write-back resurrected the session as a partial object holding only `accessToken`.

That object is truthy, so it survives the `!this.session` guard in `getSessions`, and the next scoped lookup evaluates `this.session?.scopes.includes(r)` against an undefined `scopes`, raising "Cannot read properties of undefined (reading 'includes')". The corruption is sticky: the partial session also has no `id`, so `removeSession` and `signOut` no longer match it and cannot clear it. Every subsequent `getSessions` call throws until the window reloads, which is why a handful of affected users produced a large, sustained volume of this error.

TypeScript did not catch it because narrowing a field survives an `await` in the type system but not at runtime. Snapshot the session into a local instead of relying on that narrowing, abandon the write-back when the field no longer holds the session we set out to refresh, and re-read it after the refresh before returning.