### PR TITLE
feat: migrate `propagateCredentials` to OnePlatform API behind flag

### DIFF
--- a/project-words.txt
+++ b/project-words.txt
@@ -5,6 +5,7 @@ chromedriver
 colab
 colabclient
 colaboratory
+credprop
 dryrun
 ephem
 extest

--- a/src/colab/client/v1/api.ts
+++ b/src/colab/client/v1/api.ts
@@ -75,7 +75,7 @@ export enum AuthType {
   AUTH_USER_EPHEMERAL = 'auth_user_ephemeral',
 }
 
-/** Colab supported auth types. */
+/** Colab supported access token types. */
 export enum AccessTokenType {
   DFS_EPHEMERAL = 'ACCESS_TOKEN_TYPE_DFS_EPHEMERAL',
   AUTH_USER_EPHEMERAL = 'ACCESS_TOKEN_TYPE_AUTH_USER_EPHEMERAL',

--- a/src/colab/client/v1/api.ts
+++ b/src/colab/client/v1/api.ts
@@ -604,7 +604,7 @@ export const EXPERIMENT_FLAG_DEFAULT_VALUES: Record<
   ExperimentFlag,
   ExperimentFlagValue
 > = {
-  [ExperimentFlag.EnableOpCredentialPropagationApi]: true,
+  [ExperimentFlag.EnableOpCredentialPropagationApi]: false,
   [ExperimentFlag.EnablePublicApi]: false,
   [ExperimentFlag.EnableTelemetry]: false,
   [ExperimentFlag.ResourcePollIntervalMs]: 10000,

--- a/src/colab/client/v1/api.ts
+++ b/src/colab/client/v1/api.ts
@@ -75,6 +75,12 @@ export enum AuthType {
   AUTH_USER_EPHEMERAL = 'auth_user_ephemeral',
 }
 
+/** Colab supported auth types. */
+export enum AccessTokenType {
+  DFS_EPHEMERAL = 'ACCESS_TOKEN_TYPE_DFS_EPHEMERAL',
+  AUTH_USER_EPHEMERAL = 'ACCESS_TOKEN_TYPE_AUTH_USER_EPHEMERAL',
+}
+
 /**
  * Normalize the similar but different representations of subscription tiers
  *
@@ -484,7 +490,7 @@ export const ResourcesSchema = z.object({
 /** Resources on a Colab runtime. */
 export type Resources = z.infer<typeof ResourcesSchema>;
 
-/** Result from the Colab Drive credentials propagation API. */
+/** Schema of the Colab credentials propagation API result. */
 export const CredentialsPropagationResultSchema = z
   .object({
     /** Whether the credentials are or were already propagated. */
@@ -496,9 +502,41 @@ export const CredentialsPropagationResultSchema = z
     ...rest,
     unauthorizedRedirectUri: unauthorized_redirect_uri,
   }));
+/** Type of the Colab credentials propagation API result. */
 export type CredentialsPropagationResult = z.infer<
   typeof CredentialsPropagationResultSchema
 >;
+
+/** OnePlatform API error schema. */
+export const OnePlatformErrorSchema = z.object({
+  /** The error object. */
+  error: z.object({
+    /** The error status code, e.g. 400. */
+    code: z.number(),
+    /** The error message. */
+    message: z.string(),
+    /** The canonical error status, e.g. FAILED_PRECONDITION. */
+    status: z.string(),
+    /** The optional error details. */
+    details: z.array(z.record(z.string(), z.any())).optional(),
+  }),
+});
+/** OnePlatform API error type. */
+export type OnePlatformError = z.infer<typeof OnePlatformErrorSchema>;
+
+/** API error info schema. */
+export const ErrorInfoSchema = z.object({
+  /** The type URL for the error info. */
+  '@type': z.literal('type.googleapis.com/google.rpc.ErrorInfo'),
+  /** The error reason. */
+  reason: z.string(),
+  /** The error domain. */
+  domain: z.string(),
+  /** The optional error metadata. */
+  metadata: z.record(z.string(), z.string()).optional(),
+});
+/** API error info type. */
+export type ErrorInfo = z.infer<typeof ErrorInfoSchema>;
 
 /**
  * Maps a Colab {@link Variant} to a human-friendly machine type name.
@@ -554,6 +592,7 @@ export function isHighMemOnlyAccelerator(accelerator?: string): boolean {
 
 /** The experiment flags supported by the Colab extension. */
 export enum ExperimentFlag {
+  EnableOpCredentialPropagationApi = 'enable_op_credprop_api_vscode',
   EnablePublicApi = 'enable_public_api_vscode',
   EnableTelemetry = 'enable_vscode_telemetry',
   ResourcePollIntervalMs = 'resource_poll_interval_ms',
@@ -565,6 +604,7 @@ export const EXPERIMENT_FLAG_DEFAULT_VALUES: Record<
   ExperimentFlag,
   ExperimentFlagValue
 > = {
+  [ExperimentFlag.EnableOpCredentialPropagationApi]: true,
   [ExperimentFlag.EnablePublicApi]: false,
   [ExperimentFlag.EnableTelemetry]: false,
   [ExperimentFlag.ResourcePollIntervalMs]: 10000,

--- a/src/colab/client/v1/index.ts
+++ b/src/colab/client/v1/index.ts
@@ -457,12 +457,9 @@ export class ColabClient {
         body: JSON.stringify(payload),
         signal,
       });
-      return {
-        success: true,
-        unauthorizedRedirectUri: undefined,
-      };
+      return { success: true, unauthorizedRedirectUri: undefined };
     } catch (error: unknown) {
-      const unauthorizedRedirectUri = getUnauthorizedRedirectUri(error);
+      const unauthorizedRedirectUri = extractUnauthorizedRedirectUri(error);
       if (!unauthorizedRedirectUri) {
         throw error;
       }
@@ -653,7 +650,7 @@ function mapShapeToURLParam(shape: Shape): string | undefined {
   }
 }
 
-function getUnauthorizedRedirectUri(error: unknown): string | undefined {
+function extractUnauthorizedRedirectUri(error: unknown): string | undefined {
   if (
     !(error instanceof ColabRequestError) ||
     error.response.status !== 400 ||

--- a/src/colab/client/v1/index.ts
+++ b/src/colab/client/v1/index.ts
@@ -25,6 +25,7 @@ import {
   InsufficientQuotaError,
   TooManyAssignmentsError,
 } from '../../errors';
+import { getFlag } from '../../experiment-state';
 import {
   COLAB_CLIENT_AGENT_HEADER,
   COLAB_RUNTIME_PROXY_TOKEN_HEADER,
@@ -32,6 +33,7 @@ import {
   COLAB_VS_CODE_APP_NAME,
   COLAB_VS_CODE_EXTENSION_VERSION,
   COLAB_XSRF_TOKEN_HEADER,
+  CONTENT_TYPE_JSON_HEADER,
 } from '../../headers';
 import { Shape, Variant } from '../../types';
 import {
@@ -58,6 +60,12 @@ import {
   isHighMemOnlyAccelerator,
   Resources,
   ResourcesSchema,
+  AccessTokenType,
+  ExperimentFlag,
+  OnePlatformError,
+  OnePlatformErrorSchema,
+  ErrorInfoSchema,
+  ErrorInfo,
 } from './api';
 
 const TUN_ENDPOINT = '/tun/m';
@@ -368,6 +376,31 @@ export class ColabClient {
     },
     signal?: AbortSignal,
   ): Promise<CredentialsPropagationResult> {
+    const enableOp = getFlag(ExperimentFlag.EnableOpCredentialPropagationApi);
+    if (!enableOp) {
+      return this.propagateCredentialsV1(endpoint, params, signal);
+    }
+    return this.propagateCredentialsV2(
+      endpoint,
+      {
+        accessTokenType:
+          params.authType === AuthType.DFS_EPHEMERAL
+            ? AccessTokenType.DFS_EPHEMERAL
+            : AccessTokenType.AUTH_USER_EPHEMERAL,
+        dryRun: params.dryRun,
+      },
+      signal,
+    );
+  }
+
+  private async propagateCredentialsV1(
+    endpoint: string,
+    params: {
+      authType: AuthType;
+      dryRun: boolean;
+    },
+    signal?: AbortSignal,
+  ): Promise<CredentialsPropagationResult> {
     const url = new URL(
       `${TUN_ENDPOINT}/credentials-propagation/${endpoint}`,
       this.colabDomain,
@@ -393,6 +426,66 @@ export class ColabClient {
       },
       CredentialsPropagationResultSchema,
     );
+  }
+
+  private async propagateCredentialsV2(
+    endpoint: string,
+    params: {
+      accessTokenType: AccessTokenType;
+      dryRun: boolean;
+    },
+    signal?: AbortSignal,
+  ): Promise<CredentialsPropagationResult> {
+    const url = new URL(
+      'v1/credential-propagation:enable',
+      this.colabGapiDomain,
+    );
+
+    const payload = {
+      endpoint,
+      accessTokenType: params.accessTokenType,
+      dryRun: params.dryRun,
+      version: '2',
+    };
+
+    try {
+      await this.issueRequest(url, {
+        method: 'POST',
+        headers: {
+          [CONTENT_TYPE_JSON_HEADER.key]: CONTENT_TYPE_JSON_HEADER.value,
+        },
+        body: JSON.stringify(payload),
+        signal,
+      });
+      return {
+        success: true,
+        unauthorizedRedirectUri: undefined,
+      };
+    } catch (e: unknown) {
+      if (
+        e instanceof ColabRequestError &&
+        e.response.status === 400 &&
+        e.responseBody
+      ) {
+        const errorBody = JSON.parse(e.responseBody) as unknown;
+        if (isOnePlatformError(errorBody)) {
+          for (const detail of errorBody.error.details ?? []) {
+            if (!isErrorInfo(detail)) {
+              continue;
+            }
+            if (detail.reason !== 'OAUTH_CONSENT_REQUIRED') {
+              continue;
+            }
+            return {
+              success: false,
+              unauthorizedRedirectUri:
+                detail.metadata?.unauthorized_redirect_uri,
+            };
+          }
+        }
+      }
+      throw e;
+    }
   }
 
   /**
@@ -576,4 +669,12 @@ function mapShapeToURLParam(shape: Shape): string | undefined {
     default:
       return undefined;
   }
+}
+
+function isOnePlatformError(obj: unknown): obj is OnePlatformError {
+  return OnePlatformErrorSchema.safeParse(obj).success;
+}
+
+function isErrorInfo(obj: unknown): obj is ErrorInfo {
+  return ErrorInfoSchema.safeParse(obj).success;
 }

--- a/src/colab/client/v1/index.ts
+++ b/src/colab/client/v1/index.ts
@@ -461,30 +461,12 @@ export class ColabClient {
         success: true,
         unauthorizedRedirectUri: undefined,
       };
-    } catch (e: unknown) {
-      if (
-        e instanceof ColabRequestError &&
-        e.response.status === 400 &&
-        e.responseBody
-      ) {
-        const errorBody = JSON.parse(e.responseBody) as unknown;
-        if (isOnePlatformError(errorBody)) {
-          for (const detail of errorBody.error.details ?? []) {
-            if (!isErrorInfo(detail)) {
-              continue;
-            }
-            if (detail.reason !== 'OAUTH_CONSENT_REQUIRED') {
-              continue;
-            }
-            return {
-              success: false,
-              unauthorizedRedirectUri:
-                detail.metadata?.unauthorized_redirect_uri,
-            };
-          }
-        }
+    } catch (error: unknown) {
+      const unauthorizedRedirectUri = getUnauthorizedRedirectUri(error);
+      if (!unauthorizedRedirectUri) {
+        throw error;
       }
-      throw e;
+      return { success: false, unauthorizedRedirectUri };
     }
   }
 
@@ -669,6 +651,31 @@ function mapShapeToURLParam(shape: Shape): string | undefined {
     default:
       return undefined;
   }
+}
+
+function getUnauthorizedRedirectUri(error: unknown): string | undefined {
+  if (
+    !(error instanceof ColabRequestError) ||
+    error.response.status !== 400 ||
+    !error.responseBody
+  ) {
+    return undefined;
+  }
+
+  const errorBody: unknown = JSON.parse(error.responseBody);
+  if (!isOnePlatformError(errorBody)) {
+    return undefined;
+  }
+
+  const details = errorBody.error.details ?? [];
+  if (
+    details.length !== 1 ||
+    !isErrorInfo(details[0]) ||
+    details[0].reason !== 'OAUTH_CONSENT_REQUIRED'
+  ) {
+    return undefined;
+  }
+  return details[0].metadata?.unauthorized_redirect_uri;
 }
 
 function isOnePlatformError(obj: unknown): obj is OnePlatformError {

--- a/src/colab/client/v1/index.unit.test.ts
+++ b/src/colab/client/v1/index.unit.test.ts
@@ -1042,10 +1042,6 @@ describe('ColabClient', () => {
             status: 'FAILED_PRECONDITION',
             details: [
               {
-                '@type': 'type.googleapis.com/google.rpc.CustomError',
-                someOtherField: 'someValue',
-              },
-              {
                 '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
                 reason: 'OAUTH_CONSENT_REQUIRED',
                 domain: COLAB_HOST,
@@ -1098,55 +1094,65 @@ describe('ColabClient', () => {
         {
           name: 'errors with non-ErrorInfo details',
           status: 400,
-          hasErrorInfo: false,
+          hasNonErrorInfoDetail: true,
+        },
+        {
+          name: 'errors with more than one detail',
+          status: 400,
+          hasErrorInfo: true,
+          reason: 'OAUTH_CONSENT_REQUIRED',
+          hasNonErrorInfoDetail: true,
         },
       ];
-      errorTests.forEach(({ name, status, reason, hasErrorInfo }) => {
-        it(`rejects on ${name}`, async () => {
-          const errorBody: OnePlatformError = {
-            error: {
-              code: status,
-              message: 'Some error message',
-              status: 'SOME_ERROR_STATUS',
-              details: [],
-            },
-          };
-          if (hasErrorInfo) {
-            errorBody.error.details?.push({
-              '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
-              reason,
-              domain: COLAB_HOST,
-            });
-          } else {
-            errorBody.error.details?.push({
-              '@type': 'type.googleapis.com/google.rpc.BadRequest',
-              someOtherField: 'someValue',
-            });
-          }
-          fetchStub
-            .withArgs(
-              urlMatcher({
-                method: 'POST',
-                host: GOOGLE_APIS_HOST,
-                path: '/v1/credential-propagation:enable',
-                otherHeaders: {
-                  [CONTENT_TYPE_JSON_HEADER.key]:
-                    CONTENT_TYPE_JSON_HEADER.value,
-                },
-                withAuthUser: false,
-              }),
-            )
-            .resolves(new Response(JSON.stringify(errorBody), { status }));
-          const endpoint = 'mock-server';
+      errorTests.forEach(
+        ({ name, status, reason, hasErrorInfo, hasNonErrorInfoDetail }) => {
+          it(`rejects on ${name}`, async () => {
+            const errorBody: OnePlatformError = {
+              error: {
+                code: status,
+                message: 'Some error message',
+                status: 'SOME_ERROR_STATUS',
+                details: [],
+              },
+            };
+            if (hasErrorInfo) {
+              errorBody.error.details?.push({
+                '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+                reason,
+                domain: COLAB_HOST,
+              });
+            }
+            if (hasNonErrorInfoDetail) {
+              errorBody.error.details?.push({
+                '@type': 'type.googleapis.com/google.rpc.BadRequest',
+                someOtherField: 'someValue',
+              });
+            }
+            fetchStub
+              .withArgs(
+                urlMatcher({
+                  method: 'POST',
+                  host: GOOGLE_APIS_HOST,
+                  path: '/v1/credential-propagation:enable',
+                  otherHeaders: {
+                    [CONTENT_TYPE_JSON_HEADER.key]:
+                      CONTENT_TYPE_JSON_HEADER.value,
+                  },
+                  withAuthUser: false,
+                }),
+              )
+              .resolves(new Response(JSON.stringify(errorBody), { status }));
+            const endpoint = 'mock-server';
 
-          await expect(
-            client.propagateCredentials(endpoint, {
-              authType: AuthType.AUTH_USER_EPHEMERAL,
-              dryRun: true,
-            }),
-          ).to.eventually.be.rejectedWith(ColabRequestError);
-        });
-      });
+            await expect(
+              client.propagateCredentials(endpoint, {
+                authType: AuthType.AUTH_USER_EPHEMERAL,
+                dryRun: true,
+              }),
+            ).to.eventually.be.rejectedWith(ColabRequestError);
+          });
+        },
+      );
     });
   });
 

--- a/src/colab/client/v1/index.unit.test.ts
+++ b/src/colab/client/v1/index.unit.test.ts
@@ -6,7 +6,7 @@
 
 import { randomUUID } from 'crypto';
 import { expect } from 'chai';
-import fetch, { Response } from 'node-fetch';
+import fetch, { Request, Response } from 'node-fetch';
 import { SinonStub, SinonMatcher } from 'sinon';
 import * as sinon from 'sinon';
 import { ColabAssignedServer } from '../../../jupyter/servers';
@@ -14,10 +14,12 @@ import { TestUri } from '../../../test/helpers/uri';
 import { uuidToWebSafeBase64 } from '../../../utils/uuid';
 import {
   AcceleratorUnavailableError,
+  ColabRequestError,
   DenylistedError,
   InsufficientQuotaError,
   TooManyAssignmentsError,
 } from '../../errors';
+import { TEST_ONLY as EXPERIMENT_TEST } from '../../experiment-state';
 import {
   ACCEPT_JSON_HEADER,
   AUTHORIZATION_HEADER,
@@ -27,6 +29,7 @@ import {
   COLAB_VS_CODE_APP_NAME,
   COLAB_VS_CODE_EXTENSION_VERSION,
   COLAB_XSRF_TOKEN_HEADER,
+  CONTENT_TYPE_JSON_HEADER,
 } from '../../headers';
 import { Shape, SubscriptionTier, Variant } from '../../types';
 import {
@@ -39,6 +42,7 @@ import {
   ConsumptionUserInfo,
   UserInfo,
   ListedAssignment,
+  OnePlatformError,
 } from './api';
 import { ColabClient } from '.';
 
@@ -92,6 +96,7 @@ describe('ColabClient', () => {
   });
 
   afterEach(() => {
+    EXPERIMENT_TEST.resetExperimentsForTest();
     sinon.restore();
   });
 
@@ -920,55 +925,227 @@ describe('ColabClient', () => {
       { authType: AuthType.AUTH_USER_EPHEMERAL, dryRun: true },
       { authType: AuthType.AUTH_USER_EPHEMERAL, dryRun: false },
     ];
-    tests.forEach(({ authType, dryRun }) => {
-      it(`successfully propagates ${authType} credentials${dryRun ? ' (dryRun)' : ''}`, async () => {
-        const endpoint = 'mock-server';
-        const path = `/tun/m/credentials-propagation/${endpoint}`;
-        const token = 'mock-xsrf-token';
-        const queryParams = {
-          authtype: authType,
-          dryrun: String(dryRun),
-          record: 'false',
-          version: '2',
-          propagate: 'true',
+
+    describe('with OP API disabled', () => {
+      beforeEach(() => {
+        EXPERIMENT_TEST.setFlagForTest(
+          ExperimentFlag.EnableOpCredentialPropagationApi,
+          false,
+        );
+      });
+
+      tests.forEach(({ authType, dryRun }) => {
+        it(`successfully propagates ${authType} credentials${dryRun ? ' (dryRun)' : ''}`, async () => {
+          const endpoint = 'mock-server';
+          const path = `/tun/m/credentials-propagation/${endpoint}`;
+          const token = 'mock-xsrf-token';
+          const queryParams = {
+            authtype: authType,
+            dryrun: String(dryRun),
+            record: 'false',
+            version: '2',
+            propagate: 'true',
+          };
+          fetchStub
+            .withArgs(
+              urlMatcher({
+                method: 'GET',
+                host: COLAB_HOST,
+                path,
+                queryParams,
+              }),
+            )
+            .resolves(
+              new Response(withXSSI(JSON.stringify({ token })), {
+                status: 200,
+              }),
+            );
+          fetchStub
+            .withArgs(
+              urlMatcher({
+                method: 'POST',
+                host: COLAB_HOST,
+                path,
+                queryParams,
+                otherHeaders: { [COLAB_XSRF_TOKEN_HEADER.key]: token },
+              }),
+            )
+            .resolves(
+              new Response(withXSSI(JSON.stringify({ success: true })), {
+                status: 200,
+              }),
+            );
+
+          const result = client.propagateCredentials(endpoint, {
+            authType,
+            dryRun,
+          });
+
+          await expect(result).to.eventually.be.fulfilled;
+          sinon.assert.calledTwice(fetchStub);
+        });
+      });
+    });
+
+    describe('with OP API enabled', () => {
+      beforeEach(() => {
+        EXPERIMENT_TEST.setFlagForTest(
+          ExperimentFlag.EnableOpCredentialPropagationApi,
+          true,
+        );
+      });
+
+      tests.forEach(({ authType, dryRun }) => {
+        it(`successfully propagates ${authType} credentials${dryRun ? ' (dryRun)' : ''}`, async () => {
+          fetchStub
+            .withArgs(
+              urlMatcher({
+                method: 'POST',
+                host: GOOGLE_APIS_HOST,
+                path: '/v1/credential-propagation:enable',
+                otherHeaders: {
+                  [CONTENT_TYPE_JSON_HEADER.key]:
+                    CONTENT_TYPE_JSON_HEADER.value,
+                },
+                withAuthUser: false,
+              }),
+            )
+            .resolves(new Response(/* body= */ undefined, { status: 200 }));
+          const endpoint = 'mock-server';
+
+          const result = client.propagateCredentials(endpoint, {
+            authType,
+            dryRun,
+          });
+
+          await expect(result).to.eventually.deep.equal({
+            success: true,
+            unauthorizedRedirectUri: undefined,
+          });
+          sinon.assert.calledOnce(fetchStub);
+          const req = fetchStub.getCall(0).args[0] as Request;
+          await expect(req.json()).to.eventually.deep.equal({
+            endpoint,
+            accessTokenType: `ACCESS_TOKEN_TYPE_${authType.toUpperCase()}`,
+            dryRun,
+            version: '2',
+          });
+        });
+      });
+
+      it('extracts unauthorized redirect URI from OAUTH_CONSENT_REQUIRED error', async () => {
+        const oauthUrl = 'test-unauthorized-redirect-uri';
+        const errorBody = {
+          error: {
+            code: 400,
+            message: 'Precondition check failed.',
+            status: 'FAILED_PRECONDITION',
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.rpc.CustomError',
+                someOtherField: 'someValue',
+              },
+              {
+                '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+                reason: 'OAUTH_CONSENT_REQUIRED',
+                domain: COLAB_HOST,
+                metadata: {
+                  unauthorized_redirect_uri: oauthUrl,
+                },
+              },
+            ],
+          },
         };
         fetchStub
           .withArgs(
             urlMatcher({
-              method: 'GET',
-              host: COLAB_HOST,
-              path,
-              queryParams,
-            }),
-          )
-          .resolves(
-            new Response(withXSSI(JSON.stringify({ token })), {
-              status: 200,
-            }),
-          );
-        fetchStub
-          .withArgs(
-            urlMatcher({
               method: 'POST',
-              host: COLAB_HOST,
-              path,
-              queryParams,
-              otherHeaders: { [COLAB_XSRF_TOKEN_HEADER.key]: token },
+              host: GOOGLE_APIS_HOST,
+              path: '/v1/credential-propagation:enable',
+              otherHeaders: {
+                [CONTENT_TYPE_JSON_HEADER.key]: CONTENT_TYPE_JSON_HEADER.value,
+              },
+              withAuthUser: false,
             }),
           )
