### PR TITLE
fix: report the underlying cause of wrapped errors

### DIFF
--- a/src/common/error-description.ts
+++ b/src/common/error-description.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Maximum number of `cause` links to follow when describing an error. */
+const MAX_CAUSE_DEPTH = 4;
+
+/**
+ * Cap on a reported message. The depth limit bounds how deep a cause chain is
+ * walked but not how wide, and a single `AggregateError` can hold hundreds of
+ * entries. An oversized event would take its whole batch down with it.
+ */
+const MAX_MESSAGE_CHARS = 2000;
+
+/**
+ * Caps a message so a single oversized value cannot break its consumer.
+ *
+ * @param msg - The message to cap.
+ * @returns The message, truncated with its original length appended when it
+ * exceeds the cap.
+ */
+export function truncateMessage(msg: string): string {
+  return msg.length <= MAX_MESSAGE_CHARS
+    ? msg
+    : `${msg.slice(0, MAX_MESSAGE_CHARS)}... (${String(msg.length)} chars total)`;
+}
+
+function hasStringCode(e: Error): e is Error & { code: string } {
+  return 'code' in e && typeof e.code === 'string';
+}
+
+function describeLink(e: Error): string {
+  const head = hasStringCode(e) ? `${e.name}(${e.code})` : e.name;
+  return e.message ? `${head}: ${e.message}` : head;
+}
+
+function nextLinks(e: Error): Error[] {
+  // An AggregateError's own message is empty; the detail is in `errors`.
+  if (e instanceof AggregateError) {
+    return e.errors.filter(
+      (sub: unknown): sub is Error => sub instanceof Error,
+    );
+  }
+  return e.cause instanceof Error ? [e.cause] : [];
+}
+
+/**
+ * Flattens an error's `cause` chain into a single line.
+ *
+ * Wrappers like undici's `fetch failed` and the generated client's
+ * `FetchError` carry no detail of their own; the real failure is nested.
+ *
+ * @param e - The error to describe.
+ * @returns The joined causes, or the empty string when there are none.
+ */
+export function describeCauses(e: Error): string {
+  const seen = new Set<Error>([e]);
+  const parts: string[] = [];
+  let links = nextLinks(e);
+
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH && links.length > 0; depth++) {
+    const deeper: Error[] = [];
+    for (const link of links) {
+      if (seen.has(link)) {
+        continue;
+      }
+      seen.add(link);
+      parts.push(describeLink(link));
+      deeper.push(...nextLinks(link));
+    }
+    links = deeper;
+  }
+  return parts.join(' <- ');
+}

