### PR TITLE
fix: back off consumption polling after repeated failures

### DIFF
--- a/src/colab/consumption/poller.ts
+++ b/src/colab/consumption/poller.ts
@@ -9,6 +9,7 @@ import {
   OverrunPolicy,
   SequentialTaskRunner,
   StartMode,
+  TimeoutError,
 } from '../../common/task-runner';
 import { Toggleable } from '../../common/toggleable';
 import { AssignmentChangeEvent } from '../../jupyter/assignments';
@@ -17,6 +18,36 @@ import { ConsumptionUserInfo } from '../client/v1/api';
 
 const POLL_INTERVAL_MS = 1000 * 60; // 1 minute.
 const TASK_TIMEOUT_MS = 1000 * 10; // 10 seconds.
+/**
+ * Ceiling on the consecutive intervals skipped while backing off, so a user who
+ * is simply offline issues ~4 requests an hour rather than 60.
+ */
+const MAX_BACKOFF_INTERVALS = 15;
+
+/**
+ * Number of poll intervals to sit out after a run of failures.
+ *
+ * @param failures - Consecutive failures so far, at least one.
+ * @returns The number of intervals to skip before trying again.
+ */
+function backoffIntervals(failures: number): number {
+  const base = Math.min(2 ** (failures - 1), MAX_BACKOFF_INTERVALS);
+  const jittered = Math.round(base * (0.5 + Math.random()));
+  return Math.min(Math.max(jittered, 1), MAX_BACKOFF_INTERVALS);
+}
+
+/**
+ * Reports whether a failed poll says anything about the network.
+ *
+ * The runner aborts polls it has superseded or disposed, which is routine. A
+ * timeout is different: the request really is hanging and we should back off.
+ *
+ * @param signal - The signal the poll ran under.
+ * @returns True when the failure should count towards the backoff.
+ */
+function countsAsFailure(signal?: AbortSignal): boolean {
+  return !signal?.aborted || signal.reason instanceof TimeoutError;
+}
 
 /**
  * Periodically polls for CCU info changes and emits an event on updates.
@@ -30,6 +61,8 @@ export class ConsumptionPoller implements Toggleable, Disposable {
   private readonly runner: SequentialTaskRunner;
   private assignmentListener?: Disposable;
   private consumptionUserInfo?: ConsumptionUserInfo;
+  private consecutiveFailures = 0;
+  private intervalsToSkip = 0;
   private isDisposed = false;
 
   /**
@@ -80,9 +113,11 @@ export class ConsumptionPoller implements Toggleable, Disposable {
   on(): void {
     this.guardDisposed();
     this.runner.start(StartMode.Immediately);
-    this.assignmentListener ??= this.assignmentChange(
-      this.runner.runNow.bind(this.runner),
-    );
+    this.assignmentListener ??= this.assignmentChange(() => {
+      // Assignment changes move CCU rates, so we bail on the backoff.
+      this.intervalsToSkip = 0;
+      this.runner.runNow();
+    });
   }
 
   /**
@@ -91,6 +126,8 @@ export class ConsumptionPoller implements Toggleable, Disposable {
   off(): void {
     this.guardDisposed();
     this.runner.stop();
+    this.consecutiveFailures = 0;
+    this.intervalsToSkip = 0;
     if (this.assignmentListener) {
       this.assignmentListener.dispose();
       this.assignmentListener = undefined;
@@ -114,8 +151,23 @@ export class ConsumptionPoller implements Toggleable, Disposable {
     if (this.isDisposed) {
       return;
     }
-    const consumptionUserInfo =
-      await this.client.getConsumptionUserInfo(signal);
+    if (this.intervalsToSkip > 0) {
+      this.intervalsToSkip--;
+      return;
+    }
+
+    let consumptionUserInfo: ConsumptionUserInfo;
+    try {
+      consumptionUserInfo = await this.client.getConsumptionUserInfo(signal);
+    } catch (err: unknown) {
+      if (countsAsFailure(signal)) {
+        this.consecutiveFailures++;
+        this.intervalsToSkip = backoffIntervals(this.consecutiveFailures);
+      }
+      throw err;
+    }
+    this.consecutiveFailures = 0;
+
     if (
       JSON.stringify(consumptionUserInfo) ===
       JSON.stringify(this.consumptionUserInfo)
@@ -131,4 +183,5 @@ export class ConsumptionPoller implements Toggleable, Disposable {
 export const TEST_ONLY = {
   POLL_INTERVAL_MS,
   TASK_TIMEOUT_MS,
+  MAX_BACKOFF_INTERVALS,
 };

--- a/src/colab/consumption/poller.ts
+++ b/src/colab/consumption/poller.ts
@@ -20,7 +20,8 @@ const POLL_INTERVAL_MS = 1000 * 60; // 1 minute.
 const TASK_TIMEOUT_MS = 1000 * 10; // 10 seconds.
 /**
  * Ceiling on the consecutive intervals skipped while backing off, so a user who
- * is simply offline issues ~4 requests an hour rather than 60.
+ * is simply offline issues ~4 requests an hour (one every 15 minutes) rather
+ * than 60.
  */
 const MAX_BACKOFF_INTERVALS = 15;
 