-          .resolves(
-            new Response(withXSSI(JSON.stringify({ success: true })), {
-              status: 200,
-            }),
-          );
+          .resolves(new Response(JSON.stringify(errorBody), { status: 400 }));
+        const endpoint = 'mock-server';
 
         const result = client.propagateCredentials(endpoint, {
-          authType,
-          dryRun,
+          authType: AuthType.DFS_EPHEMERAL,
+          dryRun: true,
         });
 
-        await expect(result).to.eventually.be.fulfilled;
-        sinon.assert.calledTwice(fetchStub);
+        await expect(result).to.eventually.deep.equal({
+          success: false,
+          unauthorizedRedirectUri: oauthUrl,
+        });
+      });
+
+      const errorTests = [
+        {
+          name: 'non-400 errors',
+          status: 401,
+          hasErrorInfo: true,
+          reason: 'OAUTH_CONSENT_REQUIRED',
+        },
+        {
+          name: 'errors with non-OAUTH_CONSENT_REQUIRED reason',
+          status: 400,
+          hasErrorInfo: true,
+          reason: 'A_DIFFERENT_REASON',
+        },
+        {
+          name: 'errors with non-ErrorInfo details',
+          status: 400,
+          hasErrorInfo: false,
+        },
+      ];
+      errorTests.forEach(({ name, status, reason, hasErrorInfo }) => {
+        it(`rejects on ${name}`, async () => {
+          const errorBody: OnePlatformError = {
+            error: {
+              code: status,
+              message: 'Some error message',
+              status: 'SOME_ERROR_STATUS',
+              details: [],
+            },
+          };
+          if (hasErrorInfo) {
+            errorBody.error.details?.push({
+              '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+              reason,
+              domain: COLAB_HOST,
+            });
+          } else {
+            errorBody.error.details?.push({
+              '@type': 'type.googleapis.com/google.rpc.BadRequest',
+              someOtherField: 'someValue',
+            });
+          }
+          fetchStub
+            .withArgs(
+              urlMatcher({
+                method: 'POST',
+                host: GOOGLE_APIS_HOST,
+                path: '/v1/credential-propagation:enable',
+                otherHeaders: {
+                  [CONTENT_TYPE_JSON_HEADER.key]:
+                    CONTENT_TYPE_JSON_HEADER.value,
+                },
+                withAuthUser: false,
+              }),
+            )
+            .resolves(new Response(JSON.stringify(errorBody), { status }));
+          const endpoint = 'mock-server';
+
+          await expect(
+            client.propagateCredentials(endpoint, {
+              authType: AuthType.AUTH_USER_EPHEMERAL,
+              dryRun: true,
+            }),
+          ).to.eventually.be.rejectedWith(ColabRequestError);
+        });
       });
     });
   });


### PR DESCRIPTION
Migrate `propagateCredentials` to call the new OnePlatform API behind the `enable_op_credprop_api_vscode` feature flag.

I intentionally isolated the changes and branching logic in `colab/client/v1/index.ts` to avoid touching too many places. Unlike the old API, the new API returns the OAuth redirect URL in `ErrorInfo` with a 400 status instead of in a 200 success response.

See http://go/paste/4895389396893696 for a sample error response containing the OAuth redirect URL.

---

**Local test screenshot**:

<img width="601" height="708" alt="credprop_local_test" src="https://github.com/user-attachments/assets/3e5ad261-c766-47cc-8616-6010501704ea" />

---

Internal tracking bug: b/556251396