--- a/src/common/error-description.unit.test.ts
+++ b/src/common/error-description.unit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect } from 'chai';
+import { describeCauses, truncateMessage } from './error-description';
+
+const MAX_MESSAGE_CHARS = 2000;
+const MAX_CAUSE_DEPTH = 4;
+
+describe('truncateMessage', () => {
+  it('leaves a message at the cap untouched', () => {
+    const msg = 'x'.repeat(MAX_MESSAGE_CHARS);
+
+    expect(truncateMessage(msg)).to.equal(msg);
+  });
+
+  it('truncates messages over the cap', () => {
+    const msg = 'x'.repeat(MAX_MESSAGE_CHARS + 1);
+
+    expect(truncateMessage(msg)).to.equal(
+      `${'x'.repeat(MAX_MESSAGE_CHARS)}... (2001 chars total)`,
+    );
+  });
+
+  it('leaves the empty string alone', () => {
+    expect(truncateMessage('')).to.equal('');
+  });
+});
+
+describe('describeCauses', () => {
+  it('returns the empty string for a cause-free error', () => {
+    // Callers branch on emptiness to decide whether to append anything, so
+    // this must be empty rather than a placeholder.
+    expect(describeCauses(new Error('lonely'))).to.equal('');
+  });
+
+  it('describes a single cause as name and message', () => {
+    const e = new Error('outer', { cause: new TypeError('inner') });
+
+    expect(describeCauses(e)).to.equal('TypeError: inner');
+  });
+
+  it('includes a string code alongside the name', () => {
+    const cause = Object.assign(new Error('connect failed'), {
+      code: 'ECONNREFUSED',
+    });
+
+    expect(describeCauses(new Error('outer', { cause }))).to.equal(
+      'Error(ECONNREFUSED): connect failed',
+    );
+  });
+
+  it('ignores a code that is not a string', () => {
+    // Node's `errno` style numeric codes would otherwise render as "(-111)".
+    const cause = Object.assign(new Error('connect failed'), { code: -111 });
+
+    expect(describeCauses(new Error('outer', { cause }))).to.equal(
+      'Error: connect failed',
+    );
+  });
+
+  it('omits the separator for a cause with no message', () => {
+    expect(describeCauses(new Error('outer', { cause: new Error() }))).to.equal(
+      'Error',
+    );
+  });
+
+  it('ignores a cause that is not an Error', () => {
+    // `cause` is untyped, so a string or object cause is legal and must not
+    // be dereferenced as if it were an Error.
+    expect(describeCauses(new Error('outer', { cause: 'a string' }))).to.equal(
+      '',
+    );
+  });
+
+  it('joins a chain in order, outermost cause first', () => {
+    const root = new Error('root');
+    const middle = new TypeError('middle', { cause: root });
+
+    expect(describeCauses(new Error('outer', { cause: middle }))).to.equal(
+      'TypeError: middle <- Error: root',
+    );
+  });
+
+  it(`follows at most ${String(MAX_CAUSE_DEPTH)} links`, () => {
+    let cause = new Error('link-0');
+    for (let i = 1; i <= 10; i++) {
+      cause = new Error(`link-${String(i)}`, { cause });
+    }
+
+    const parts = describeCauses(new Error('outer', { cause })).split(' <- ');
+
+    expect(parts).to.have.lengthOf(MAX_CAUSE_DEPTH);
+    // Walks outward-in, so the deepest links are the ones dropped.
+    expect(parts[0]).to.equal('Error: link-10');
+    expect(parts[MAX_CAUSE_DEPTH - 1]).to.equal('Error: link-7');
+  });
+
+  it('expands every branch of an AggregateError', () => {
+    const cause = new AggregateError([new Error('first'), new Error('second')]);
+
+    expect(describeCauses(new Error('outer', { cause }))).to.equal(
+      'AggregateError <- Error: first <- Error: second',
+    );
+  });
+
+  it('skips non-Error entries inside an AggregateError', () => {
+    const cause = new AggregateError(['just a string', new Error('real')]);
+
+    expect(describeCauses(new Error('outer', { cause }))).to.equal(
+      'AggregateError <- Error: real',
+    );
+  });
+
+  it('terminates on a cycle rather than looping', () => {
+    const a = new Error('a');
+    const b = new Error('b', { cause: a });
+    a.cause = b;
+
+    expect(describeCauses(b)).to.equal('Error: a');
+  });
+
+  it('reports a self-referential cause once', () => {
+    const e = new Error('self');
+    e.cause = e;
+
+    // `e` seeds the seen set, so its own link is never emitted.
+    expect(describeCauses(e)).to.equal('');
+  });
+});

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -9,6 +9,7 @@ import { Disposable } from 'vscode';
 import { AuthType } from '../colab/client/v1/api';
 import { getExperimentIds } from '../colab/experiment-state';
 import { SubscriptionTier as ColabSubscriptionTier } from '../colab/types';
+import { describeCauses, truncateMessage } from '../common/error-description';
 import { COLAB_EXT_IDENTIFIER } from '../config/constants';
 import { getPackageInfo } from '../config/package-info';
 import { JUPYTER_EXT_IDENTIFIER } from '../jupyter/jupyter-extension';
@@ -134,14 +135,25 @@ export const telemetry = {
   },
   logError: (e: unknown) => {
     if (e instanceof Error) {
+      const causes = describeCauses(e);
       log({
-        error_event: { name: e.name, msg: e.message, stack: e.stack ?? '' },
+        error_event: {
+          name: e.name,
+          msg: truncateMessage(
+            causes ? `${e.message} <- ${causes}` : e.message,
+          ),
+          stack: e.stack ?? '',
+        },
       });
     } else if (typeof e === 'string') {
-      log({ error_event: { name: 'Error', msg: e, stack: '' } });
+      log({
+        error_event: { name: 'Error', msg: truncateMessage(e), stack: '' },
+      });
     } else {
       const msg = e ? JSON.stringify(e) : String(e);
-      log({ error_event: { name: 'Error', msg, stack: '' } });
+      log({
+        error_event: { name: 'Error', msg: truncateMessage(msg), stack: '' },
+      });
     }
   },
   logHandleEphemeralAuth: (authType: AuthType) => {

--- a/src/telemetry/telemetry.unit.test.ts
+++ b/src/telemetry/telemetry.unit.test.ts
@@ -207,6 +207,110 @@ describe('Telemetry Module', () => {
       });
     }
 
