### PR TITLE
build: bump version to 0.9.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.4",
         "@jupyterlab/services": "^7.5.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
Changes since last bump:

- fix: don't resurrect a cleared session after a token refresh (#691)
- fix: stop reporting cancellations as errors (#687)
- fix: report background task failures to telemetry (#688)
- fix: redact and truncate request errors (#686)
- build(deps): bump fast-uri from 3.1.5 to 3.1.7 (#690)
- build(deps-dev): bump @humanfs/node from 0.16.6 to 0.16.8 (#689)
- fix: drop kernel input replies when the socket has closed (#684)
- fix: give each error class its own name (#683)
- fix: keep task names readable in minified builds (#682)
- chore: remove redundant eslint-disable. (#680)
- chore: bump vscode-extension-tester (#679)