### PR TITLE
build: bump version to 0.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "colab",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "colab",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.4",
         "@jupyterlab/services": "^7.5.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Colab",
   "description": "Connect notebooks to Colab servers.",
   "icon": "icon.png",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "pricing": "Free",
   "homepage": "https://github.com/googlecolab/colab-vscode",
   "repository": {


### PR DESCRIPTION
Changes since last bump:

- feat: migrate `propagateCredentials` to OnePlatform API behind flag (#692)
- build(deps-dev): bump js-yaml from 4.3.1 to 4.3.2 (#696)