@@ -30,7 +31,7 @@ const MAX_BACKOFF_INTERVALS = 15;
  * @param failures - Consecutive failures so far, at least one.
  * @returns The number of intervals to skip before trying again.
  */
-function backoffIntervals(failures: number): number {
+function calculateBackoffIntervals(failures: number): number {
   const base = Math.min(2 ** (failures - 1), MAX_BACKOFF_INTERVALS);
   const jittered = Math.round(base * (0.5 + Math.random()));
   return Math.min(Math.max(jittered, 1), MAX_BACKOFF_INTERVALS);
@@ -45,7 +46,7 @@ function backoffIntervals(failures: number): number {
  * @param signal - The signal the poll ran under.
  * @returns True when the failure should count towards the backoff.
  */
-function countsAsFailure(signal?: AbortSignal): boolean {
+function countsAsNetworkFailure(signal?: AbortSignal): boolean {
   return !signal?.aborted || signal.reason instanceof TimeoutError;
 }
 
@@ -160,9 +161,11 @@ export class ConsumptionPoller implements Toggleable, Disposable {
     try {
       consumptionUserInfo = await this.client.getConsumptionUserInfo(signal);
     } catch (err: unknown) {
-      if (countsAsFailure(signal)) {
+      if (countsAsNetworkFailure(signal)) {
         this.consecutiveFailures++;
-        this.intervalsToSkip = backoffIntervals(this.consecutiveFailures);
+        this.intervalsToSkip = calculateBackoffIntervals(
+          this.consecutiveFailures,
+        );
       }
       throw err;
     }

--- a/src/colab/consumption/poller.unit.test.ts
+++ b/src/colab/consumption/poller.unit.test.ts
@@ -251,6 +251,197 @@ describe('ConsumptionPoller', () => {
     });
   });
 
+  describe('when polling fails', () => {
+    let randomStub: sinon.SinonStub<[], number>;
+
+    beforeEach(async () => {
+      // Deterministic jitter: the multiplier becomes exactly 1.
+      randomStub = sinon.stub(Math, 'random').returns(0.5);
+      clientStub.getConsumptionUserInfo.rejects(new Error('offline'));
+      poller.on();
+      await fakeClock.tickAsync(TASK_TIMEOUT_MS);
+      clientStub.getConsumptionUserInfo.resetHistory();
+    });
+
+    it('skips the next interval after a single failure', async () => {
+      await fakeClock.tickAsync(POLL_INTERVAL_MS);
+
+      sinon.assert.notCalled(clientStub.getConsumptionUserInfo);
+    });
+
+    it('retries once the backoff has elapsed', async () => {
+      await fakeClock.tickAsync(POLL_INTERVAL_MS * 2);
+
+      sinon.assert.calledOnce(clientStub.getConsumptionUserInfo);
+    });
+
+    it('backs off further with each consecutive failure', async () => {
+      // Second failure, so the next attempt waits two intervals rather than
+      // the one that followed the first.
+      await fakeClock.tickAsync(POLL_INTERVAL_MS * 2);
+      clientStub.getConsumptionUserInfo.resetHistory();
+
+      await fakeClock.tickAsync(POLL_INTERVAL_MS * 2);
+      sinon.assert.notCalled(clientStub.getConsumptionUserInfo);
+
+      await fakeClock.tickAsync(POLL_INTERVAL_MS);
+      sinon.assert.calledOnce(clientStub.getConsumptionUserInfo);
+    });
+
+    /** Advances to just after a poll runs, so its backoff starts here. */
+    async function settleOnFreshBackoff(): Promise<void> {
+      for (let i = 0; i < 200; i++) {
+        clientStub.getConsumptionUserInfo.resetHistory();
+        await fakeClock.tickAsync(POLL_INTERVAL_MS);
+        if (clientStub.getConsumptionUserInfo.called) {
+          clientStub.getConsumptionUserInfo.resetHistory();
+          return;
+        }
+      }
+      expect.fail('the poller never retried');
+    }
+
+    it('caps the backoff at fifteen intervals', async () => {
+      // Far more failures than needed to saturate the exponential growth.
+      await fakeClock.tickAsync(POLL_INTERVAL_MS * 500);
+      await settleOnFreshBackoff();
+
+      await fakeClock.tickAsync(POLL_INTERVAL_MS * 15);
+      sinon.assert.notCalled(clientStub.getConsumptionUserInfo);
+
+      await fakeClock.tickAsync(POLL_INTERVAL_MS);
+      sinon.assert.calledOnce(clientStub.getConsumptionUserInfo);
+    });
+
+    it('caps the backoff even after jitter rounds up', async () => {
+      // Maximum jitter, which without a post-jitter clamp turns 15 into 23.
+      randomStub.returns(0.999);
+      await fakeClock.tickAsync(POLL_INTERVAL_MS * 500);
+      await settleOnFreshBackoff();
+
+      await fakeClock.tickAsync(POLL_INTERVAL_MS * 16);
+
+      sinon.assert.called(clientStub.getConsumptionUserInfo);
+    });
+
+    it('jitters the backoff', async () => {
+      // A second failure has a base of two intervals; maximum jitter takes it
+      // to three.
+      randomStub.returns(0.999);
+      await fakeClock.tickAsync(POLL_INTERVAL_MS * 2);
+      clientStub.getConsumptionUserInfo.resetHistory();
+
+      await fakeClock.tickAsync(POLL_INTERVAL_MS * 3);
+      sinon.assert.notCalled(clientStub.getConsumptionUserInfo);
+
+      await fakeClock.tickAsync(POLL_INTERVAL_MS);
+      sinon.assert.calledOnce(clientStub.getConsumptionUserInfo);
+    });
+
+    it('resets the backoff after a success', async () => {
+      clientStub.getConsumptionUserInfo.resolves(DEFAULT_CCU_INFO);
+      await fakeClock.tickAsync(POLL_INTERVAL_MS * 2);
+
+      // Failing again should earn the one-interval backoff of a first
+      // failure, not the two intervals of a second consecutive one.
+      clientStub.getConsumptionUserInfo.rejects(new Error('offline again'));
+      await fakeClock.tickAsync(POLL_INTERVAL_MS);
+      clientStub.getConsumptionUserInfo.resetHistory();
+
+      await fakeClock.tickAsync(POLL_INTERVAL_MS);
+      sinon.assert.notCalled(clientStub.getConsumptionUserInfo);
+
+      await fakeClock.tickAsync(POLL_INTERVAL_MS);
+      sinon.assert.calledOnce(clientStub.getConsumptionUserInfo);
+    });
+
+    it('clears the backoff when toggled off and back on', async () => {
+      // Escalate well past a single interval of backoff.
+      await fakeClock.tickAsync(POLL_INTERVAL_MS * 10);
+      poller.off();
+      await fakeClock.tickAsync(TASK_TIMEOUT_MS);
+      clientStub.getConsumptionUserInfo.resetHistory();
+
+      poller.on();
+
+      sinon.assert.calledOnce(clientStub.getConsumptionUserInfo);
+    });
+
+    it('polls immediately when an assignment changes', () => {
+      assignmentChangeEmitter.fire({ added: [], removed: [], changed: [] });
+
+      sinon.assert.calledOnce(clientStub.getConsumptionUserInfo);
+    });
+  });
+
+  describe('aborts are not network failures', () => {
+    beforeEach(async () => {
+      sinon.stub(Math, 'random').returns(0.5);
+      clientStub.getConsumptionUserInfo.resolves(DEFAULT_CCU_INFO);
+      poller.on();
+      await fakeClock.tickAsync(TASK_TIMEOUT_MS);
+    });
+
+    it('does not accrue backoff from superseded polls', async () => {
+      // Hang until aborted, the way an in-flight request behaves.
+      clientStub.getConsumptionUserInfo.callsFake(
+        (signal?: AbortSignal) =>
+          new Promise((_, reject) => {
+            signal?.addEventListener('abort', () => {
+              reject(new Error('The user aborted a request.'));
+            });
+          }),
+      );
+
+      // Each change abandons the poll the previous one started. Kept well
+      // inside the task timeout so none of these is a genuine hang.
+      for (let i = 0; i < 3; i++) {
+        assignmentChangeEmitter.fire({ added: [], removed: [], changed: [] });
+        await fakeClock.tickAsync(1);
+      }
+
+      // Let the last one be superseded by a poll that completes, so nothing
+      // is left in flight to time out during the probe below.
+      clientStub.getConsumptionUserInfo.resolves(DEFAULT_CCU_INFO);
+      assignmentChangeEmitter.fire({ added: [], removed: [], changed: [] });
+      await fakeClock.tickAsync(1);
+      clientStub.getConsumptionUserInfo.resetHistory();
+
+      // A plain scheduled tick: it only runs if no backoff was armed.
+      await fakeClock.tickAsync(POLL_INTERVAL_MS);
+
+      sinon.assert.called(clientStub.getConsumptionUserInfo);
+    });
+
+    it('polls immediately when toggled back on after being toggled off', async () => {
+      poller.off();
+      await fakeClock.tickAsync(TASK_TIMEOUT_MS);
+      clientStub.getConsumptionUserInfo.resetHistory();
+
+      poller.on();
+
+      sinon.assert.calledOnce(clientStub.getConsumptionUserInfo);
+    });
+
+    it('still backs off when a poll times out', async () => {
+      // node-fetch rejects on abort, so a timeout surfaces as a rejection.
+      clientStub.getConsumptionUserInfo.callsFake(
+        (signal?: AbortSignal) =>
+          new Promise((_, reject) => {
+            signal?.addEventListener('abort', () => {
+              reject(new Error('The user aborted a request.'));
+            });
+          }),
+      );
+      await fakeClock.tickAsync(POLL_INTERVAL_MS + TASK_TIMEOUT_MS);
+      clientStub.getConsumptionUserInfo.resetHistory();
+
+      await fakeClock.tickAsync(POLL_INTERVAL_MS);
+
+      sinon.assert.notCalled(clientStub.getConsumptionUserInfo);
+    });
+  });
+
   describe('toggled off', () => {
     beforeEach(async () => {
       clientStub.getConsumptionUserInfo.resolves(DEFAULT_CCU_INFO);

--- a/src/common/task-runner.ts
+++ b/src/common/task-runner.ts
@@ -346,7 +346,14 @@ class NonGracefulAbandonError extends Error {
   }
 }
 
-class TimeoutError extends Error {
+/** The reason a task's signal is aborted when it outruns its timeout. */
+export class TimeoutError extends Error {
+  /**
+   * Initializes a new instance.
+   *
+   * @param taskName - The name of the task that timed out.
+   * @param afterMs - The timeout the task exceeded.
+   */
   constructor(taskName: string, afterMs: number) {
     super(`Task "${taskName}" timed out after ${afterMs.toString()}ms`);
     this.name = 'TimeoutError';


### PR DESCRIPTION
The poll retried every 60s indefinitely, so one badly-networked user generated thousands of identical failures a day. Consecutive failures now skip an exponentially growing number of intervals, capped at 15 and jittered; success, an assignment change, or toggling off clears it.

Aborts from the runner superseding or disposing a poll are not counted. They don't  change the network conditions, and counting them swallowed the replacement poll. A timeout still counts, since a hanging request is the case this exists for.