### PR TITLE
feat: concurrent files upload to colab

### DIFF
--- a/src/colab/commands/files.ts
+++ b/src/colab/commands/files.ts
@@ -70,23 +70,45 @@ export async function upload(
           cancellable: false,
         },
         async (progress) => {
-          for (const op of operations) {
+
+          const dirOps = operations.filter((op) => op.type === 'directory');
+          const fileOps = operations.filter((op) => op.type === 'file');
+
+          for (const op of dirOps) {
             try {
-              if (op.type === 'directory') {
-                await createDirectory(vs, op.dest);
-              } else {
-                const fileName = op.source.path.split('/').pop() ?? '';
-                progress.report({
-                  message: `Importing ${fileName}...`,
-                  increment: incrementPerFile,
-                });
-                const content = await vs.workspace.fs.readFile(op.source);
-                await vs.workspace.fs.writeFile(op.dest, content);
-                successCount++;
-                uploadedBytes += content.byteLength;
-              }
+              await createDirectory(vs, op.dest);
             } catch (err) {
-              log.error(`Failed to process ${op.dest.toString()}`, err);
+              log.error(`Failed to create directory ${op.dest.toString()}`, err);
+              failCount++;
+            }
+          }
+
+          const uploadResults = await Promise.all(
+            fileOps.map(
+              async (op) => {
+                try {
+                  const fileName = op.source.path.split('/').pop() ?? '';
+                  progress.report({
+                    message: `Importing ${fileName}...`,
+                    increment: incrementPerFile,
+                  });
+                  const content = await vs.workspace.fs.readFile(op.source);
+                  await vs.workspace.fs.writeFile(op.dest, content);
+                  return { success: true, bytes: content.byteLength };
+
+                } catch (err) {
+                  log.error(`Failed to process ${op.dest.toString()}`, err);
+                  return { success: false, bytes: 0 };
+                }
+              }
+            )
+          );
+
+          for (const result of uploadResults) {
+            if (result.success) {
+              successCount++;
+              uploadedBytes += result.bytes;
+            } else {
               failCount++;
             }
           }

--- a/src/colab/commands/files.ts
+++ b/src/colab/commands/files.ts
@@ -70,7 +70,6 @@ export async function upload(
           cancellable: false,
         },
         async (progress) => {
-
           const dirOps = operations.filter((op) => op.type === 'directory');
           const fileOps = operations.filter((op) => op.type === 'file');
 
@@ -78,30 +77,24 @@ export async function upload(
             try {
               await createDirectory(vs, op.dest);
             } catch (err) {
-              log.error(`Failed to create directory ${op.dest.toString()}`, err);
+              log.error(
+                `Failed to create directory ${op.dest.toString()}`,
+                err,
+              );
               failCount++;
             }
           }
 
           const uploadResults = await Promise.all(
-            fileOps.map(
-              async (op) => {
-                try {
-                  const fileName = op.source.path.split('/').pop() ?? '';
-                  progress.report({
-                    message: `Importing ${fileName}...`,
-                    increment: incrementPerFile,
-                  });
-                  const content = await vs.workspace.fs.readFile(op.source);
-                  await vs.workspace.fs.writeFile(op.dest, content);
-                  return { success: true, bytes: content.byteLength };
-
-                } catch (err) {
-                  log.error(`Failed to process ${op.dest.toString()}`, err);
-                  return { success: false, bytes: 0 };
-                }
-              }
-            )
+            fileOps.map(async (op) => {
+              const result = await uploadFile(vs, op.source, op.dest);
+              const fileName = op.source.path.split('/').pop() ?? '';
+              progress.report({
+                message: `Importing ${fileName}...`,
+                increment: incrementPerFile,
+              });
+              return result;
+            }),
           );
 
           for (const result of uploadResults) {
@@ -262,5 +255,20 @@ async function createDirectory(vs: typeof vscode, uri: vscode.Uri) {
     if (!dirExists) {
       throw err;
     }
+  }
+}
+
+async function uploadFile(
+  vs: typeof vscode,
+  source: vscode.Uri,
+  dest: vscode.Uri,
+): Promise<{ success: boolean; bytes: number }> {
+  try {
+    const content = await vs.workspace.fs.readFile(source);
+    await vs.workspace.fs.writeFile(dest, content);
+    return { success: true, bytes: content.byteLength };
+  } catch (err) {
+    log.error(`Failed to process ${dest.toString()}`, err);
+    return { success: false, bytes: 0 };
   }
 }


### PR DESCRIPTION
Hi Colab Team,

I happen to use this feature quite a lot and notice that uploading an entire folder took some amount of time. I made a simple change to allow concurrent upload using simple `Promise.all` to allow interleaving upload without waiting prior file upload to be completed.

Let me know if I missed something from this PR. This is my first contribution to the repo. 

Thanks,