+    describe('with a wrapped cause', () => {
+      it('appends the underlying cause', () => {
+        // The shape undici produces for a refused connection.
+        const cause = Object.assign(
+          new Error('connect ECONNREFUSED 127.0.0.1:443'),
+          { code: 'ECONNREFUSED' },
+        );
+
+        telemetry.logError(new TypeError('fetch failed', { cause }));
+
+        sinon.assert.calledOnceWithMatch(logStub, {
+          error_event: {
+            msg: 'fetch failed <- Error(ECONNREFUSED): connect ECONNREFUSED 127.0.0.1:443',
+          },
+        });
+      });
+
+      it('follows a chain of wrappers', () => {
+        const root = new Error('socket hang up');
+        const middle = new TypeError('fetch failed', { cause: root });
+
+        telemetry.logError(new Error('request failed', { cause: middle }));
+
+        sinon.assert.calledOnceWithMatch(logStub, {
+          error_event: {
+            msg: 'request failed <- TypeError: fetch failed <- Error: socket hang up',
+          },
+        });
+      });
+
+      it('descends into an AggregateError, whose message is empty', () => {
+        const cause = new AggregateError([
+          new Error('connect ECONNREFUSED ::1:443'),
+          new Error('connect ECONNREFUSED 127.0.0.1:443'),
+        ]);
+
+        telemetry.logError(new TypeError('fetch failed', { cause }));
+
+        sinon.assert.calledOnceWithMatch(logStub, {
+          error_event: {
+            msg:
+              'fetch failed <- AggregateError <- ' +
+              'Error: connect ECONNREFUSED ::1:443 <- ' +
+              'Error: connect ECONNREFUSED 127.0.0.1:443',
+          },
+        });
+      });
+
+      it('leaves a cause-free error untouched', () => {
+        telemetry.logError(new Error('plain failure'));
+
+        sinon.assert.calledOnceWithMatch(logStub, {
+          error_event: { msg: 'plain failure' },
+        });
+      });
+
+      it('terminates on a cycle', () => {
+        const a = new Error('a');
+        const b = new Error('b', { cause: a });
+        a.cause = b;
+
+        telemetry.logError(b);
+
+        sinon.assert.calledOnceWithMatch(logStub, {
+          error_event: { msg: 'b <- Error: a' },
+        });
+      });
+
+      it('caps an enormous message', () => {
+        // A wide AggregateError is only one level deep but unbounded in size.
+        const cause = new AggregateError(
+          Array.from(
+            { length: 500 },
+            (_, i) => new Error(`sub failure number ${String(i)}`),
+          ),
+        );
+
+        telemetry.logError(new TypeError('fetch failed', { cause }));
+
+        sinon.assert.calledOnceWithMatch(logStub, {
+          error_event: {
+            msg: sinon.match(
+              (msg: string) => msg.length < 2200 && msg.includes('chars total'),
+            ),
+          },
+        });
+      });
+
+      it('bounds a very deep chain', () => {
+        let error = new Error('root');
+        for (let i = 0; i < 20; i++) {
+          error = new Error(`wrap${String(i)}`, { cause: error });
+        }
+
+        telemetry.logError(error);
+
+        sinon.assert.calledOnceWithMatch(logStub, {
+          error_event: {
+            msg: sinon.match((msg: string) => msg.split(' <- ').length === 5),
+          },
+        });
+      });
+    });
+
     it('logs with the correct time', () => {
       const curTime = fakeClock.tick(100);
 


### PR DESCRIPTION
Node reports every transport failure as "fetch failed" and the generated client wraps that again, so a bunch of error events have no details. The cause chain is now flattened into the message.

Reported messages are also capped: the depth limit bounds how deep a chain is walked but not how wide, and one oversized event would take its whole telemetry batch with it. Feels like a fine first pass, can tune if it's not obvious from the errors we continue to see after.